### PR TITLE
Trace system

### DIFF
--- a/master-firmware/package.yml
+++ b/master-firmware/package.yml
@@ -55,6 +55,7 @@ target.arm:
     - src/base/encoder.c
     - src/base/base_controller.c
     - src/config_msgpack.c
+    - src/trace/trace_points.c
 
 source:
     - src/unix_timestamp.c
@@ -62,6 +63,7 @@ source:
     - src/trajectories.c
     - src/base/polar.c
     - src/base/odometry.c
+    - src/trace/trace.c
 
 include_directories:
     - src/
@@ -75,6 +77,8 @@ tests:
     - tests/bus_enumerator.cpp
     - tests/polar_test.cpp
     - tests/odometry_test.cpp
+    - src/trace/tests/trace_test.cpp
+    - src/trace/tests/trace_points.c
 
 templates:
     app_src.mk.jinja: app_src.mk

--- a/master-firmware/src/commands.c
+++ b/master-firmware/src/commands.c
@@ -21,7 +21,7 @@
 #include "base/odometry.h"
 #include "base/base_controller.h"
 #include "obstacle_avoidance/obstacle_avoidance.h"
-
+#include <trace/trace.h>
 
 static void cmd_mem(BaseSequentialStream *chp, int argc, char *argv[]) {
     size_t n, size;
@@ -508,6 +508,28 @@ static void cmd_blocking_detection_config(BaseSequentialStream *chp, int argc, c
     }
 }
 
+static void print_fn(void *arg, const char *fmt, ...)
+{
+    BaseSequentialStream *chp = (BaseSequentialStream *)arg;
+    va_list ap;
+    va_start(ap, fmt);
+    chvprintf(chp, fmt, ap);
+    va_end(ap);
+}
+
+static void cmd_trace(BaseSequentialStream *chp, int argc, char *argv[])
+{
+    if (argc != 1) {
+        chprintf(chp, "Usage: trace dump|clear\r\n");
+        return;
+    }
+    if (strcmp("dump", argv[0]) == 0) {
+        trace_print(print_fn, chp);
+    } else if (strcmp("clear", argv[0]) == 0) {
+        trace_clear();
+    }
+}
+
 const ShellCommand commands[] = {
     {"crashme", cmd_crashme},
     {"config_tree", cmd_config_tree},
@@ -531,6 +553,7 @@ const ShellCommand commands[] = {
     {"path", cmd_pathplanner},
     {"obs", cmd_create_static_obstacle},
     {"bdconf", cmd_blocking_detection_config},
+    {"trace", cmd_trace},
     // {"wheel_corr", cmd_wheel_correction},
     {NULL, NULL}
 };

--- a/master-firmware/src/rpc_server.c
+++ b/master-firmware/src/rpc_server.c
@@ -5,6 +5,7 @@
 #include "rpc_server.h"
 #include "rpc_callbacks.h"
 #include "msg_callbacks.h"
+#include <trace/trace_points.h>
 
 #define RPC_SERVER_STACKSIZE 2048
 #define RPC_SERVER_PORT 20001
@@ -207,6 +208,7 @@ void message_server_thread(void *arg)
             if (netbuf_copy(buf, buffer, buf->p->tot_len) == 0) {
                 chSysHalt("udp message buffer too small");
             }
+            trace_integer(TRACE_POINT_RPC_MESSAGE_RCV, buf->p->tot_len);
             message_process(buffer, buf->p->tot_len, message_callbacks, message_callbacks_len);
         }
         netbuf_delete(buf);
@@ -243,6 +245,8 @@ void message_transmit(uint8_t *input_buffer, size_t input_buffer_size, ip_addr_t
         // TODO: Do something useful
         return;
     }
+
+    trace_integer(TRACE_POINT_RPC_MESSAGE_SEND, input_buffer_size);
 
     netbuf_ref(buf, input_buffer, input_buffer_size);
 

--- a/master-firmware/src/trace/tests/trace_points.c
+++ b/master-firmware/src/trace/tests/trace_points.c
@@ -1,0 +1,8 @@
+#include "trace_points.h"
+
+#undef C
+#define C(x) #x,
+
+const char *event_names[] = {
+    TRACE_POINTS
+};

--- a/master-firmware/src/trace/tests/trace_points.h
+++ b/master-firmware/src/trace/tests/trace_points.h
@@ -1,0 +1,16 @@
+#ifndef TRACE_POINTS_H
+#define TRACE_POINTS_H
+
+#define TRACE_POINTS \
+    C(TRACE_POINT_0) \
+    C(TRACE_POINT_1) \
+    C(TRACE_POINT_2) \
+
+/* List of all trace points in numerical format. */
+#undef C
+#define C(x) x,
+enum {
+    TRACE_POINTS
+};
+
+#endif /* TRACE_POINTS_H */

--- a/master-firmware/src/trace/tests/trace_test.cpp
+++ b/master-firmware/src/trace/tests/trace_test.cpp
@@ -1,0 +1,180 @@
+#include <CppUTest/TestHarness.h>
+#include "../trace.h"
+#include "trace_points.h"
+
+extern "C"
+unsigned int timestamp;
+
+TEST_GROUP(TraceTestGroup)
+{
+    void setup()
+    {
+        timestamp = 1234;
+        trace_init();
+        trace_enable();
+    }
+};
+
+TEST(TraceTestGroup, CorrectInit)
+{
+    CHECK_EQUAL(0, trace_buffer.nb_events);
+    CHECK_EQUAL(0, trace_buffer.write_index);
+    CHECK_EQUAL(true, trace_buffer.active);
+}
+
+TEST(TraceTestGroup, CanTraceSimpleEvent)
+{
+    trace(TRACE_POINT_1);
+    CHECK_EQUAL(TRACE_POINT_1, trace_buffer.data[0].event_id);
+    CHECK_EQUAL(TRACE_TYPE_STRING, trace_buffer.data[0].type);
+    CHECK_EQUAL(1234, trace_buffer.data[0].timestamp);
+    STRCMP_EQUAL("", trace_buffer.data[0].data.string);
+    CHECK_EQUAL(1, trace_buffer.nb_events);
+    CHECK_EQUAL(1, trace_buffer.write_index);
+}
+
+TEST(TraceTestGroup, CanTraceEventWithMessage)
+{
+    trace_string(TRACE_POINT_1, "trace message");
+    CHECK_EQUAL(TRACE_POINT_1, trace_buffer.data[0].event_id);
+    CHECK_EQUAL(TRACE_TYPE_STRING, trace_buffer.data[0].type);
+    CHECK_EQUAL(1234, trace_buffer.data[0].timestamp);
+    STRCMP_EQUAL("trace message", trace_buffer.data[0].data.string);
+}
+
+TEST(TraceTestGroup, CanTraceEventWithInteger)
+{
+    trace_integer(TRACE_POINT_1, 0xC0FFEE);
+    CHECK_EQUAL(TRACE_POINT_1, trace_buffer.data[0].event_id);
+    CHECK_EQUAL(TRACE_TYPE_INTEGER, trace_buffer.data[0].type);
+    CHECK_EQUAL(1234, trace_buffer.data[0].timestamp);
+    CHECK_EQUAL(0xC0FFEE, trace_buffer.data[0].data.integer);
+}
+
+TEST(TraceTestGroup, CanTraceEventWithScalar)
+{
+    trace_scalar(TRACE_POINT_1, 3.141);
+    CHECK_EQUAL(TRACE_POINT_1, trace_buffer.data[0].event_id);
+    CHECK_EQUAL(TRACE_TYPE_SCALAR, trace_buffer.data[0].type);
+    CHECK_EQUAL(1234, trace_buffer.data[0].timestamp);
+    CHECK_EQUAL((float)3.141, trace_buffer.data[0].data.scalar);
+}
+
+TEST(TraceTestGroup, CanTraceEventWithAddress)
+{
+    int data;
+    trace_address(TRACE_POINT_1, &data);
+    CHECK_EQUAL(TRACE_POINT_1, trace_buffer.data[0].event_id);
+    CHECK_EQUAL(TRACE_TYPE_ADDRESS, trace_buffer.data[0].type);
+    CHECK_EQUAL(1234, trace_buffer.data[0].timestamp);
+    CHECK_EQUAL(&data, trace_buffer.data[0].data.address);
+}
+
+TEST(TraceTestGroup, CanTraceMultipleEvents)
+{
+    trace_integer(TRACE_POINT_0, 101);
+    CHECK_EQUAL(TRACE_POINT_0, trace_buffer.data[0].event_id);
+
+    trace_integer(TRACE_POINT_1, 202);
+    CHECK_EQUAL(TRACE_POINT_1, trace_buffer.data[1].event_id);
+
+    trace_integer(TRACE_POINT_2, 303);
+    CHECK_EQUAL(TRACE_POINT_2, trace_buffer.data[2].event_id);
+
+    CHECK_EQUAL(3, trace_buffer.nb_events);
+    CHECK_EQUAL(3, trace_buffer.write_index);
+}
+
+TEST(TraceTestGroup, CorrectRingbufferOverwrite)
+{
+    // fill trace buffer
+    int i;
+    for (i = 0; i < TRACE_BUFFER_SIZE; i++) {
+        trace_integer(TRACE_POINT_0, 0xFFFFFFFF);
+    }
+
+    CHECK_EQUAL(TRACE_BUFFER_SIZE, trace_buffer.nb_events);
+    CHECK_EQUAL(0, trace_buffer.write_index);
+
+    // wrap around & overwrite first element
+    trace_string(TRACE_POINT_1, "hello world");
+
+    CHECK_EQUAL(TRACE_POINT_0, trace_buffer.data[TRACE_BUFFER_SIZE-1].event_id);
+
+    CHECK_EQUAL(TRACE_POINT_1, trace_buffer.data[0].event_id);
+    CHECK_EQUAL(TRACE_TYPE_STRING, trace_buffer.data[0].type);
+    STRCMP_EQUAL("hello world", trace_buffer.data[0].data.string);
+
+    CHECK_EQUAL(TRACE_BUFFER_SIZE, trace_buffer.nb_events);
+    CHECK_EQUAL(1, trace_buffer.write_index);
+}
+
+extern "C"
+void print_fn(void *p, const char *fmt, ...)
+{
+    va_list ap;
+    va_start(ap, fmt);
+    char **buf = (char **)p;
+    int n = vsprintf(*buf, fmt, ap);
+    if (n > 0) {
+        *buf += n;
+    }
+    va_end(ap);
+}
+
+TEST_GROUP(TracePrintTestGroup)
+{
+    char buffer[1000];
+    void *arg;
+    void setup()
+    {
+        timestamp = 1234;
+        memset(buffer, 0, sizeof(buffer));
+        arg = &buffer;
+        trace_init();
+        trace_enable();
+    }
+};
+
+TEST(TracePrintTestGroup, CanPrintEventWithInteger)
+{
+    trace_integer(TRACE_POINT_1, 42);
+    trace_print(print_fn, &arg);
+    STRCMP_EQUAL("[1234] TRACE_POINT_1: 42\n", buffer);
+}
+
+TEST(TracePrintTestGroup, CanPrintEventWithMessage)
+{
+    trace_string(TRACE_POINT_0, "hello world");
+    trace_print(print_fn, &arg);
+    STRCMP_EQUAL("[1234] TRACE_POINT_0: \"hello world\"\n", buffer);
+}
+
+TEST(TracePrintTestGroup, CanPrintEventWithScalar)
+{
+    trace_scalar(TRACE_POINT_2, 1.5);
+    trace_print(print_fn, &arg);
+    STRCMP_EQUAL("[1234] TRACE_POINT_2: 1.500000\n", buffer);
+}
+
+TEST(TracePrintTestGroup, CanPrintEventWithAddr)
+{
+    int foo;
+    trace_address(TRACE_POINT_0, &foo);
+    trace_print(print_fn, &arg);
+    char buf[100];
+    snprintf(buf, sizeof(buf), "[1234] TRACE_POINT_0: %p\n", &foo);
+    STRCMP_EQUAL(buf, buffer);
+}
+
+TEST(TracePrintTestGroup, CanPrintMultipleEventWithInteger)
+{
+    trace_string(TRACE_POINT_0, "hello");
+    trace_integer(TRACE_POINT_1, 42);
+    trace_scalar(TRACE_POINT_2, 1);
+    trace_print(print_fn, &arg);
+    STRCMP_EQUAL(
+        "[1234] TRACE_POINT_0: \"hello\"\n"
+        "[1234] TRACE_POINT_1: 42\n"
+        "[1234] TRACE_POINT_2: 1.000000\n", buffer);
+}

--- a/master-firmware/src/trace/trace.c
+++ b/master-firmware/src/trace/trace.c
@@ -2,16 +2,16 @@
 #include <stddef.h>
 #include <string.h>
 
-#ifdef _CHIBIOS_RT_
-#include <ch.h>
-#define TRACE_LOCK() syssts_t __syssst = chSysGetStatusAndLockX()
-#define TRACE_UNLOCK() chSysRestoreStatusX(__syssst)
-#define TRACE_TIMESTAMP_GET() ST2MS(chVTGetSystemTimeX())
-#else /* TEST */
+#ifdef TESTS
 #define TRACE_LOCK()
 #define TRACE_UNLOCK()
 unsigned int timestamp = 0;
 #define TRACE_TIMESTAMP_GET() timestamp
+#else /* ChibiOS */
+#include <ch.h>
+#define TRACE_LOCK() syssts_t __syssst = chSysGetStatusAndLockX()
+#define TRACE_UNLOCK() chSysRestoreStatusX(__syssst)
+#define TRACE_TIMESTAMP_GET() ST2MS(chVTGetSystemTimeX())
 #endif
 
 struct trace_buffer_struct trace_buffer;

--- a/master-firmware/src/trace/trace.c
+++ b/master-firmware/src/trace/trace.c
@@ -1,0 +1,145 @@
+#include "trace.h"
+#include <stddef.h>
+#include <string.h>
+
+#ifdef _CHIBIOS_RT_
+#include <ch.h>
+#define TRACE_LOCK() syssts_t __syssst = chSysGetStatusAndLockX()
+#define TRACE_UNLOCK() chSysRestoreStatusX(__syssst)
+#define TRACE_TIMESTAMP_GET() ST2MS(chVTGetSystemTimeX())
+#else /* TEST */
+#define TRACE_LOCK()
+#define TRACE_UNLOCK()
+unsigned int timestamp = 0;
+#define TRACE_TIMESTAMP_GET() timestamp
+#endif
+
+struct trace_buffer_struct trace_buffer;
+
+static void trace_push_event(uint8_t event_id, struct trace_event *event)
+{
+    if (!trace_buffer.active) {
+        return;
+    }
+    event->event_id = event_id;
+    event->timestamp = TRACE_TIMESTAMP_GET();
+
+    TRACE_LOCK();
+    struct trace_event *p;
+    p = &trace_buffer.data[trace_buffer.write_index];
+    trace_buffer.write_index = (trace_buffer.write_index + 1) % TRACE_BUFFER_SIZE;
+    if (trace_buffer.nb_events < TRACE_BUFFER_SIZE) {
+        trace_buffer.nb_events += 1;
+    }
+    *p = *event;
+    TRACE_UNLOCK();
+}
+
+void trace(uint8_t event_id)
+{
+    struct trace_event e;
+    e.type = TRACE_TYPE_STRING;
+    e.data.string = "";
+    trace_push_event(event_id, &e);
+}
+
+void trace_address(uint8_t event_id, void *p)
+{
+    struct trace_event e;
+    e.type = TRACE_TYPE_ADDRESS;
+    e.data.address = p;
+    trace_push_event(event_id, &e);
+}
+
+void trace_string(uint8_t event_id, const char *str)
+{
+    struct trace_event e;
+    e.type = TRACE_TYPE_STRING;
+    e.data.string = str;
+    trace_push_event(event_id, &e);
+}
+
+void trace_scalar(uint8_t event_id, float f)
+{
+    struct trace_event e;
+    e.type = TRACE_TYPE_SCALAR;
+    e.data.scalar = f;
+    trace_push_event(event_id, &e);
+}
+
+void trace_integer(uint8_t event_id, int32_t i)
+{
+    struct trace_event e;
+    e.type = TRACE_TYPE_INTEGER;
+    e.data.integer = i;
+    trace_push_event(event_id, &e);
+}
+
+/** Initialize the trace system
+ *
+ * @note Tracing should be initialized
+ */
+void trace_init(void)
+{
+    memset(&trace_buffer, 0, sizeof(trace_buffer));
+}
+
+/** Enable trace */
+void trace_enable(void)
+{
+    trace_buffer.active = true;
+}
+
+/** Disable trace
+ *
+ * @note Trace calls are still allowed, they just are not saved.
+ */
+void trace_disable(void)
+{
+    trace_buffer.active = false;
+}
+
+/** Clear the trace buffer */
+void trace_clear(void)
+{
+    TRACE_LOCK();
+    trace_buffer.write_index = 0;
+    trace_buffer.nb_events = 0;
+    TRACE_UNLOCK();
+}
+
+void trace_print(void (*print_fn)(void *, const char *, ...), void *arg)
+{
+    trace_buffer.active = false;
+    size_t i;
+    size_t index;
+    if (trace_buffer.nb_events == TRACE_BUFFER_SIZE) {
+        index = trace_buffer.write_index;
+    } else {
+        index = 0;
+    }
+    for (i = 0; i < trace_buffer.nb_events; i++) {
+        struct trace_event *e = &trace_buffer.data[index];
+        print_fn(arg, "[%u] %s: ", e->timestamp, event_names[e->event_id]);
+        switch (e->type) {
+        case TRACE_TYPE_STRING:
+            print_fn(arg, "\"%s\"\n", e->data.string);
+            break;
+        case TRACE_TYPE_ADDRESS:
+#ifdef _CHIBIOS_RT_ // workaround for chprintf
+            print_fn(arg, "%x\n", e->data.address);
+#else
+            print_fn(arg, "%p\n", e->data.address);
+#endif
+            break;
+        case TRACE_TYPE_SCALAR:
+            print_fn(arg, "%f\n", e->data.scalar);
+            break;
+        case TRACE_TYPE_INTEGER:
+            print_fn(arg, "%d\n", e->data.integer);
+            break;
+        };
+        index = (index + 1) % TRACE_BUFFER_SIZE;
+    }
+    trace_buffer.active = true;
+}

--- a/master-firmware/src/trace/trace.h
+++ b/master-firmware/src/trace/trace.h
@@ -1,0 +1,59 @@
+#ifndef TRACE_H
+#define TRACE_H
+
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+
+#ifndef TRACE_BUFFER_SIZE
+#define TRACE_BUFFER_SIZE 200
+#endif
+
+extern const char *event_names[];
+
+enum {
+    TRACE_TYPE_STRING,
+    TRACE_TYPE_ADDRESS,
+    TRACE_TYPE_SCALAR,
+    TRACE_TYPE_INTEGER,
+};
+
+struct trace_event {
+    uint32_t event_id:8;
+    uint32_t type:2;
+    uint32_t timestamp:22;
+    union {
+        void *address;
+        const char *string;
+        int32_t integer;
+        float scalar;
+    } data;
+};
+
+extern struct trace_buffer_struct {
+    bool active;
+    size_t write_index;
+    size_t nb_events;
+    struct trace_event data[TRACE_BUFFER_SIZE];
+} trace_buffer;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void trace(uint8_t event);
+void trace_address(uint8_t event, void *p);
+void trace_string(uint8_t event, const char *str);
+void trace_scalar(uint8_t event_id, float f);
+void trace_integer(uint8_t event_id, int32_t i);
+void trace_init(void);
+void trace_enable(void);
+void trace_disable(void);
+void trace_clear(void);
+void trace_print(void (*print_fn)(void *, const char *, ...), void *arg);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TRACE_H */

--- a/master-firmware/src/trace/trace_points.c
+++ b/master-firmware/src/trace/trace_points.c
@@ -1,0 +1,8 @@
+#include "trace_points.h"
+
+#undef C
+#define C(x) #x,
+
+const char *event_names[] = {
+    TRACE_POINTS
+};

--- a/master-firmware/src/trace/trace_points.h
+++ b/master-firmware/src/trace/trace_points.h
@@ -1,0 +1,19 @@
+#ifndef TRACE_POINTS_H
+#define TRACE_POINTS_H
+
+#include "trace.h"
+
+#define TRACE_POINTS \
+    C(TRACE_POINT_PANIC) \
+    C(TRACE_POINT_CONTEXT_SWITCH) \
+    C(TRACE_POINT_RPC_MESSAGE_RCV) \
+    C(TRACE_POINT_RPC_MESSAGE_SEND) \
+
+/* List of all trace points in numerical format. */
+#undef C
+#define C(x) x,
+enum {
+    TRACE_POINTS
+};
+
+#endif /* TRACE_POINTS_H */


### PR DESCRIPTION
To have better debug info I need the possibility to trace events in software.

This is largely inspired by earlier work from @antoinealb - I just needed more data stored in the trace events (int, float, pointers and strings).

There is still an issue: For some reason the event timestamp is always 0. Has anyone experience with `chVTGetSystemTimeX()` and knows what is needed to get a useful value from it?
