### PR TITLE
Trajectory manager tests

### DIFF
--- a/master-firmware/package.yml
+++ b/master-firmware/package.yml
@@ -31,15 +31,6 @@ target.arm:
     - src/can/motor_manager.c
     - src/malloc_lock.c
     - src/usbconf.c
-    - src/aversive/error/error.c
-    - src/aversive/robot_system/angle_distance.c
-    - src/aversive/robot_system/robot_system.c
-    - src/aversive/position_manager/position_manager.c
-    - src/aversive/quadramp/quadramp.c
-    - src/aversive/control_system_manager/control_system_manager.c
-    - src/aversive/trajectory_manager/trajectory_manager.c
-    - src/aversive/trajectory_manager/trajectory_manager_core.c
-    - src/aversive/trajectory_manager/trajectory_manager_utils.c
     - src/aversive/blocking_detection_manager/blocking_detection_manager.c
     - src/aversive_port/cvra_motors.c
     - src/aversive_port/cvra_pid.c
@@ -63,7 +54,15 @@ source:
     - src/aversive/math/geometry/polygon.c
     - src/aversive/math/geometry/vect_base.c
     - src/aversive/math/vect2/vect2.c
-
+    - src/aversive/robot_system/angle_distance.c
+    - src/aversive/error/error.c
+    - src/aversive/robot_system/robot_system.c
+    - src/aversive/quadramp/quadramp.c
+    - src/aversive/control_system_manager/control_system_manager.c
+    - src/aversive/position_manager/position_manager.c
+    - src/aversive/trajectory_manager/trajectory_manager.c
+    - src/aversive/trajectory_manager/trajectory_manager_core.c
+    - src/aversive/trajectory_manager/trajectory_manager_utils.c
 
 include_directories:
     - src/

--- a/master-firmware/package.yml
+++ b/master-firmware/package.yml
@@ -82,6 +82,7 @@ tests:
     - tests/obstacle_avoidance.cpp
     - src/trace/tests/trace_test.cpp
     - src/trace/tests/trace_points.c
+    - tests/trajectory_manager_test.cpp
 
 templates:
     app_src.mk.jinja: app_src.mk

--- a/master-firmware/src/aversive/position_manager/position_manager.c
+++ b/master-firmware/src/aversive/position_manager/position_manager.c
@@ -29,20 +29,17 @@
 void position_init(struct robot_position *pos)
 {
     memset(pos, 0, sizeof(struct robot_position));
-    // platform_create_semaphore(&pos->lock, 1);
 }
 
 /** Set a new robot position */
 void position_set(struct robot_position *pos, int16_t x, int16_t y, double a_deg)
 {
-    // platform_take_semaphore(&pos->lock);
     pos->pos_d.a = (a_deg * M_PI)/ 180.0;
     pos->pos_d.x = x;
     pos->pos_d.y = y;
     pos->pos_s16.x = x;
     pos->pos_s16.y = y;
     pos->pos_s16.a = a_deg;
-    // platform_signal_semaphore(&pos->lock);
 }
 
 #ifdef CONFIG_MODULE_COMPENSATE_CENTRIFUGAL_FORCE
@@ -136,7 +133,6 @@ void position_manage(struct robot_position *pos)
     delta.angle = encoders.angle - pos->prev_encoders.angle;
 
     /* update double position */
-    // platform_take_semaphore(&pos->lock);
     a = pos->pos_d.a;
     x = pos->pos_d.x;
     y = pos->pos_d.y;
@@ -204,7 +200,6 @@ void position_manage(struct robot_position *pos)
     pos->pos_s16.x = x_s16;
     pos->pos_s16.y = y_s16;
     pos->pos_s16.a = a_s16;
-    // platform_signal_semaphore(&pos->lock);
 }
 
 

--- a/master-firmware/src/aversive/position_manager/position_manager.h
+++ b/master-firmware/src/aversive/position_manager/position_manager.h
@@ -144,7 +144,6 @@ struct robot_position
 #ifdef CONFIG_MODULE_COMPENSATE_CENTRIFUGAL_FORCE
     double centrifugal_coef;            /**< Coefficient for the centrifugal computation */
 #endif
-    semaphore_t lock;                   /**< Lock to prevent concurrent access. */
 };
 
 

--- a/master-firmware/src/aversive/trajectory_manager/trajectory_manager_core.c
+++ b/master-firmware/src/aversive/trajectory_manager/trajectory_manager_core.c
@@ -662,7 +662,9 @@ void trajectory_manager_thd(void * param)
                     break;
             }
         }
+#ifndef TESTS
         chThdSleepMilliseconds(TRAJ_EVT_PERIOD);
+#endif
     }
 }
 

--- a/master-firmware/tests/trajectory_manager_test.cpp
+++ b/master-firmware/tests/trajectory_manager_test.cpp
@@ -1,0 +1,103 @@
+#include <CppUTest/TestHarness.h>
+#include <CppUTestExt/MockSupport.h>
+
+extern "C" {
+#include "trajectory_manager/trajectory_manager.h"
+#include "trajectory_manager/trajectory_manager_core.h"
+#include "trajectory_manager/trajectory_manager_utils.h"
+#include "control_system_manager/control_system_manager.h"
+#include "quadramp/quadramp.h"
+#include "position_manager/position_manager.h"
+}
+
+TEST_GROUP(TrajectoryManagerTestGroup)
+{
+    struct trajectory traj;
+    struct cs distance_cs, angle_cs;
+    struct quadramp_filter distance_qr, angle_qr;
+    struct robot_position pos;
+    struct robot_system rs;
+
+    const int max_speed = 10;
+
+    void setup()
+    {
+        quadramp_init(&angle_qr);
+        quadramp_init(&distance_qr);
+
+        cs_init(&distance_cs);
+        cs_init(&angle_cs);
+        cs_set_consign_filter(&distance_cs, quadramp_do_filter, &distance_qr);
+        cs_set_consign_filter(&angle_cs, quadramp_do_filter, &angle_qr);
+
+        rs_init(&rs);
+        position_init(&pos);
+        position_set(&pos, 0, 0, 0);
+
+        trajectory_manager_init(&traj, 20);
+        trajectory_set_cs(&traj, &distance_cs, &angle_cs);
+        trajectory_set_robot_params(&traj, &rs, &pos);
+
+        auto angle_start_deg = 10;
+        auto angle_window_deg = 1;
+        auto distance_window_mm = 10;
+
+        trajectory_set_windows(&traj, distance_window_mm,
+                               angle_window_deg, angle_start_deg);
+
+        trajectory_set_acc(&traj, 10, 10);
+        trajectory_set_speed(&traj, max_speed, max_speed);
+
+        // Finally go to a point
+        trajectory_goto_forward_xy_abs(&traj, 200, 200);
+    }
+};
+
+TEST(TrajectoryManagerTestGroup, StateChanges)
+{
+    // Checks that the trajectory manager is running, and turning to align
+    // itself with the target point.
+    CHECK_TRUE(traj.scheduled);
+    CHECK_EQUAL(RUNNING_XY_F_START, traj.state);
+}
+
+TEST(TrajectoryManagerTestGroup, ChangesToInPlaceRotation)
+{
+    // Checks that the robot starts rotating in place
+    trajectory_manager_xy_event(&traj);
+
+    CHECK_EQUAL(RUNNING_XY_F_ANGLE, traj.state);
+
+    // Check that we are rotating in place
+    CHECK_EQUAL(0, get_quadramp_distance_speed(&traj));
+    CHECK_TRUE(get_quadramp_angle_speed(&traj) > 0);
+}
+
+TEST(TrajectoryManagerTestGroup, ChangesToDriving)
+{
+    /* The robot turned enough, now check that we are moving. */
+    position_set(&pos, 0, 0, 45);
+
+    trajectory_manager_xy_event(&traj);
+    trajectory_manager_xy_event(&traj);
+    trajectory_manager_xy_event(&traj);
+
+    CHECK_EQUAL(RUNNING_XY_F_ANGLE_OK, traj.state);
+
+    // Since we are aligned to the target, we expect to go full speed
+    DOUBLES_EQUAL(max_speed, get_quadramp_angle_speed(&traj), 0.01);
+    DOUBLES_EQUAL(max_speed, get_quadramp_distance_speed(&traj), 0.01);
+}
+
+TEST(TrajectoryManagerTestGroup, RemovesEventWhenInWindow)
+{
+    trajectory_manager_xy_event(&traj);
+    trajectory_manager_xy_event(&traj);
+
+    // Moves the robot in the destination window, which means it should not
+    // update the trajectory
+    position_set(&pos, 199, 199, 45);
+    trajectory_manager_xy_event(&traj);
+
+    CHECK_FALSE(traj.scheduled);
+}


### PR DESCRIPTION
This PR implements a few "smoke" tests for the trajectory manager. I did not want to test it completely, but at least we have some basic infrastructure to use when we want to change `trajectory_manager`.