### PR TITLE
Serve SD card logs via HTTP

### DIFF
--- a/master-firmware/package.yml
+++ b/master-firmware/package.yml
@@ -42,6 +42,7 @@ target.arm:
     - src/trace/trace_points.c
     - src/robot_helpers/strategy_helpers.c
     - src/strategy.c
+    - src/filesystem.c
     - src/http/server.c
 
 source:

--- a/master-firmware/package.yml
+++ b/master-firmware/package.yml
@@ -42,6 +42,7 @@ target.arm:
     - src/trace/trace_points.c
     - src/robot_helpers/strategy_helpers.c
     - src/strategy.c
+    - src/http/server.c
 
 source:
     - src/unix_timestamp.c

--- a/master-firmware/src/debug/log.c
+++ b/master-firmware/src/debug/log.c
@@ -14,7 +14,6 @@
 
 MUTEX_DECL(log_lock);
 
-static FATFS SDC_FS;
 static FIL logfile_fp;
 static bool log_file_enabled = false;
 
@@ -114,16 +113,8 @@ static void vlogfile_log_message(struct error *e, va_list args)
 static bool try_sd_card_mount(void)
 {
     FRESULT err;
-    sdcStart(&SDCD1, NULL);
-    sdcConnect(&SDCD1);
-
-    err = f_mount(&SDC_FS, "", 1);
-    if (err != FR_OK) {
-        WARNING("Cannot mount SD card!");
-        return false;
-    }
-
     err = f_open(&logfile_fp, "/log.txt", FA_OPEN_ALWAYS | FA_WRITE);
+
     if (err != FR_OK) {
         WARNING("Cannot create log file.");
         return false;

--- a/master-firmware/src/debug/log.c
+++ b/master-firmware/src/debug/log.c
@@ -24,6 +24,7 @@ static void vlogfile_log_message(struct error *e, va_list args);
 static void log_message(struct error *e, ...)
 {
     va_list va;
+
     chMtxLock(&log_lock);
 
     va_start(va, e);

--- a/master-firmware/src/filesystem.c
+++ b/master-firmware/src/filesystem.c
@@ -1,0 +1,19 @@
+#include <ch.h>
+#include <hal.h>
+#include <ff.h>
+#include <error/error.h>
+#include "filesystem.h"
+
+static FATFS SDC_FS;
+
+void filesystem_start(void)
+{
+    FRESULT err;
+    sdcStart(&SDCD1, NULL);
+    sdcConnect(&SDCD1);
+
+    err = f_mount(&SDC_FS, "", 1);
+    if (err != FR_OK) {
+        WARNING("Cannot mount SD card!");
+    }
+}

--- a/master-firmware/src/filesystem.h
+++ b/master-firmware/src/filesystem.h
@@ -1,0 +1,6 @@
+#ifndef FILESYSTEM_H
+#define FILESYSTEM_H
+
+void filesystem_start(void);
+
+#endif

--- a/master-firmware/src/http/server.c
+++ b/master-firmware/src/http/server.c
@@ -1,0 +1,100 @@
+#include <error/error.h>
+#include <lwip/opt.h>
+#include <lwip/arch.h>
+#include <lwip/api.h>
+
+#include "server.h"
+
+#if LWIP_NETCONN == 0
+#error "HTTP server requires the netconn API"
+#endif
+
+#define HTTP_PORT 80
+
+static const char http_html_hdr[] = "HTTP/1.1 200 OK\r\nContent-type: text/html\r\n\r\n";
+static const char http_index_html[] =
+    "<html><head><title>Congrats!</title></head><body><h1>Welcome to our lwIP HTTP server!</h1><p>This is a small test page, served by httpserver-netconn.</body></html>";
+
+/** Serve one HTTP connection accepted in the http thread */
+static void
+http_server_netconn_serve(struct netconn *conn)
+{
+    struct netbuf *inbuf;
+    char *buf;
+    u16_t buflen;
+    err_t err;
+
+    /* Read the data from the port, blocking if nothing yet there.
+       We assume the request (the part we care about) is in one netbuf */
+    err = netconn_recv(conn, &inbuf);
+
+    if (err == ERR_OK) {
+        netbuf_data(inbuf, (void**)&buf, &buflen);
+
+        /* Is this an HTTP GET command? (only check the first 5 chars, since
+           there are other formats for GET, and we're keeping it very simple )*/
+        if (buflen >= 5 &&
+            buf[0] == 'G' &&
+            buf[1] == 'E' &&
+            buf[2] == 'T' &&
+            buf[3] == ' ' &&
+            buf[4] == '/' ) {
+
+            /* Send the HTML header
+             * subtract 1 from the size, since we dont send the \0 in the string
+             * NETCONN_NOCOPY: our data is const static, so no need to copy it
+             */
+            netconn_write(conn, http_html_hdr, sizeof(http_html_hdr) - 1, NETCONN_NOCOPY);
+
+            /* Send our HTML page */
+            netconn_write(conn, http_index_html, sizeof(http_index_html) - 1, NETCONN_NOCOPY);
+        }
+    }
+    /* Close the connection (server closes in HTTP) */
+    netconn_close(conn);
+
+    /* Delete the buffer (netconn_recv gives us ownership,
+       so we have to make sure to deallocate the buffer) */
+    netbuf_delete(inbuf);
+}
+
+/** The main function, never returns! */
+static THD_FUNCTION(http_server_thread, arg)
+{
+    struct netconn *conn, *newconn;
+    err_t err;
+    LWIP_UNUSED_ARG(arg);
+
+    chRegSetThreadName("http");
+
+    /* Create a new TCP connection handle */
+    /* Bind to port 80 (HTTP) with default IP address */
+    conn = netconn_new(NETCONN_TCP);
+    netconn_bind(conn, IP_ADDR_ANY, HTTP_PORT);
+
+    if (conn != NULL) {
+        ERROR("cannot bind to port %d.", HTTP_PORT);
+    }
+
+    /* Put the connection into LISTEN state */
+    netconn_listen(conn);
+
+    do {
+        err = netconn_accept(conn, &newconn);
+        if (err == ERR_OK) {
+            http_server_netconn_serve(newconn);
+            netconn_delete(newconn);
+        }
+    } while (err == ERR_OK);
+    WARNING("netconn_accept received error %d, aborting.", err);
+    netconn_close(conn);
+    netconn_delete(conn);
+}
+
+/** Initialize the HTTP server (start its thread) */
+void http_server_start(void)
+{
+    static THD_WORKING_AREA(http_server_wa, 1024);
+    chThdCreateStatic(http_server_wa, sizeof(http_server_wa), NORMALPRIO,
+                      http_server_thread, NULL);
+}

--- a/master-firmware/src/http/server.h
+++ b/master-firmware/src/http/server.h
@@ -1,0 +1,7 @@
+#ifndef SERVER_H
+#define SERVER_H
+
+void http_server_start(void);
+
+
+#endif

--- a/master-firmware/src/main.c
+++ b/master-firmware/src/main.c
@@ -33,6 +33,7 @@
 #include "base/base_controller.h"
 #include "trace/trace_points.h"
 #include "strategy.h"
+#include "http/server.h"
 
 void init_base_motors(void);
 
@@ -180,7 +181,6 @@ int main(void) {
     /* Initialize global objects. */
     config_init();
 
-
     /* Initialise timestamp module */
     timestamp_stm32_init();
 
@@ -226,6 +226,7 @@ int main(void) {
     uavcan_node_start(10);
     rpc_server_init();
     message_server_init();
+    http_server_start();
 
     init_base_motors();
     config_load_from_flash();

--- a/master-firmware/src/main.c
+++ b/master-firmware/src/main.c
@@ -33,6 +33,7 @@
 #include "base/base_controller.h"
 #include "trace/trace_points.h"
 #include "strategy.h"
+#include "filesystem.h"
 #include "http/server.h"
 
 void init_base_motors(void);
@@ -154,6 +155,10 @@ int main(void) {
 
     /* Initializes a serial driver.  */
     sdStart(&SD3, &debug_uart_config);
+
+    /* Try to mount the filesystem. */
+    filesystem_start();
+
     log_init();
 
     NOTICE("boot");


### PR DESCRIPTION
This PR adds the ability to download the logs from the SD card via HTTP. This allows the retrieval of previous logs without having to open the robot and remove the SD card.

@SyrianSpock ok ?

<img width="807" alt="screen shot 2016-11-16 at 22 55 49" src="https://cloud.githubusercontent.com/assets/2419961/20384193/38cf3c3c-acb3-11e6-8531-6bb81e52f9a5.png">
