### PR TITLE
Arm refactoring #2: Remove unused stuff

### DIFF
--- a/master-firmware/src/commands.c
+++ b/master-firmware/src/commands.c
@@ -935,11 +935,11 @@ static void cmd_scara_mv(BaseSequentialStream *chp, int argc, char *argv[])
 
     scara_pos(arm, &x, &y, &z, COORDINATE_TABLE);
     scara_trajectory_init(&trajectory);
-    scara_trajectory_append_point_with_length(&trajectory, x, y, z, COORDINATE_TABLE, 0, arm->length[0], arm->length[1]);
+    scara_trajectory_append_point(&trajectory, x, y, z, COORDINATE_TABLE, 0, arm->length);
 
     x = atof(argv[0]);
     y = atof(argv[1]);
-    scara_trajectory_append_point_with_length(&trajectory, x, y, z, COORDINATE_TABLE, 1, arm->length[0], arm->length[1]);
+    scara_trajectory_append_point(&trajectory, x, y, z, COORDINATE_TABLE, 1, arm->length);
     scara_do_trajectory(arm, &trajectory);
 
     chprintf(chp, "Moving %s arm to %f %f %f in table frame\r\n", argv[0], x, y, z);
@@ -1044,8 +1044,8 @@ static void cmd_scara_traj(BaseSequentialStream *chp, int argc, char *argv[])
             }
 
             if (j == point_len) {
-                scara_trajectory_append_point_with_length(&trajectory, point[0], point[1], point[2],
-                        system, (float)point[3] * 0.001, arm->length[0], arm->length[1]);
+                scara_trajectory_append_point(&trajectory, point[0], point[1], point[2],
+                        system, (float)point[3] * 0.001, arm->length);
                 i++;
 
                 chprintf(chp, "Point %d coord:%s x:%d y:%d z:%d dt:%d added successfully.\n",

--- a/master-firmware/src/robot_helpers/strategy_helpers.c
+++ b/master-firmware/src/robot_helpers/strategy_helpers.c
@@ -89,12 +89,12 @@ unsigned strategy_set_arm_trajectory(scara_t* arm, arm_waypoint_t* trajectory, u
     scara_trajectory_init(&arm->trajectory);
 
     for (size_t i = 0; i < trajectory_length; i++) {
-        scara_trajectory_append_point_with_length(
+        scara_trajectory_append_point(
             &arm->trajectory,
             trajectory[i].x, trajectory[i].y, trajectory[i].z,
             trajectory[i].coord,
             (float)trajectory[i].dt * 0.001,
-            arm->length[0], arm->length[1]);
+            arm->length);
 
         duration += trajectory[i].dt;
     }

--- a/master-firmware/src/scara/scara.c
+++ b/master-firmware/src/scara/scara.c
@@ -224,7 +224,5 @@ void scara_set_related_robot_pos(scara_t *arm, struct robot_position *pos)
 
 void scara_shutdown(scara_t *arm)
 {
-    // scara_take_semaphore(&arm->trajectory_semaphore);
     scara_trajectory_delete(&arm->trajectory);
-    // scara_signal_semaphore(&arm->trajectory_semaphore);
 }

--- a/master-firmware/src/scara/scara.c
+++ b/master-firmware/src/scara/scara.c
@@ -49,12 +49,7 @@ void scara_ugly_mode_disable(scara_t* arm)
 }
 
 
-void scara_goto(scara_t* arm,
-                float x,
-                float y,
-                float z,
-                scara_coordinate_t system,
-                const float duration)
+void scara_goto(scara_t* arm, float x, float y, float z, scara_coordinate_t system, const float duration)
 {
     scara_trajectory_init(&(arm->trajectory));
     scara_trajectory_append_point(&(arm->trajectory), x, y, z, system, duration, arm->length);
@@ -121,14 +116,10 @@ void scara_manage(scara_t *arm)
     point_t target = {.x = frame.position[0], .y = frame.position[1]};
 
     point_t p1, p2;
-    arm->kinematics_solution_count = scara_num_possible_elbow_positions(target,
-                                                                        arm->length[0],
-                                                                        arm->length[1],
-                                                                        &p1,
-                                                                        &p2);
-    DEBUG("Inverse kinematics: found %d possible solutions", arm->kinematics_solution_count);
+    int kinematics_solution_count = scara_num_possible_elbow_positions(target, arm->length[0], arm->length[1], &p1, &p2);
+    DEBUG("Inverse kinematics: found %d possible solutions", kinematics_solution_count);
 
-    if (arm->kinematics_solution_count == 0) {
+    if (kinematics_solution_count == 0) {
         arm->last_loop = current_date;
 
         arm->shoulder_joint.set_velocity(arm->shoulder_joint.args, 0);
@@ -136,7 +127,7 @@ void scara_manage(scara_t *arm)
 
         chMtxUnlock(&arm->lock);
         return;
-    } else if (arm->kinematics_solution_count == 2) {
+    } else if (kinematics_solution_count == 2) {
         shoulder_mode_t mode;
         mode = scara_orientation_mode(arm->shoulder_mode, arm->offset_rotation);
         p1 = scara_shoulder_solve(target, p1, p2, mode);

--- a/master-firmware/src/scara/scara.c
+++ b/master-firmware/src/scara/scara.c
@@ -68,12 +68,7 @@ void scara_move_z(scara_t* arm, float z_new, scara_coordinate_t system, const fl
     scara_goto(arm, x, y, z_new, system, duration);
 }
 
-
-void scara_pos_with_length(scara_t* arm,
-                           float* x,
-                           float* y,
-                           float* z,
-                           scara_coordinate_t system)
+void scara_pos(scara_t* arm, float* x, float* y, float* z, scara_coordinate_t system)
 {
     point_t pos;
     pos = scara_forward_kinematics(arm->shoulder_pos, arm->elbow_pos, arm->length);
@@ -93,11 +88,6 @@ void scara_pos_with_length(scara_t* arm,
     *x = pos.x;
     *y = pos.y;
     *z = arm->z_pos;
-}
-
-void scara_pos(scara_t* arm, float* x, float* y, float* z, scara_coordinate_t system)
-{
-    scara_pos_with_length(arm, x, y, z, system);
 }
 
 void scara_do_trajectory(scara_t *arm, scara_trajectory_t *traj)
@@ -171,8 +161,7 @@ void scara_manage(scara_t *arm)
 
     if (arm->control_mode == CONTROL_JAM_PID_XYA) {
         float measured_x, measured_y, measured_z;
-        scara_pos_with_length(arm, &measured_x, &measured_y, &measured_z,
-                              COORDINATE_ARM);
+        scara_pos(arm, &measured_x, &measured_y, &measured_z, COORDINATE_ARM);
 
         float consign_x = pid_process(&arm->x_pid, measured_x - frame.position[0]);
         float consign_y = pid_process(&arm->y_pid, measured_y - frame.position[1]);
@@ -182,8 +171,7 @@ void scara_manage(scara_t *arm)
                                arm->elbow_pos, frame.length[0], frame.length[1],
                                &velocity_alpha, &velocity_beta);
 
-        scara_pos_with_length(arm, &measured_x, &measured_y, &measured_z,
-                              frame.coordinate_type);
+        scara_pos(arm, &measured_x, &measured_y, &measured_z, frame.coordinate_type);
 
         DEBUG("Arm x %.3f y %.3f Arm velocities %.3f %.3f",
               measured_x, measured_y, velocity_alpha, velocity_beta);

--- a/master-firmware/src/scara/scara.c
+++ b/master-firmware/src/scara/scara.c
@@ -67,8 +67,7 @@ void scara_goto_with_length(scara_t* arm,
                             const float duration)
 {
     scara_trajectory_init(&(arm->trajectory));
-    scara_trajectory_append_point_with_length(&(arm->trajectory), x, y, z, system, duration,
-                                              arm->length[0], arm->length[1]);
+    scara_trajectory_append_point(&(arm->trajectory), x, y, z, system, duration, arm->length);
     scara_do_trajectory(arm, &(arm->trajectory));
 }
 

--- a/master-firmware/src/scara/scara.c
+++ b/master-firmware/src/scara/scara.c
@@ -56,16 +56,6 @@ void scara_goto(scara_t* arm,
                 scara_coordinate_t system,
                 const float duration)
 {
-    scara_goto_with_length(arm, x, y, z, system, duration);
-}
-
-void scara_goto_with_length(scara_t* arm,
-                            float x,
-                            float y,
-                            float z,
-                            scara_coordinate_t system,
-                            const float duration)
-{
     scara_trajectory_init(&(arm->trajectory));
     scara_trajectory_append_point(&(arm->trajectory), x, y, z, system, duration, arm->length);
     scara_do_trajectory(arm, &(arm->trajectory));

--- a/master-firmware/src/scara/scara.h
+++ b/master-firmware/src/scara/scara.h
@@ -45,7 +45,6 @@ typedef struct {
 
     /* Path informations */
     scara_trajectory_t trajectory;    /**< Current trajectory of the arm. */
-    semaphore_t trajectory_semaphore;
     struct robot_position *robot_pos;
 
     shoulder_mode_t shoulder_mode;

--- a/master-firmware/src/scara/scara.h
+++ b/master-firmware/src/scara/scara.h
@@ -48,7 +48,6 @@ typedef struct {
     semaphore_t trajectory_semaphore;
     int32_t last_loop;              /**< Timestamp of the last loop execution, in us since boot. */
     struct robot_position *robot_pos;
-    int kinematics_solution_count;
 
     shoulder_mode_t shoulder_mode;
     scara_control_mode_t control_mode;

--- a/master-firmware/src/scara/scara.h
+++ b/master-firmware/src/scara/scara.h
@@ -46,7 +46,6 @@ typedef struct {
     /* Path informations */
     scara_trajectory_t trajectory;    /**< Current trajectory of the arm. */
     semaphore_t trajectory_semaphore;
-    int32_t last_loop;              /**< Timestamp of the last loop execution, in us since boot. */
     struct robot_position *robot_pos;
 
     shoulder_mode_t shoulder_mode;

--- a/master-firmware/src/scara/scara.h
+++ b/master-firmware/src/scara/scara.h
@@ -75,8 +75,6 @@ void scara_ugly_mode_disable(scara_t* arm);
 
 /* Goto position in specified coordinate system */
 void scara_goto(scara_t* arm, float x, float y, float z, scara_coordinate_t system, const float duration);
-void scara_goto_with_length(scara_t* arm, float x, float y, float z, scara_coordinate_t system,
-                            const float duration);
 
 /* Move arm in axis only */
 void scara_move_z(scara_t* arm, float z, scara_coordinate_t system, const float duration);

--- a/master-firmware/src/scara/scara_trajectories.c
+++ b/master-firmware/src/scara/scara_trajectories.c
@@ -51,14 +51,6 @@ void scara_trajectory_append_point(scara_trajectory_t *traj, const float x, cons
     traj->frames[traj->frame_count-1].length[1] = length[1];
 }
 
-void scara_trajectory_append_point_with_length(scara_trajectory_t *traj, const float x, const float y, const float z,
-                                               scara_coordinate_t system,
-                                               const float duration, const float l1, const float l2)
-{
-    float length[2] = {l1, l2};
-    scara_trajectory_append_point(traj, x, y, z, system, duration, length);
-}
-
 void scara_trajectory_delete(scara_trajectory_t *traj)
 {
     if (traj->frame_count != 0) {

--- a/master-firmware/src/scara/scara_trajectories.h
+++ b/master-firmware/src/scara/scara_trajectories.h
@@ -24,12 +24,6 @@ void scara_trajectory_append_point(scara_trajectory_t *traj, const float x, cons
  */
 void scara_trajectory_init(scara_trajectory_t *traj);
 
-
-/** same as scara_trajectory_append_point but with a custom length. */
-void scara_trajectory_append_point_with_length(scara_trajectory_t *traj, const float x, const float y, const float z,
-                                               scara_coordinate_t system, const float duration,
-                                               const float l1, const float l2);
-
 void scara_trajectory_delete(scara_trajectory_t *traj);
 
 void scara_trajectory_copy(scara_trajectory_t *dest, scara_trajectory_t *src);

--- a/master-firmware/tests/scara.cpp
+++ b/master-firmware/tests/scara.cpp
@@ -62,13 +62,6 @@ TEST_GROUP(ArmTestGroup)
     }
 };
 
-TEST(ArmTestGroup, LagCompensationIsInitialized)
-{
-    scara_time_set(42);
-    scara_init(&arm);
-    CHECK_EQUAL(42, arm.last_loop);
-}
-
 TEST(ArmTestGroup, ShoulderModeIsSetToBack)
 {
     scara_init(&arm);
@@ -134,14 +127,6 @@ TEST(ArmTestGroup, ArmManageIsAtomicWithUnreachableTarget)
     mock().expectOneCall("chMtxUnlock").withPointerParameter("lock", &arm.lock);
 
     scara_manage(&arm);
-}
-
-TEST(ArmTestGroup, ArmManageUpdatesLastLoop)
-{
-    scara_time_set(42);
-    CHECK_EQUAL(0, arm.trajectory.frame_count);
-    scara_manage(&arm);
-    CHECK_EQUAL(42, arm.last_loop)
 }
 
 TEST(ArmTestGroup, ArmManageChangesConsign)

--- a/master-firmware/tests/scara.cpp
+++ b/master-firmware/tests/scara.cpp
@@ -127,7 +127,7 @@ TEST(ArmTestGroup, ArmManageIsAtomicWithEmptyTraj)
 
 TEST(ArmTestGroup, ArmManageIsAtomicWithUnreachableTarget)
 {
-    scara_trajectory_append_point_with_length(&traj, 10000, 10000, 10, COORDINATE_ARM, 1., 10, 10);
+    scara_trajectory_append_point(&traj, 10000, 10000, 10, COORDINATE_ARM, 1., arbitraryLengths);
     scara_do_trajectory(&arm, &traj);
     lock_mocks_enable(true);
     mock().expectOneCall("chMtxLock").withPointerParameter("lock", &arm.lock);
@@ -260,14 +260,15 @@ TEST(ArmTestGroup, LengthAreInterpolated)
     scara_waypoint_t result;
     const int32_t date = 5 * 1000000;
     arm.offset_rotation = M_PI / 2;
-    scara_trajectory_append_point_with_length(&traj, 0, 0, 0, COORDINATE_ARM, 1., 10, 10);
-    scara_trajectory_append_point_with_length(&traj, 0, 0, 0, COORDINATE_ARM, 10., 100, 200);
+    const float arbitraryLongerLengths[2] = {arbitraryLengths[0] * 2, arbitraryLengths[1] * 2};
+    scara_trajectory_append_point(&traj, 0, 0, 0, COORDINATE_ARM, 1., arbitraryLengths);
+    scara_trajectory_append_point(&traj, 0, 0, 0, COORDINATE_ARM, 10., arbitraryLongerLengths);
 
     scara_do_trajectory(&arm, &traj);
 
     result = scara_position_for_date(&arm, date);
-    DOUBLES_EQUAL(55, result.length[0], 0.1);
-    DOUBLES_EQUAL(105, result.length[1], 0.1);
+    DOUBLES_EQUAL(arbitraryLengths[0] * 1.5, result.length[0], 0.1);
+    DOUBLES_EQUAL(arbitraryLengths[1] * 1.5, result.length[1], 0.1);
 }
 
 

--- a/master-firmware/tests/scara_trajectories.cpp
+++ b/master-firmware/tests/scara_trajectories.cpp
@@ -97,8 +97,8 @@ TEST(ArmTrajectoriesBuilderTest, WaypointInterpolation)
 {
     const int32_t interpolation_date = 5 * 1000000; // microseconds
     scara_waypoint_t result;
-    scara_trajectory_append_point_with_length(&traj, 0, 0, 0, COORDINATE_ARM, 1., 100, 100);
-    scara_trajectory_append_point_with_length(&traj, 10, 20, 30, COORDINATE_ARM, 10., 200, 200);
+    scara_trajectory_append_point(&traj, 0, 0, 0, COORDINATE_ARM, 1., arbitraryLengths);
+    scara_trajectory_append_point(&traj, 10, 20, 30, COORDINATE_ARM, 10., arbitraryLengths);
 
     result = scara_trajectory_interpolate_waypoints(traj.frames[0], traj.frames[1], interpolation_date);
     CHECK_EQUAL(interpolation_date, result.date);
@@ -106,7 +106,4 @@ TEST(ArmTrajectoriesBuilderTest, WaypointInterpolation)
     DOUBLES_EQUAL(5., result.position[0], 0.1);
     DOUBLES_EQUAL(10., result.position[1], 0.1);
     DOUBLES_EQUAL(15., result.position[2], 0.1);
-
-    DOUBLES_EQUAL(150., result.length[0], 0.1);
-    DOUBLES_EQUAL(150., result.length[1], 0.1);
 }


### PR DESCRIPTION
This PR removes hacks/features not used in the arm's code:
- The variable length hack introduced last year to handle the change of forearm length depending on the hand's pitch
- The kinematics solution count is only used locally, no need to store it in the arm's state
- The last loop time was previously recorded but never used for lag compensation as advertised by comments.
- The unused trajectory semaphore