### PR TITLE
Arm refactoring #3: Introduce Lie group formalism

### DIFF
--- a/master-firmware/package.yml
+++ b/master-firmware/package.yml
@@ -78,6 +78,7 @@ source:
     - src/aversive/trajectory_manager/trajectory_manager.c
     - src/aversive/trajectory_manager/trajectory_manager_core.c
     - src/aversive/trajectory_manager/trajectory_manager_utils.c
+    - src/scara/lie_groups.c
     - src/scara/joint.c
     - src/scara/scara_utils.c
     - src/scara/scara_trajectories.c
@@ -116,6 +117,7 @@ tests:
     - tests/scara_kinematics_integration.cpp
     - tests/scara.cpp
     - tests/test_hand.cpp
+    - tests/lie_groups.cpp
 
 templates:
     app_src.mk.jinja: app_src.mk

--- a/master-firmware/src/scara/lie_groups.c
+++ b/master-firmware/src/scara/lie_groups.c
@@ -20,6 +20,11 @@ point_t so2_rotate(so2_t rotation, point_t point)
     return point;
 }
 
+point_t so2_inverse_rotate(so2_t rotation, point_t point)
+{
+    return so2_rotate(so2_create(- rotation.angle), point);
+}
+
 vect_t translation_2d(float x, float y)
 {
     vect_t translation = {.x = x, .y = y};
@@ -38,6 +43,16 @@ point_t se2_transform(se2_t transform, point_t point)
 
     point.x += transform.translation.x;
     point.y += transform.translation.y;
+
+    return point;
+}
+
+point_t se2_inverse_transform(se2_t transform, point_t point)
+{
+    point.x -= transform.translation.x;
+    point.y -= transform.translation.y;
+
+    point = so2_inverse_rotate(transform.rotation, point);
 
     return point;
 }

--- a/master-firmware/src/scara/lie_groups.c
+++ b/master-firmware/src/scara/lie_groups.c
@@ -1,0 +1,21 @@
+#include "lie_groups.h"
+
+so2_t so2_create(float angle)
+{
+    so2_t rotation = {.angle = angle};
+    return rotation;
+}
+
+point_t so2_rotate(so2_t rotation, point_t point)
+{
+    vect2_cart cartesian_point = {.x = point.x, .y = point.y};
+    vect2_pol polar_point;
+
+    vect2_cart2pol(&cartesian_point, &polar_point);
+    polar_point.theta += rotation.angle;
+    vect2_pol2cart(&polar_point, &cartesian_point);
+
+    point.x = cartesian_point.x;
+    point.y = cartesian_point.y;
+    return point;
+}

--- a/master-firmware/src/scara/lie_groups.c
+++ b/master-firmware/src/scara/lie_groups.c
@@ -19,3 +19,25 @@ point_t so2_rotate(so2_t rotation, point_t point)
     point.y = cartesian_point.y;
     return point;
 }
+
+vect_t translation_2d(float x, float y)
+{
+    vect_t translation = {.x = x, .y = y};
+    return translation;
+}
+
+se2_t se2_create(float angle, vect_t translation)
+{
+    se2_t transform = {.rotation = so2_create(angle), .translation = translation};
+    return transform;
+}
+
+point_t se2_transform(se2_t transform, point_t point)
+{
+    point = so2_rotate(transform.rotation, point);
+
+    point.x += transform.translation.x;
+    point.y += transform.translation.y;
+
+    return point;
+}

--- a/master-firmware/src/scara/lie_groups.h
+++ b/master-firmware/src/scara/lie_groups.h
@@ -1,0 +1,16 @@
+#ifndef LIE_GROUPS_H
+#define LIE_GROUPS_H
+
+#include <aversive/math/vect2/vect2.h>
+#include <aversive/math/geometry/vect_base.h>
+
+// Special Orientation group 2 (SO2) defines a 2D rotation
+typedef struct {
+    float angle;
+} so2_t;
+
+so2_t so2_create(float angle);
+
+point_t so2_rotate(so2_t rotation, point_t point);
+
+#endif

--- a/master-firmware/src/scara/lie_groups.h
+++ b/master-firmware/src/scara/lie_groups.h
@@ -13,4 +13,17 @@ so2_t so2_create(float angle);
 
 point_t so2_rotate(so2_t rotation, point_t point);
 
+// Translation
+vect_t translation_2d(float x, float y);
+
+// Special Euclidian group 2 (SE2) defines a 2D rigid body transform (rotation + translation)
+typedef struct {
+    so2_t rotation;
+    vect_t translation;
+} se2_t;
+
+se2_t se2_create(float angle, vect_t translation);
+
+point_t se2_transform(se2_t transform, point_t point);
+
 #endif

--- a/master-firmware/src/scara/lie_groups.h
+++ b/master-firmware/src/scara/lie_groups.h
@@ -12,6 +12,7 @@ typedef struct {
 so2_t so2_create(float angle);
 
 point_t so2_rotate(so2_t rotation, point_t point);
+point_t so2_inverse_rotate(so2_t rotation, point_t point);
 
 // Translation
 vect_t translation_2d(float x, float y);
@@ -25,5 +26,6 @@ typedef struct {
 se2_t se2_create(float angle, vect_t translation);
 
 point_t se2_transform(se2_t transform, point_t point);
+point_t se2_inverse_transform(se2_t transform, point_t point);
 
 #endif

--- a/master-firmware/src/scara/scara_utils.c
+++ b/master-firmware/src/scara/scara_utils.c
@@ -4,14 +4,8 @@
 
 point_t scara_coordinate_robot2arm(point_t robot_point, vect2_cart offset_xy, float offset_angle)
 {
-    point_t arm_point = {
-        .x = robot_point.x - offset_xy.x,
-        .y = robot_point.y - offset_xy.y
-    };
-
-    arm_point = so2_rotate(so2_create(- offset_angle), arm_point);
-
-    return arm_point;
+    se2_t arm2robot = se2_create(offset_angle, translation_2d(offset_xy.x, offset_xy.y));
+    return se2_inverse_transform(arm2robot, robot_point);
 }
 
 point_t scara_coordinate_arm2robot(point_t arm_point, vect2_cart offset_xy, float offset_angle)
@@ -22,14 +16,8 @@ point_t scara_coordinate_arm2robot(point_t arm_point, vect2_cart offset_xy, floa
 
 point_t scara_coordinate_table2robot(point_t target_point, point_t robot_pos, float robot_a_rad)
 {
-    point_t robot_point = {
-        .x = target_point.x - robot_pos.x,
-        .y = target_point.y - robot_pos.y
-    };
-
-    robot_point = so2_rotate(so2_create(- robot_a_rad), robot_point);
-
-    return robot_point;
+    se2_t robot2table = se2_create(robot_a_rad, translation_2d(robot_pos.x, robot_pos.y));
+    return se2_inverse_transform(robot2table, target_point);
 }
 
 point_t scara_coordinate_robot2table(point_t robot_point, point_t robot_pos, float robot_a_rad)

--- a/master-firmware/src/scara/scara_utils.c
+++ b/master-firmware/src/scara/scara_utils.c
@@ -16,14 +16,8 @@ point_t scara_coordinate_robot2arm(point_t robot_point, vect2_cart offset_xy, fl
 
 point_t scara_coordinate_arm2robot(point_t arm_point, vect2_cart offset_xy, float offset_angle)
 {
-    arm_point = so2_rotate(so2_create(offset_angle), arm_point);
-
-    point_t robot_point = {
-        .x = arm_point.x + offset_xy.x,
-        .y = arm_point.y + offset_xy.y
-    };
-
-    return robot_point;
+    se2_t arm2robot = se2_create(offset_angle, translation_2d(offset_xy.x, offset_xy.y));
+    return se2_transform(arm2robot, arm_point);
 }
 
 point_t scara_coordinate_table2robot(point_t target_point, point_t robot_pos, float robot_a_rad)
@@ -40,12 +34,6 @@ point_t scara_coordinate_table2robot(point_t target_point, point_t robot_pos, fl
 
 point_t scara_coordinate_robot2table(point_t robot_point, point_t robot_pos, float robot_a_rad)
 {
-    robot_point = so2_rotate(so2_create(robot_a_rad), robot_point);
-
-    point_t table_point = {
-        .x = robot_point.x + robot_pos.x,
-        .y = robot_point.y + robot_pos.y
-    };
-
-    return table_point;
+    se2_t robot2table = se2_create(robot_a_rad, translation_2d(robot_pos.x, robot_pos.y));
+    return se2_transform(robot2table, robot_point);
 }

--- a/master-firmware/src/scara/scara_utils.c
+++ b/master-firmware/src/scara/scara_utils.c
@@ -1,80 +1,51 @@
 #include "scara_utils.h"
+#include "lie_groups.h"
 
 
-point_t scara_coordinate_robot2arm(point_t target_point, vect2_cart offset_xy, float offset_angle)
+point_t scara_coordinate_robot2arm(point_t robot_point, vect2_cart offset_xy, float offset_angle)
 {
-    vect2_cart target;
-    vect2_pol target_pol;
-    target.x = target_point.x;
-    target.y = target_point.y;
+    point_t arm_point = {
+        .x = robot_point.x - offset_xy.x,
+        .y = robot_point.y - offset_xy.y
+    };
 
-    vect2_sub_cart(&target, &offset_xy, &target);
-    vect2_cart2pol(&target, &target_pol);
+    arm_point = so2_rotate(so2_create(- offset_angle), arm_point);
 
-    target_pol.theta -= offset_angle;
-
-    vect2_pol2cart(&target_pol, &target);
-
-    target_point.x = target.x;
-    target_point.y = target.y;
-
-    return target_point;
+    return arm_point;
 }
 
 point_t scara_coordinate_arm2robot(point_t arm_point, vect2_cart offset_xy, float offset_angle)
 {
-    point_t robot_point;
-    vect2_cart robot_cart;
-    vect2_pol robot_pol;
+    arm_point = so2_rotate(so2_create(offset_angle), arm_point);
 
-    robot_cart.x = arm_point.x;
-    robot_cart.y = arm_point.y;
-
-    vect2_cart2pol(&robot_cart, &robot_pol);
-    robot_pol.theta += offset_angle;
-    vect2_pol2cart(&robot_pol, &robot_cart);
-
-    vect2_add_cart(&robot_cart, &offset_xy, &robot_cart);
-
-    robot_point.x = robot_cart.x;
-    robot_point.y = robot_cart.y;
+    point_t robot_point = {
+        .x = arm_point.x + offset_xy.x,
+        .y = arm_point.y + offset_xy.y
+    };
 
     return robot_point;
 }
 
 point_t scara_coordinate_table2robot(point_t target_point, point_t robot_pos, float robot_a_rad)
 {
-    vect2_cart target;
-    vect2_pol target_pol;
+    point_t robot_point = {
+        .x = target_point.x - robot_pos.x,
+        .y = target_point.y - robot_pos.y
+    };
 
-    target.x = target_point.x - robot_pos.x;
-    target.y = target_point.y - robot_pos.y;
+    robot_point = so2_rotate(so2_create(- robot_a_rad), robot_point);
 
-    vect2_cart2pol(&target, &target_pol);
-    target_pol.theta -= robot_a_rad;
-    vect2_pol2cart(&target_pol, &target);
-
-    target_point.x = target.x;
-    target_point.y = target.y;
-
-    return target_point;
+    return robot_point;
 }
 
 point_t scara_coordinate_robot2table(point_t robot_point, point_t robot_pos, float robot_a_rad)
 {
-    point_t table_point;
-    vect2_cart table_cart;
-    vect2_pol table_pol;
+    robot_point = so2_rotate(so2_create(robot_a_rad), robot_point);
 
-    table_cart.x = robot_point.x;
-    table_cart.y = robot_point.y;
-
-    vect2_cart2pol(&table_cart, &table_pol);
-    table_pol.theta += robot_a_rad;
-    vect2_pol2cart(&table_pol, &table_cart);
-
-    table_point.x = table_cart.x + robot_pos.x;
-    table_point.y = table_cart.y + robot_pos.y;
+    point_t table_point = {
+        .x = robot_point.x + robot_pos.x,
+        .y = robot_point.y + robot_pos.y
+    };
 
     return table_point;
 }

--- a/master-firmware/tests/lie_groups.cpp
+++ b/master-firmware/tests/lie_groups.cpp
@@ -40,6 +40,17 @@ TEST(AnSO2LieGroup, ComputesRotatedPoint)
     DOUBLES_EQUAL(point.x, rotated.y, 0.01);
 }
 
+TEST(AnSO2LieGroup, ComputesInverseRotatedPoint)
+{
+    so2_t rotation = so2_create(pi / 2);
+    point_t point = {.x = 10, .y = 20};
+
+    point_t rotated = so2_inverse_rotate(rotation, point);
+
+    DOUBLES_EQUAL(point.y, rotated.x, 0.01);
+    DOUBLES_EQUAL(- point.x, rotated.y, 0.01);
+}
+
 TEST_GROUP(AnSE2LieGroup)
 {
     const float pi = M_PI;
@@ -74,4 +85,15 @@ TEST(AnSE2LieGroup, RotatesAndTranslatesPoint)
 
     DOUBLES_EQUAL(- point.y + 1, transformed.x, 0.01);
     DOUBLES_EQUAL(+ point.x + 2, transformed.y, 0.01);
+}
+
+TEST(AnSE2LieGroup, AppliesInverseTransformToPoint)
+{
+    se2_t transform = se2_create(M_PI / 2, {1, 2});
+    point_t point = {.x = 10, .y = 20};
+
+    point_t transformed = se2_inverse_transform(transform, point);
+
+    DOUBLES_EQUAL(  (point.y - 2), transformed.x, 0.01);
+    DOUBLES_EQUAL(- (point.x - 1), transformed.y, 0.01);
 }

--- a/master-firmware/tests/lie_groups.cpp
+++ b/master-firmware/tests/lie_groups.cpp
@@ -39,3 +39,39 @@ TEST(AnSO2LieGroup, ComputesRotatedPoint)
     DOUBLES_EQUAL(- point.y, rotated.x, 0.01);
     DOUBLES_EQUAL(point.x, rotated.y, 0.01);
 }
+
+TEST_GROUP(AnSE2LieGroup)
+{
+    const float pi = M_PI;
+};
+
+TEST(AnSE2LieGroup, ConstructsFromAngleAndVector)
+{
+    se2_t transform = se2_create(1, translation_2d(2, 3));
+
+    CHECK_EQUAL(1, transform.rotation.angle);
+    CHECK_EQUAL(2, transform.translation.x);
+    CHECK_EQUAL(3, transform.translation.y);
+}
+
+TEST(AnSE2LieGroup, ReturnsSamePointWhenTransformIsIdentity)
+{
+    se2_t identity = se2_create(0, {0, 0});
+    point_t point = {.x = 10, .y = 20};
+
+    point_t transformed = se2_transform(identity, point);
+
+    DOUBLES_EQUAL(point.x, transformed.x, 0.01);
+    DOUBLES_EQUAL(point.y, transformed.y, 0.01);
+}
+
+TEST(AnSE2LieGroup, RotatesAndTranslatesPoint)
+{
+    se2_t transform = se2_create(M_PI / 2, {1, 2});
+    point_t point = {.x = 10, .y = 20};
+
+    point_t transformed = se2_transform(transform, point);
+
+    DOUBLES_EQUAL(- point.y + 1, transformed.x, 0.01);
+    DOUBLES_EQUAL(+ point.x + 2, transformed.y, 0.01);
+}

--- a/master-firmware/tests/lie_groups.cpp
+++ b/master-firmware/tests/lie_groups.cpp
@@ -1,0 +1,41 @@
+#include "CppUTest/TestHarness.h"
+#include <cmath>
+
+extern "C" {
+#include "scara/lie_groups.h"
+}
+
+TEST_GROUP(AnSO2LieGroup)
+{
+    const float zero = 0;
+    const float pi = M_PI;
+};
+
+TEST(AnSO2LieGroup, ConstructsFromAngle)
+{
+    so2_t rotation = so2_create(pi);
+
+    CHECK_EQUAL(pi, rotation.angle);
+}
+
+TEST(AnSO2LieGroup, ComputesRotationOfAngleZero)
+{
+    so2_t rotation = so2_create(zero);
+    point_t point = {.x = 10, .y = 20};
+
+    point_t rotated = so2_rotate(rotation, point);
+
+    DOUBLES_EQUAL(point.x, rotated.x, 0.01);
+    DOUBLES_EQUAL(point.y, rotated.y, 0.01);
+}
+
+TEST(AnSO2LieGroup, ComputesRotatedPoint)
+{
+    so2_t rotation = so2_create(pi / 2);
+    point_t point = {.x = 10, .y = 20};
+
+    point_t rotated = so2_rotate(rotation, point);
+
+    DOUBLES_EQUAL(- point.y, rotated.x, 0.01);
+    DOUBLES_EQUAL(point.x, rotated.y, 0.01);
+}


### PR DESCRIPTION
This PR introduces Lie group formalism to abstract away rigid body transformations done in the code.
Defines only 2D rotations (SO2) and 2D transforms (SE2).