### PR TITLE
Arm refactoring #5: Hardware interface

### DIFF
--- a/master-firmware/package.yml
+++ b/master-firmware/package.yml
@@ -116,6 +116,7 @@ tests:
     - tests/scara_trajectories.cpp
     - tests/scara_kinematics.cpp
     - tests/scara_kinematics_integration.cpp
+    - tests/scara_hardware_interface.cpp
     - tests/scara.cpp
     - tests/test_hand.cpp
     - tests/lie_groups.cpp

--- a/master-firmware/package.yml
+++ b/master-firmware/package.yml
@@ -80,6 +80,7 @@ source:
     - src/aversive/trajectory_manager/trajectory_manager_utils.c
     - src/scara/lie_groups.c
     - src/scara/joint.c
+    - src/scara/scara_hardware_interface.c
     - src/scara/scara_utils.c
     - src/scara/scara_trajectories.c
     - src/scara/scara_kinematics.c

--- a/master-firmware/src/arms/arms_controller.c
+++ b/master-firmware/src/arms/arms_controller.c
@@ -37,9 +37,9 @@ void arms_init(void)
     static cvra_arm_motor_t shoulder_joint = {.id = "shoulder-joint", .direction = -1, .index = 0};
     static cvra_arm_motor_t elbow_joint = {.id = "elbow-joint", .direction = -1, .index = 0};
 
-    joint_set_callbacks(&(main_arm.z_joint), set_motor_position, set_motor_velocity, get_motor_position, &z_joint);
-    joint_set_callbacks(&(main_arm.elbow_joint), set_motor_position, set_motor_velocity, get_motor_position, &elbow_joint);
-    joint_set_callbacks(&(main_arm.shoulder_joint), set_motor_position, set_motor_velocity, get_motor_position, &shoulder_joint);
+    joint_set_callbacks(&(main_arm.hw_interface.z_joint), set_motor_position, set_motor_velocity, get_motor_position, &z_joint);
+    joint_set_callbacks(&(main_arm.hw_interface.elbow_joint), set_motor_position, set_motor_velocity, get_motor_position, &elbow_joint);
+    joint_set_callbacks(&(main_arm.hw_interface.shoulder_joint), set_motor_position, set_motor_velocity, get_motor_position, &shoulder_joint);
 
     scara_set_related_robot_pos(&main_arm, &robot.pos);
 

--- a/master-firmware/src/scara/joint.c
+++ b/master-firmware/src/scara/joint.c
@@ -8,3 +8,12 @@ void joint_set_callbacks(joint_t *joint, void (*set_position)(void *, float),
   joint->get_position = get_position;
   joint->args = args;
 }
+
+void joint_set(joint_t* joint, joint_setpoint_t setpoint)
+{
+    if (setpoint.mode == POSITION) {
+        joint->set_position(joint->args, setpoint.value);
+    } else if (setpoint.mode == VELOCITY) {
+        joint->set_velocity(joint->args, setpoint.value);
+    }
+}

--- a/master-firmware/src/scara/joint.h
+++ b/master-firmware/src/scara/joint.h
@@ -13,4 +13,18 @@ void joint_set_callbacks(joint_t *joint, void (*set_position)(void *, float),
                          void (*set_velocity)(void *, float),
                          float (*get_position)(void *), void *args);
 
+/** Joint setpoint mode */
+typedef enum {
+    POSITION,
+    VELOCITY
+} joint_mode_t;
+
+/** Joint setpoint */
+typedef struct {
+    joint_mode_t mode;
+    float value;
+} joint_setpoint_t;
+
+void joint_set(joint_t* joint, joint_setpoint_t setpoint);
+
 #endif

--- a/master-firmware/src/scara/scara.c
+++ b/master-firmware/src/scara/scara.c
@@ -8,8 +8,6 @@
 #include "scara_port.h"
 #include "scara_jacobian.h"
 
-static void scara_shutdown_joints(scara_t* arm);
-
 static void scara_lock(mutex_t* mutex)
 {
     chMtxLock(mutex);
@@ -162,7 +160,7 @@ void scara_manage(scara_t *arm)
         DEBUG("Inverse kinematics: Found a solution");
     } else {
         DEBUG("Inverse kinematics: Found no solution, disabling the arm");
-        scara_shutdown_joints(arm);
+        scara_hw_shutdown_joints(&arm->hw_interface);
         scara_unlock(&arm->lock);
         return;
     }
@@ -249,11 +247,4 @@ void scara_set_related_robot_pos(scara_t *arm, struct robot_position *pos)
 void scara_shutdown(scara_t *arm)
 {
     scara_trajectory_delete(&arm->trajectory);
-}
-
-
-void scara_shutdown_joints(scara_t* arm)
-{
-    arm->hw_interface.shoulder_joint.set_velocity(arm->hw_interface.shoulder_joint.args, 0);
-    arm->hw_interface.elbow_joint.set_velocity(arm->hw_interface.elbow_joint.args, 0);
 }

--- a/master-firmware/src/scara/scara.c
+++ b/master-firmware/src/scara/scara.c
@@ -175,15 +175,19 @@ void scara_manage(scara_t *arm)
         DEBUG("Arm x %.3f y %.3f Arm velocities %.3f %.3f",
               measured_x, measured_y, velocity_alpha, velocity_beta);
 
-        /* Set motor commands */
-        arm->hw_interface.z_joint.set_position(arm->hw_interface.z_joint.args, frame.position[2]);
-        arm->hw_interface.shoulder_joint.set_velocity(arm->hw_interface.shoulder_joint.args, velocity_alpha);
-        arm->hw_interface.elbow_joint.set_velocity(arm->hw_interface.elbow_joint.args, velocity_beta);
+        scara_joint_setpoints_t joint_setpoints = {
+            .z = {POSITION, frame.position[2]},
+            .shoulder = {VELOCITY, velocity_alpha},
+            .elbow = {VELOCITY, velocity_beta}
+        };
+        scara_hw_set_joints(&arm->hw_interface, joint_setpoints);
     } else {
-        /* Set motor positions */
-        arm->hw_interface.z_joint.set_position(arm->hw_interface.z_joint.args, frame.position[2]);
-        arm->hw_interface.shoulder_joint.set_position(arm->hw_interface.shoulder_joint.args, alpha);
-        arm->hw_interface.elbow_joint.set_position(arm->hw_interface.elbow_joint.args, beta);
+        scara_joint_setpoints_t joint_setpoints = {
+            .z = {POSITION, frame.position[2]},
+            .shoulder = {POSITION, alpha},
+            .elbow = {POSITION, beta}
+        };
+        scara_hw_set_joints(&arm->hw_interface, joint_setpoints);
     }
 
     scara_unlock(&arm->lock);

--- a/master-firmware/src/scara/scara.c
+++ b/master-firmware/src/scara/scara.c
@@ -103,9 +103,9 @@ void scara_do_trajectory(scara_t *arm, scara_trajectory_t *traj)
 
 static void scara_read_joint_positions(scara_t *arm)
 {
-    arm->z_pos = arm->z_joint.get_position(arm->z_joint.args);
-    arm->shoulder_pos = arm->shoulder_joint.get_position(arm->shoulder_joint.args);
-    arm->elbow_pos = arm->elbow_joint.get_position(arm->elbow_joint.args);
+    arm->z_pos = arm->hw_interface.z_joint.get_position(arm->hw_interface.z_joint.args);
+    arm->shoulder_pos = arm->hw_interface.shoulder_joint.get_position(arm->hw_interface.shoulder_joint.args);
+    arm->elbow_pos = arm->hw_interface.elbow_joint.get_position(arm->hw_interface.elbow_joint.args);
 }
 
 bool scara_compute_joint_angles(scara_t* arm, scara_waypoint_t frame, float* alpha, float* beta)
@@ -185,14 +185,14 @@ void scara_manage(scara_t *arm)
               measured_x, measured_y, velocity_alpha, velocity_beta);
 
         /* Set motor commands */
-        arm->z_joint.set_position(arm->z_joint.args, frame.position[2]);
-        arm->shoulder_joint.set_velocity(arm->shoulder_joint.args, velocity_alpha);
-        arm->elbow_joint.set_velocity(arm->elbow_joint.args, velocity_beta);
+        arm->hw_interface.z_joint.set_position(arm->hw_interface.z_joint.args, frame.position[2]);
+        arm->hw_interface.shoulder_joint.set_velocity(arm->hw_interface.shoulder_joint.args, velocity_alpha);
+        arm->hw_interface.elbow_joint.set_velocity(arm->hw_interface.elbow_joint.args, velocity_beta);
     } else {
         /* Set motor positions */
-        arm->z_joint.set_position(arm->z_joint.args, frame.position[2]);
-        arm->shoulder_joint.set_position(arm->shoulder_joint.args, alpha);
-        arm->elbow_joint.set_position(arm->elbow_joint.args, beta);
+        arm->hw_interface.z_joint.set_position(arm->hw_interface.z_joint.args, frame.position[2]);
+        arm->hw_interface.shoulder_joint.set_position(arm->hw_interface.shoulder_joint.args, alpha);
+        arm->hw_interface.elbow_joint.set_position(arm->hw_interface.elbow_joint.args, beta);
     }
 
     scara_unlock(&arm->lock);
@@ -254,6 +254,6 @@ void scara_shutdown(scara_t *arm)
 
 void scara_shutdown_joints(scara_t* arm)
 {
-    arm->shoulder_joint.set_velocity(arm->shoulder_joint.args, 0);
-    arm->elbow_joint.set_velocity(arm->elbow_joint.args, 0);
+    arm->hw_interface.shoulder_joint.set_velocity(arm->hw_interface.shoulder_joint.args, 0);
+    arm->hw_interface.elbow_joint.set_velocity(arm->hw_interface.elbow_joint.args, 0);
 }

--- a/master-firmware/src/scara/scara.h
+++ b/master-firmware/src/scara/scara.h
@@ -11,7 +11,7 @@
 
 #include <pid/pid.h>
 
-#include "joint.h"
+#include "scara_hardware_interface.h"
 #include "scara_kinematics.h"
 #include "scara_waypoint.h"
 
@@ -21,15 +21,13 @@ typedef enum {
     CONTROL_JAM_PID_XYA,      /**< Control using jacobian and PIDs on x,y,a, smooth cartesian trajectories. */
 } scara_control_mode_t;
 
+
 /** Scara arm datastruct */
 typedef struct {
     vect2_cart offset_xy; /**< Offset vector between center of robot and shoulder. */
     float offset_rotation; /**< Rotation between the robot base and shoulder in rad. */
 
-    /* Motor joints */
-    joint_t z_joint;
-    joint_t shoulder_joint;
-    joint_t elbow_joint;
+    scara_hardware_interface_t hw_interface;
 
     /* Motor positions */
     float z_pos;

--- a/master-firmware/src/scara/scara.h
+++ b/master-firmware/src/scara/scara.h
@@ -29,10 +29,7 @@ typedef struct {
 
     scara_hardware_interface_t hw_interface;
 
-    /* Motor positions */
-    float z_pos;
-    float shoulder_pos;
-    float elbow_pos;
+    scara_joint_positions_t joint_positions;
 
     /* Control system */
     pid_ctrl_t x_pid;

--- a/master-firmware/src/scara/scara.h
+++ b/master-firmware/src/scara/scara.h
@@ -27,9 +27,8 @@ typedef struct {
     vect2_cart offset_xy; /**< Offset vector between center of robot and shoulder. */
     float offset_rotation; /**< Rotation between the robot base and shoulder in rad. */
 
-    scara_hardware_interface_t hw_interface;
-
-    scara_joint_positions_t joint_positions;
+    scara_hardware_interface_t hw_interface; /**< Hardware interface handling joint IO */
+    scara_joint_positions_t joint_positions; /**< Cached joint positions */
 
     /* Control system */
     pid_ctrl_t x_pid;

--- a/master-firmware/src/scara/scara_hardware_interface.c
+++ b/master-firmware/src/scara/scara_hardware_interface.c
@@ -6,3 +6,14 @@ void scara_hw_shutdown_joints(scara_hardware_interface_t* hw_interface)
     hw_interface->shoulder_joint.set_velocity(hw_interface->shoulder_joint.args, 0);
     hw_interface->elbow_joint.set_velocity(hw_interface->elbow_joint.args, 0);
 }
+
+scara_joint_positions_t scara_hw_read_joint_positions(scara_hardware_interface_t* hw_interface)
+{
+    scara_joint_positions_t joint_positions;
+
+    joint_positions.z = hw_interface->z_joint.get_position(hw_interface->z_joint.args);
+    joint_positions.shoulder = hw_interface->shoulder_joint.get_position(hw_interface->shoulder_joint.args);
+    joint_positions.elbow = hw_interface->elbow_joint.get_position(hw_interface->elbow_joint.args);
+
+    return joint_positions;
+}

--- a/master-firmware/src/scara/scara_hardware_interface.c
+++ b/master-firmware/src/scara/scara_hardware_interface.c
@@ -1,0 +1,8 @@
+#include "scara_hardware_interface.h"
+
+void scara_hw_shutdown_joints(scara_hardware_interface_t* hw_interface)
+{
+    hw_interface->z_joint.set_velocity(hw_interface->z_joint.args, 0);
+    hw_interface->shoulder_joint.set_velocity(hw_interface->shoulder_joint.args, 0);
+    hw_interface->elbow_joint.set_velocity(hw_interface->elbow_joint.args, 0);
+}

--- a/master-firmware/src/scara/scara_hardware_interface.c
+++ b/master-firmware/src/scara/scara_hardware_interface.c
@@ -17,3 +17,10 @@ scara_joint_positions_t scara_hw_read_joint_positions(scara_hardware_interface_t
 
     return joint_positions;
 }
+
+void scara_hw_set_joints(scara_hardware_interface_t* hw_interface, scara_joint_setpoints_t setpoints)
+{
+    joint_set(&hw_interface->z_joint, setpoints.z);
+    joint_set(&hw_interface->shoulder_joint, setpoints.shoulder);
+    joint_set(&hw_interface->elbow_joint, setpoints.elbow);
+}

--- a/master-firmware/src/scara/scara_hardware_interface.h
+++ b/master-firmware/src/scara/scara_hardware_interface.h
@@ -9,6 +9,14 @@ typedef struct {
     joint_t elbow_joint;
 } scara_hardware_interface_t;
 
+typedef struct {
+    float z;
+    float shoulder;
+    float elbow;
+} scara_joint_positions_t;
+
 void scara_hw_shutdown_joints(scara_hardware_interface_t* hw_interface);
+
+scara_joint_positions_t scara_hw_read_joint_positions(scara_hardware_interface_t* hw_interface);
 
 #endif

--- a/master-firmware/src/scara/scara_hardware_interface.h
+++ b/master-firmware/src/scara/scara_hardware_interface.h
@@ -15,8 +15,16 @@ typedef struct {
     float elbow;
 } scara_joint_positions_t;
 
+typedef struct {
+     joint_setpoint_t z;
+     joint_setpoint_t shoulder;
+     joint_setpoint_t elbow;
+} scara_joint_setpoints_t;
+
 void scara_hw_shutdown_joints(scara_hardware_interface_t* hw_interface);
 
 scara_joint_positions_t scara_hw_read_joint_positions(scara_hardware_interface_t* hw_interface);
+
+void scara_hw_set_joints(scara_hardware_interface_t* hw_interface, scara_joint_setpoints_t setpoints);
 
 #endif

--- a/master-firmware/src/scara/scara_hardware_interface.h
+++ b/master-firmware/src/scara/scara_hardware_interface.h
@@ -9,4 +9,6 @@ typedef struct {
     joint_t elbow_joint;
 } scara_hardware_interface_t;
 
+void scara_hw_shutdown_joints(scara_hardware_interface_t* hw_interface);
+
 #endif

--- a/master-firmware/src/scara/scara_hardware_interface.h
+++ b/master-firmware/src/scara/scara_hardware_interface.h
@@ -1,0 +1,12 @@
+#ifndef SCARA_HARDWARE_INTERFACE_H
+#define SCARA_HARDWARE_INTERFACE_H
+
+#include "joint.h"
+
+typedef struct {
+    joint_t z_joint;
+    joint_t shoulder_joint;
+    joint_t elbow_joint;
+} scara_hardware_interface_t;
+
+#endif

--- a/master-firmware/src/strategy.cpp
+++ b/master-firmware/src/strategy.cpp
@@ -208,7 +208,7 @@ struct IndexArms : public goap::Action<DebraState> {
 
         /* Z axis indexing */
         cvra_arm_motor_t* z_motors[] = {
-            (cvra_arm_motor_t *)main_arm.z_joint.args,
+            (cvra_arm_motor_t *)main_arm.hw_interface.z_joint.args,
         };
         float z_speeds[] = {-20};
         arms_auto_index(z_motors, z_speeds, sizeof(z_speeds) / sizeof(float));
@@ -217,8 +217,8 @@ struct IndexArms : public goap::Action<DebraState> {
 
         /* Arm indexing */
         cvra_arm_motor_t* motors[] = {
-            (cvra_arm_motor_t *)main_arm.shoulder_joint.args,
-            (cvra_arm_motor_t *)main_arm.elbow_joint.args,
+            (cvra_arm_motor_t *)main_arm.hw_interface.shoulder_joint.args,
+            (cvra_arm_motor_t *)main_arm.hw_interface.elbow_joint.args,
         };
         float motor_speeds[] = {0.8, 0.8};
         arms_auto_index(motors, motor_speeds, sizeof(motor_speeds) / sizeof(float));

--- a/master-firmware/tests/scara.cpp
+++ b/master-firmware/tests/scara.cpp
@@ -48,9 +48,9 @@ TEST_BASE(ArmTestGroupBase)
         shoulder_angle = 0;
         elbow_angle = 0;
 
-        joint_set_callbacks(&(arm.z_joint), set_motor_pos, set_motor_vel, get_motor_pos, &z_pos);
-        joint_set_callbacks(&(arm.shoulder_joint), set_motor_pos, set_motor_vel, get_motor_pos, &shoulder_angle);
-        joint_set_callbacks(&(arm.elbow_joint), set_motor_pos, set_motor_vel, get_motor_pos, &elbow_angle);
+        joint_set_callbacks(&(arm.hw_interface.z_joint), set_motor_pos, set_motor_vel, get_motor_pos, &z_pos);
+        joint_set_callbacks(&(arm.hw_interface.shoulder_joint), set_motor_pos, set_motor_vel, get_motor_pos, &shoulder_angle);
+        joint_set_callbacks(&(arm.hw_interface.elbow_joint), set_motor_pos, set_motor_vel, get_motor_pos, &elbow_angle);
     }
 
     void teardown()

--- a/master-firmware/tests/scara_hardware_interface.cpp
+++ b/master-firmware/tests/scara_hardware_interface.cpp
@@ -1,0 +1,70 @@
+#include "CppUTest/TestHarness.h"
+
+extern "C" {
+#include "scara/scara_hardware_interface.h"
+}
+
+namespace {
+    void set_motor_pos(void *m, float value)
+    {
+        *(float *)m = value;
+    }
+
+    void set_motor_vel(void *m, float value)
+    {
+        *(float *)m = value;
+    }
+
+    float get_motor_pos(void *m)
+    {
+        return *(float *)m;
+    }
+}
+
+TEST_GROUP(AScaraHWInterface)
+{
+    scara_hardware_interface_t hw_interface;
+    float z_pos {0};
+    float shoulder_angle {0};
+    float elbow_angle {0};
+
+    void setup()
+    {
+        joint_set_callbacks(&(hw_interface.z_joint), set_motor_pos, set_motor_vel, get_motor_pos, &z_pos);
+        joint_set_callbacks(&(hw_interface.shoulder_joint), set_motor_pos, set_motor_vel, get_motor_pos, &shoulder_angle);
+        joint_set_callbacks(&(hw_interface.elbow_joint), set_motor_pos, set_motor_vel, get_motor_pos, &elbow_angle);
+    }
+
+    void teardown()
+    {
+    }
+
+    void set_non_trivial_joint_states()
+    {
+        shoulder_angle = 2;
+        elbow_angle = 3;
+        z_pos = 42;
+    }
+};
+
+TEST(AScaraHWInterface, ReadsJointPositions)
+{
+    set_non_trivial_joint_states();
+
+    const auto joint_positions = scara_hw_read_joint_positions(&hw_interface);
+
+    CHECK_EQUAL(shoulder_angle, joint_positions.shoulder);
+    CHECK_EQUAL(elbow_angle, joint_positions.elbow);
+    CHECK_EQUAL(z_pos, joint_positions.z);
+}
+
+TEST(AScaraHWInterface, StopsJointsWhenAskedToShutdown)
+{
+    set_non_trivial_joint_states();
+
+    scara_hw_shutdown_joints(&hw_interface);
+
+    CHECK_EQUAL(0, shoulder_angle);
+    CHECK_EQUAL(0, elbow_angle);
+    CHECK_EQUAL(0, z_pos);
+}


### PR DESCRIPTION
This PR starts splitting the scara code into blocks. The 1st block we introduce is `scara_hardware_interface` that is handling joint IO (reading positions, setting positions and velocities).