### PR TITLE
Arm trajectory pause/continue

### DIFF
--- a/master-firmware/src/commands.c
+++ b/master-firmware/src/commands.c
@@ -1056,6 +1056,30 @@ static void cmd_scara_traj(BaseSequentialStream *chp, int argc, char *argv[])
     }
 }
 
+static void cmd_scara_pause(BaseSequentialStream *chp, int argc, char *argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    scara_t* arm = &main_arm;
+
+    scara_pause(arm);
+
+    chprintf(chp, "Arm paused trajectory\r\n");
+}
+
+static void cmd_scara_continue(BaseSequentialStream *chp, int argc, char *argv[])
+{
+    (void)argc;
+    (void)argv;
+
+    scara_t* arm = &main_arm;
+
+    scara_continue(arm);
+
+    chprintf(chp, "Arm restoring from pause\r\n");
+}
+
 static void cmd_base_mode(BaseSequentialStream *chp, int argc, char *argv[])
 {
     if (argc != 1) {
@@ -1152,6 +1176,8 @@ const ShellCommand commands[] = {
     {"scara_z", cmd_scara_z},
     {"scara_pos", cmd_scara_pos},
     {"scara_traj", cmd_scara_traj},
+    {"scara_pause", cmd_scara_pause},
+    {"scara_continue", cmd_scara_continue},
     {"base_mode", cmd_base_mode},
     {"state", cmd_state},
     {"trace", cmd_trace},

--- a/master-firmware/src/scara/scara.c
+++ b/master-firmware/src/scara/scara.c
@@ -25,6 +25,8 @@ void scara_init(scara_t *arm)
     arm->shoulder_mode = SHOULDER_BACK;
     arm->control_mode = CONTROL_JOINT_POSITION;
 
+    arm->time_offset = 0;
+
     /* Configure arm controllers */
     pid_init(&arm->x_pid);
     pid_init(&arm->y_pid);
@@ -133,7 +135,7 @@ bool scara_compute_joint_angles(scara_t* arm, scara_waypoint_t frame, float* alp
 
 void scara_manage(scara_t *arm)
 {
-    int32_t current_date = scara_time_get();
+    int32_t current_date = scara_time_get() + arm->time_offset;
 
     scara_lock(&arm->lock);
 
@@ -266,6 +268,20 @@ void scara_pause(scara_t* arm)
             &arm->trajectory, current_pos.position[0], current_pos.position[1],
             current_pos.position[2], current_pos.coordinate_type,
             current_pos.date / 1e6, &current_pos.length[0]);
+    }
+
+    scara_unlock(&arm->lock);
+}
+
+void scara_continue(scara_t* arm)
+{
+    scara_lock(&arm->lock);
+
+    if (scara_is_paused(arm)) {
+        arm->time_offset = arm->time_offset - scara_time_get();
+
+        scara_trajectory_copy(&arm->trajectory, &arm->previous_trajectory);
+        scara_trajectory_delete(&arm->previous_trajectory);
     }
 
     scara_unlock(&arm->lock);

--- a/master-firmware/src/scara/scara.c
+++ b/master-firmware/src/scara/scara.c
@@ -245,3 +245,21 @@ void scara_shutdown(scara_t *arm)
 {
     scara_trajectory_delete(&arm->trajectory);
 }
+
+void scara_pause(scara_t* arm)
+{
+    scara_lock(&arm->lock);
+
+    arm->time_offset = scara_time_get();
+
+    scara_trajectory_copy(&arm->previous_trajectory, &arm->trajectory);
+
+    scara_waypoint_t current_pos = scara_position_for_date(arm, arm->time_offset);
+    scara_trajectory_delete(&arm->trajectory);
+    scara_trajectory_append_point(
+        &arm->trajectory, current_pos.position[0], current_pos.position[1],
+        current_pos.position[2], current_pos.coordinate_type,
+        current_pos.date / 1e6, &current_pos.length[0]);
+
+    scara_unlock(&arm->lock);
+}

--- a/master-firmware/src/scara/scara.h
+++ b/master-firmware/src/scara/scara.h
@@ -90,5 +90,6 @@ void scara_set_related_robot_pos(scara_t *arm, struct robot_position *pos);
 void scara_shutdown(scara_t *arm);
 
 void scara_pause(scara_t* arm);
+void scara_continue(scara_t* arm);
 
 #endif

--- a/master-firmware/src/scara/scara.h
+++ b/master-firmware/src/scara/scara.h
@@ -44,6 +44,10 @@ typedef struct {
     shoulder_mode_t shoulder_mode;
     scara_control_mode_t control_mode;
 
+    /* Cached state for pause/continue */
+    int32_t time_offset; /**< in us */
+    scara_trajectory_t previous_trajectory; /**< Paused trajectory */
+
     mutex_t lock;
 } scara_t;
 
@@ -84,5 +88,7 @@ scara_waypoint_t scara_position_for_date(scara_t *arm, int32_t date);
 void scara_set_related_robot_pos(scara_t *arm, struct robot_position *pos);
 
 void scara_shutdown(scara_t *arm);
+
+void scara_pause(scara_t* arm);
 
 #endif

--- a/master-firmware/src/scara/scara_trajectories.c
+++ b/master-firmware/src/scara/scara_trajectories.c
@@ -87,7 +87,7 @@ bool scara_trajectory_is_empty(scara_trajectory_t* trajectory)
 scara_waypoint_t scara_trajectory_interpolate_waypoints(scara_waypoint_t k1, scara_waypoint_t k2, int32_t date)
 {
     float t;
-    scara_waypoint_t result;
+    scara_waypoint_t result = k2;
     int i;
 
     result.date = date;

--- a/master-firmware/tests/scara.cpp
+++ b/master-firmware/tests/scara.cpp
@@ -335,6 +335,17 @@ TEST(AScaraArmPause, PauseIsThreadSafe)
     scara_pause(&arm);
 }
 
+TEST(AScaraArmPause, PausingMultipleTimesDoesNotOverwriteCachedTrajectory)
+{
+    doTrajectory();
+
+    scara_pause(&arm);
+    scara_pause(&arm);
+    scara_pause(&arm);
+
+    checkTrajectoryEqual(traj, arm.previous_trajectory);
+}
+
 
 TEST_GROUP(AScaraJacobian)
 {

--- a/master-firmware/tests/scara.cpp
+++ b/master-firmware/tests/scara.cpp
@@ -262,6 +262,79 @@ TEST(AScaraArm, InterpolatesLengthsWhenTheyChangeBetweenWaypoints)
 }
 
 
+TEST_GROUP_BASE(AScaraArmPause, ArmTestGroupBase)
+{
+    void doTrajectory()
+    {
+        scara_trajectory_append_point(&traj, 1, 2, 3, COORDINATE_ARM, 0., arbitraryLengths);
+        scara_trajectory_append_point(&traj, 2, 4, 6, COORDINATE_ARM, 1., arbitraryLengths);
+        scara_trajectory_append_point(&traj, 4, 8, 12, COORDINATE_ARM, 1., arbitraryLengths);
+        scara_do_trajectory(&arm, &traj);
+
+        scara_time_set(1e6); // reached 2nd waypoint
+        scara_manage(&arm);
+    }
+
+    void checkFrameEqual(scara_waypoint_t a, scara_waypoint_t b)
+    {
+        CHECK_EQUAL(a.position[0], b.position[0]);
+        CHECK_EQUAL(a.position[1], b.position[1]);
+        CHECK_EQUAL(a.position[2], b.position[2]);
+        CHECK_EQUAL(a.date, b.date);
+        CHECK_EQUAL(a.coordinate_type, b.coordinate_type);
+        CHECK_EQUAL(a.length[0], b.length[0]);
+        CHECK_EQUAL(a.length[1], b.length[1]);
+    }
+
+    void checkTrajectoryEqual(scara_trajectory_t a, scara_trajectory_t b)
+    {
+        CHECK_EQUAL(a.frame_count, b.frame_count);
+
+        for (int i = 0; i < a.frame_count; i++) {
+            checkFrameEqual(a.frames[i], b.frames[i]);
+        }
+    }
+};
+
+TEST(AScaraArmPause, PauseCachesTime)
+{
+    doTrajectory();
+
+    scara_pause(&arm);
+
+    CHECK_EQUAL(1 * 1e6, arm.time_offset);
+}
+
+TEST(AScaraArmPause, PauseHoldsCurrentPosition)
+{
+    doTrajectory();
+
+    scara_pause(&arm);
+
+    CHECK_EQUAL(1, arm.trajectory.frame_count);
+    checkFrameEqual(traj.frames[1], arm.trajectory.frames[0]);
+}
+
+TEST(AScaraArmPause, PauseCachesPausedTrajectory)
+{
+    doTrajectory();
+
+    scara_pause(&arm);
+
+    checkTrajectoryEqual(traj, arm.previous_trajectory);
+}
+
+TEST(AScaraArmPause, PauseIsThreadSafe)
+{
+    doTrajectory();
+
+    lock_mocks_enable(true);
+    mock().expectOneCall("chMtxLock").withPointerParameter("lock", &arm.lock);
+    mock().expectOneCall("chMtxUnlock").withPointerParameter("lock", &arm.lock);
+
+    scara_pause(&arm);
+}
+
 
 TEST_GROUP(AScaraJacobian)
 {

--- a/master-firmware/tests/scara_trajectories.cpp
+++ b/master-firmware/tests/scara_trajectories.cpp
@@ -110,11 +110,16 @@ TEST(AnArmTrajectory, InterpolatesWaypoints)
     scara_trajectory_append_point(&traj, 10, 20, 30, COORDINATE_ARM, 10., arbitraryLengths);
 
     result = scara_trajectory_interpolate_waypoints(traj.frames[0], traj.frames[1], interpolation_date);
+
     CHECK_EQUAL(interpolation_date, result.date);
+    CHECK_EQUAL(COORDINATE_ARM, result.coordinate_type);
 
     DOUBLES_EQUAL(5., result.position[0], 0.1);
     DOUBLES_EQUAL(10., result.position[1], 0.1);
     DOUBLES_EQUAL(15., result.position[2], 0.1);
+
+    CHECK_TRUE(result.length[0] > 0.0);
+    CHECK_TRUE(result.length[1] > 0.0);
 }
 
 TEST(AnArmTrajectory, IsEmptyOnCreation)


### PR DESCRIPTION
This PR introduces the ability to pause a trajectory during execution and restore it.
This should ease the process of tuning and debugging arm trajectories.
Higher level pause/continue can also be implemented using this.

Implemented in pair programming session with @nuft.