### PR TITLE
Arm refactoring #6: Controllers

### DIFF
--- a/master-firmware/package.yml
+++ b/master-firmware/package.yml
@@ -87,6 +87,7 @@ source:
     - src/scara/scara.c
     - src/scara/scara_jacobian.cpp
     - src/scara/control/scara_joint_controller.c
+    - src/scara/control/scara_inverse_kinematics_controller.c
     - src/hand/hand.c
 
 include_directories:

--- a/master-firmware/package.yml
+++ b/master-firmware/package.yml
@@ -120,6 +120,7 @@ tests:
     - tests/scara_kinematics_integration.cpp
     - tests/scara_hardware_interface.cpp
     - tests/scara_joint_controller.cpp
+    - tests/scara_inverse_kinematics_controller.cpp
     - tests/scara.cpp
     - tests/test_hand.cpp
     - tests/lie_groups.cpp

--- a/master-firmware/package.yml
+++ b/master-firmware/package.yml
@@ -86,6 +86,7 @@ source:
     - src/scara/scara_kinematics.c
     - src/scara/scara.c
     - src/scara/scara_jacobian.cpp
+    - src/scara/control/scara_joint_controller.c
     - src/hand/hand.c
 
 include_directories:
@@ -117,6 +118,7 @@ tests:
     - tests/scara_kinematics.cpp
     - tests/scara_kinematics_integration.cpp
     - tests/scara_hardware_interface.cpp
+    - tests/scara_joint_controller.cpp
     - tests/scara.cpp
     - tests/test_hand.cpp
     - tests/lie_groups.cpp

--- a/master-firmware/src/arms/arms_controller.c
+++ b/master-firmware/src/arms/arms_controller.c
@@ -70,15 +70,15 @@ static void arms_update_controller_gains(parameter_namespace_t* ns, scara_t* arm
     ki = parameter_scalar_get(parameter_find(ns, "x/ki"));
     kd = parameter_scalar_get(parameter_find(ns, "x/kd"));
     ilim = parameter_scalar_get(parameter_find(ns, "x/ilimit"));
-    pid_set_gains(&arm->x_pid, kp, ki, kd);
-    pid_set_integral_limit(&arm->x_pid, ilim);
+    pid_set_gains(&arm->ik_controller.x_pid, kp, ki, kd);
+    pid_set_integral_limit(&arm->ik_controller.x_pid, ilim);
 
     kp = parameter_scalar_get(parameter_find(ns, "y/kp"));
     ki = parameter_scalar_get(parameter_find(ns, "y/ki"));
     kd = parameter_scalar_get(parameter_find(ns, "y/kd"));
     ilim = parameter_scalar_get(parameter_find(ns, "y/ilimit"));
-    pid_set_gains(&arm->y_pid, kp, ki, kd);
-    pid_set_integral_limit(&arm->y_pid, ilim);
+    pid_set_gains(&arm->ik_controller.y_pid, kp, ki, kd);
+    pid_set_integral_limit(&arm->ik_controller.y_pid, ilim);
 }
 
 static THD_FUNCTION(arms_ctrl_thd, arg)

--- a/master-firmware/src/commands.c
+++ b/master-firmware/src/commands.c
@@ -929,20 +929,19 @@ static void cmd_scara_mv(BaseSequentialStream *chp, int argc, char *argv[])
         return;
     }
     scara_t* arm = &main_arm;
-    float x, y, z;
 
     scara_trajectory_t trajectory;
 
-    scara_pos(arm, &x, &y, &z, COORDINATE_TABLE);
+    position_3d_t pos = scara_position(arm, COORDINATE_TABLE);
     scara_trajectory_init(&trajectory);
-    scara_trajectory_append_point(&trajectory, x, y, z, COORDINATE_TABLE, 0, arm->length);
+    scara_trajectory_append_point(&trajectory, pos.x, pos.y, pos.z, COORDINATE_TABLE, 0, arm->length);
 
-    x = atof(argv[0]);
-    y = atof(argv[1]);
-    scara_trajectory_append_point(&trajectory, x, y, z, COORDINATE_TABLE, 1, arm->length);
+    pos.x = atof(argv[0]);
+    pos.y = atof(argv[1]);
+    scara_trajectory_append_point(&trajectory, pos.x, pos.y, pos.z, COORDINATE_TABLE, 1, arm->length);
     scara_do_trajectory(arm, &trajectory);
 
-    chprintf(chp, "Moving %s arm to %f %f %f in table frame\r\n", argv[0], x, y, z);
+    chprintf(chp, "Moving %s arm to %f %f %f in table frame\r\n", argv[0], pos.x, pos.y, pos.z);
 }
 
 static void cmd_scara_z(BaseSequentialStream *chp, int argc, char *argv[])
@@ -968,16 +967,17 @@ static void cmd_scara_pos(BaseSequentialStream *chp, int argc, char *argv[])
 
     scara_t* arm = &main_arm;
 
-    float x, y, z;
+    position_3d_t pos;
     if (strcmp("robot", argv[0]) == 0) {
-        scara_pos(arm, &x, &y, &z, COORDINATE_ROBOT);
+        pos = scara_position(arm, COORDINATE_ROBOT);
     } else if (strcmp("table", argv[0]) == 0) {
-        scara_pos(arm, &x, &y, &z, COORDINATE_TABLE);
+        pos = scara_position(arm, COORDINATE_TABLE);
     } else {
-        scara_pos(arm, &x, &y, &z, COORDINATE_ARM);
+        pos = scara_position(arm, COORDINATE_ARM);
     }
 
-    chprintf(chp, "Position of %s arm is %f %f %f in %s frame\r\n", argv[1], x, y, z, argv[0]);
+    chprintf(chp, "Position of %s arm is %f %f %f in %s frame\r\n", argv[1],
+             pos.x, pos.y, pos.z, argv[0]);
 }
 
 
@@ -1103,15 +1103,14 @@ static void cmd_state(BaseSequentialStream *chp, int argc, char *argv[])
     (void)argc;
     (void)argv;
 
-    float x, y, z;
-
     chprintf(chp, "Current robot state:\r\n");
 
     chprintf(chp, "Position of robot is %d %d %d\r\n",
              position_get_x_s16(&robot.pos), position_get_y_s16(&robot.pos), position_get_a_deg_s16(&robot.pos));
 
-    scara_pos(&main_arm, &x, &y, &z, COORDINATE_TABLE);
-    chprintf(chp, "Position of main arm is %.1f %.1f %.1f in table frame\r\n", x, y, z);
+    position_3d_t pos = scara_position(&main_arm, COORDINATE_TABLE);
+    chprintf(chp, "Position of main arm is %.1f %.1f %.1f in table frame\r\n",
+             pos.x, pos.y, pos.z);
 }
 
 

--- a/master-firmware/src/commands.c
+++ b/master-firmware/src/commands.c
@@ -887,20 +887,18 @@ static void cmd_scara_goto(BaseSequentialStream *chp, int argc, char *argv[])
         chprintf(chp, "Usage: scara_goto frame x y z\r\n");
         return;
     }
-    float x = atof(argv[1]);
-    float y = atof(argv[2]);
-    float z = atof(argv[3]);
+    position_3d_t pos = {.x = atof(argv[1]), .y = atof(argv[2]), .z = atof(argv[3])};
 
-    chprintf(chp, "Moving arm to %f %f %f heading 0 in %s frame\r\n", x, y, z, argv[0]);
+    chprintf(chp, "Moving arm to %f %f %f heading 0 in %s frame\r\n", pos.x, pos.y, pos.z, argv[0]);
 
     scara_t* arm = &main_arm;
 
     if (strcmp("robot", argv[0]) == 0) {
-        scara_goto(arm, x, y, z, COORDINATE_ROBOT, 1.);
+        scara_goto(arm, pos, COORDINATE_ROBOT, 1.);
     } else if (strcmp("table", argv[0]) == 0) {
-        scara_goto(arm, x, y, z, COORDINATE_TABLE, 1.);
+        scara_goto(arm, pos, COORDINATE_TABLE, 1.);
     } else {
-        scara_goto(arm, x, y, z, COORDINATE_ARM, 1.);
+        scara_goto(arm, pos, COORDINATE_ARM, 1.);
     }
 }
 
@@ -934,11 +932,11 @@ static void cmd_scara_mv(BaseSequentialStream *chp, int argc, char *argv[])
 
     position_3d_t pos = scara_position(arm, COORDINATE_TABLE);
     scara_trajectory_init(&trajectory);
-    scara_trajectory_append_point(&trajectory, pos.x, pos.y, pos.z, COORDINATE_TABLE, 0, arm->length);
+    scara_trajectory_append_point(&trajectory, pos, COORDINATE_TABLE, 0, arm->length);
 
     pos.x = atof(argv[0]);
     pos.y = atof(argv[1]);
-    scara_trajectory_append_point(&trajectory, pos.x, pos.y, pos.z, COORDINATE_TABLE, 1, arm->length);
+    scara_trajectory_append_point(&trajectory, pos, COORDINATE_TABLE, 1, arm->length);
     scara_do_trajectory(arm, &trajectory);
 
     chprintf(chp, "Moving %s arm to %f %f %f in table frame\r\n", argv[0], pos.x, pos.y, pos.z);
@@ -1044,7 +1042,8 @@ static void cmd_scara_traj(BaseSequentialStream *chp, int argc, char *argv[])
             }
 
             if (j == point_len) {
-                scara_trajectory_append_point(&trajectory, point[0], point[1], point[2],
+                position_3d_t position = {.x = point[0], .y = point[1], .z = point[2]};
+                scara_trajectory_append_point(&trajectory, position,
                         system, (float)point[3] * 0.001, arm->length);
                 i++;
 

--- a/master-firmware/src/robot_helpers/strategy_helpers.c
+++ b/master-firmware/src/robot_helpers/strategy_helpers.c
@@ -91,7 +91,7 @@ unsigned strategy_set_arm_trajectory(scara_t* arm, arm_waypoint_t* trajectory, u
     for (size_t i = 0; i < trajectory_length; i++) {
         scara_trajectory_append_point(
             &arm->trajectory,
-            trajectory[i].x, trajectory[i].y, trajectory[i].z,
+            trajectory[i].pos,
             trajectory[i].coord,
             (float)trajectory[i].dt * 0.001,
             arm->length);

--- a/master-firmware/src/robot_helpers/strategy_helpers.h
+++ b/master-firmware/src/robot_helpers/strategy_helpers.h
@@ -19,9 +19,7 @@ enum strat_color_t {
 };
 
 typedef struct {
-    float x; // Desired position x of end effector in mm without mirroring
-    float y; // Desired position y of end effector in mm without mirroring
-    float z; // Desired position z of end effector in mm without mirroring
+    position_3d_t pos; // Desired position of end effector in mm without mirroring
     scara_coordinate_t coord; // Coordinate system
     unsigned dt; // Duration in ms to reach this waypoint
 } arm_waypoint_t;

--- a/master-firmware/src/scara/control/scara_inverse_kinematics_controller.c
+++ b/master-firmware/src/scara/control/scara_inverse_kinematics_controller.c
@@ -1,6 +1,7 @@
 #include "scara_inverse_kinematics_controller.h"
 
 #include <scara/scara_jacobian.h>
+#include <scara/scara_kinematics.h>
 
 #include <string.h>
 
@@ -21,22 +22,25 @@ void scara_ik_controller_set_geometry(scara_ik_controller_t *controller,
 
 scara_joint_setpoints_t
 scara_ik_controller_process(scara_ik_controller_t *controller,
-                            position_3d_t measured, position_3d_t desired,
-                            scara_joint_positions_t joint_positions)
+                            position_3d_t desired,
+                            scara_joint_positions_t measured)
 {
-    float consign_x = pid_process(&controller->x_pid, measured.x - desired.x);
-    float consign_y = pid_process(&controller->y_pid, measured.y - desired.y);
+  point_t pos = scara_forward_kinematics(measured.shoulder, measured.elbow,
+                                         controller->length);
 
-    float velocity_alpha, velocity_beta;
-    scara_jacobian_compute(consign_x, consign_y, joint_positions.shoulder,
-                           joint_positions.elbow, controller->length[0],
-                           controller->length[1], &velocity_alpha,
-                           &velocity_beta);
+  float consign_x = pid_process(&controller->x_pid, pos.x - desired.x);
+  float consign_y = pid_process(&controller->y_pid, pos.y - desired.y);
 
-    scara_joint_setpoints_t joint_setpoints = {
-        .z = {POSITION, desired.z},
-        .shoulder = {VELOCITY, velocity_alpha},
-        .elbow = {VELOCITY, velocity_beta}};
+  float velocity_alpha, velocity_beta;
+  scara_jacobian_compute(consign_x, consign_y, measured.shoulder,
+                         measured.elbow, controller->length[0],
+                         controller->length[1], &velocity_alpha,
+                         &velocity_beta);
 
-    return joint_setpoints;
+  scara_joint_setpoints_t joint_setpoints = {
+      .z = {POSITION, desired.z},
+      .shoulder = {VELOCITY, velocity_alpha},
+      .elbow = {VELOCITY, velocity_beta}};
+
+  return joint_setpoints;
 }

--- a/master-firmware/src/scara/control/scara_inverse_kinematics_controller.c
+++ b/master-firmware/src/scara/control/scara_inverse_kinematics_controller.c
@@ -2,13 +2,24 @@
 
 #include <scara/scara_jacobian.h>
 
-scara_joint_setpoints_t
-scara_ik_controller_process(position_3d_t measured, position_3d_t desired,
-                            scara_joint_positions_t joint_positions,
-                            float *length, pid_ctrl_t x_pid, pid_ctrl_t y_pid)
+#include <string.h>
+
+void scara_ik_controller_init(scara_ik_controller_t* controller)
 {
-    float consign_x = pid_process(&x_pid, measured.x - desired.x);
-    float consign_y = pid_process(&y_pid, measured.y - desired.y);
+    memset(controller, 0, sizeof(scara_ik_controller_t));
+
+    pid_init(&controller->x_pid);
+    pid_init(&controller->y_pid);
+}
+
+scara_joint_setpoints_t
+scara_ik_controller_process(scara_ik_controller_t *controller,
+                            position_3d_t measured, position_3d_t desired,
+                            scara_joint_positions_t joint_positions,
+                            float *length)
+{
+    float consign_x = pid_process(&controller->x_pid, measured.x - desired.x);
+    float consign_y = pid_process(&controller->y_pid, measured.y - desired.y);
 
     float velocity_alpha, velocity_beta;
     scara_jacobian_compute(consign_x, consign_y, joint_positions.shoulder,

--- a/master-firmware/src/scara/control/scara_inverse_kinematics_controller.c
+++ b/master-firmware/src/scara/control/scara_inverse_kinematics_controller.c
@@ -12,19 +12,26 @@ void scara_ik_controller_init(scara_ik_controller_t* controller)
     pid_init(&controller->y_pid);
 }
 
+void scara_ik_controller_set_geometry(scara_ik_controller_t *controller,
+                                      float *length)
+{
+    controller->length[0] = length[0];
+    controller->length[1] = length[1];
+}
+
 scara_joint_setpoints_t
 scara_ik_controller_process(scara_ik_controller_t *controller,
                             position_3d_t measured, position_3d_t desired,
-                            scara_joint_positions_t joint_positions,
-                            float *length)
+                            scara_joint_positions_t joint_positions)
 {
     float consign_x = pid_process(&controller->x_pid, measured.x - desired.x);
     float consign_y = pid_process(&controller->y_pid, measured.y - desired.y);
 
     float velocity_alpha, velocity_beta;
     scara_jacobian_compute(consign_x, consign_y, joint_positions.shoulder,
-                           joint_positions.elbow, length[0], length[1],
-                           &velocity_alpha, &velocity_beta);
+                           joint_positions.elbow, controller->length[0],
+                           controller->length[1], &velocity_alpha,
+                           &velocity_beta);
 
     scara_joint_setpoints_t joint_setpoints = {
         .z = {POSITION, desired.z},

--- a/master-firmware/src/scara/control/scara_inverse_kinematics_controller.c
+++ b/master-firmware/src/scara/control/scara_inverse_kinematics_controller.c
@@ -1,0 +1,24 @@
+#include "scara_inverse_kinematics_controller.h"
+
+#include <scara/scara_jacobian.h>
+
+scara_joint_setpoints_t
+scara_ik_controller_process(position_3d_t measured, position_3d_t desired,
+                            scara_joint_positions_t joint_positions,
+                            float *length, pid_ctrl_t x_pid, pid_ctrl_t y_pid)
+{
+    float consign_x = pid_process(&x_pid, measured.x - desired.x);
+    float consign_y = pid_process(&y_pid, measured.y - desired.y);
+
+    float velocity_alpha, velocity_beta;
+    scara_jacobian_compute(consign_x, consign_y, joint_positions.shoulder,
+                           joint_positions.elbow, length[0], length[1],
+                           &velocity_alpha, &velocity_beta);
+
+    scara_joint_setpoints_t joint_setpoints = {
+        .z = {POSITION, desired.z},
+        .shoulder = {VELOCITY, velocity_alpha},
+        .elbow = {VELOCITY, velocity_beta}};
+
+    return joint_setpoints;
+}

--- a/master-firmware/src/scara/control/scara_inverse_kinematics_controller.h
+++ b/master-firmware/src/scara/control/scara_inverse_kinematics_controller.h
@@ -1,0 +1,13 @@
+#ifndef SCARA_CONTROL__INVERSE_KINEMATICS_CONTROLLER_H
+#define SCARA_CONTROL__INVERSE_KINEMATICS_CONTROLLER_H
+
+#include <pid/pid.h>
+#include <scara/scara_waypoint.h>
+#include <scara/scara_hardware_interface.h>
+
+scara_joint_setpoints_t
+scara_ik_controller_process(position_3d_t measured, position_3d_t desired,
+                            scara_joint_positions_t joint_positions,
+                            float *length, pid_ctrl_t x_pid, pid_ctrl_t y_pid);
+
+#endif

--- a/master-firmware/src/scara/control/scara_inverse_kinematics_controller.h
+++ b/master-firmware/src/scara/control/scara_inverse_kinematics_controller.h
@@ -5,9 +5,18 @@
 #include <scara/scara_waypoint.h>
 #include <scara/scara_hardware_interface.h>
 
+typedef struct {
+    /* Control system */
+    pid_ctrl_t x_pid;
+    pid_ctrl_t y_pid;
+} scara_ik_controller_t;
+
+void scara_ik_controller_init(scara_ik_controller_t* controller);
+
 scara_joint_setpoints_t
-scara_ik_controller_process(position_3d_t measured, position_3d_t desired,
+scara_ik_controller_process(scara_ik_controller_t *controller,
+                            position_3d_t measured, position_3d_t desired,
                             scara_joint_positions_t joint_positions,
-                            float *length, pid_ctrl_t x_pid, pid_ctrl_t y_pid);
+                            float *length);
 
 #endif

--- a/master-firmware/src/scara/control/scara_inverse_kinematics_controller.h
+++ b/master-firmware/src/scara/control/scara_inverse_kinematics_controller.h
@@ -6,17 +6,20 @@
 #include <scara/scara_hardware_interface.h>
 
 typedef struct {
-    /* Control system */
     pid_ctrl_t x_pid;
     pid_ctrl_t y_pid;
+
+    float length[2];
 } scara_ik_controller_t;
 
 void scara_ik_controller_init(scara_ik_controller_t* controller);
 
+void scara_ik_controller_set_geometry(scara_ik_controller_t *controller,
+                                      float *length);
+
 scara_joint_setpoints_t
 scara_ik_controller_process(scara_ik_controller_t *controller,
                             position_3d_t measured, position_3d_t desired,
-                            scara_joint_positions_t joint_positions,
-                            float *length);
+                            scara_joint_positions_t joint_positions);
 
 #endif

--- a/master-firmware/src/scara/control/scara_inverse_kinematics_controller.h
+++ b/master-firmware/src/scara/control/scara_inverse_kinematics_controller.h
@@ -19,7 +19,7 @@ void scara_ik_controller_set_geometry(scara_ik_controller_t *controller,
 
 scara_joint_setpoints_t
 scara_ik_controller_process(scara_ik_controller_t *controller,
-                            position_3d_t measured, position_3d_t desired,
-                            scara_joint_positions_t joint_positions);
+                            position_3d_t desired,
+                            scara_joint_positions_t measured);
 
 #endif

--- a/master-firmware/src/scara/control/scara_joint_controller.c
+++ b/master-firmware/src/scara/control/scara_joint_controller.c
@@ -1,15 +1,49 @@
 #include "scara_joint_controller.h"
 
-scara_joint_setpoints_t scara_joint_controller_process(scara_joint_positions_t desired,
-                                                       scara_joint_positions_t measured)
+#include <error/error.h>
+
+#include <string.h>
+
+void scara_joint_controller_init(scara_joint_controller_t* controller)
+{
+    memset(controller, 0, sizeof(scara_joint_controller_t));
+}
+
+void scara_joint_controller_set_geometry(scara_joint_controller_t *controller,
+                                         float *length,
+                                         shoulder_mode_t shoulder_mode)
+{
+    controller->length[0] = length[0];
+    controller->length[1] = length[1];
+    controller->shoulder_mode = shoulder_mode;
+}
+
+scara_joint_setpoints_t
+scara_joint_controller_process(scara_joint_controller_t *controller,
+                               position_3d_t desired,
+                               scara_joint_positions_t measured)
 {
     (void)measured;
 
-    scara_joint_setpoints_t setpoints = {
-        .z = {POSITION, desired.z},
-        .shoulder = {POSITION, desired.shoulder},
-        .elbow = {POSITION, desired.elbow}
-    };
+    float alpha, beta;
+    bool solution_found = scara_compute_joint_angles(
+        desired, controller->shoulder_mode, controller->length, &alpha, &beta);
 
-    return setpoints;
+    if (solution_found) {
+        DEBUG("Inverse kinematics: Found a solution");
+        scara_joint_setpoints_t setpoint = {
+            .z = {POSITION, desired.z},
+            .shoulder = {POSITION, alpha},
+            .elbow = {POSITION, beta}
+        };
+        return setpoint;
+    } else {
+        DEBUG("Inverse kinematics: Found no solution, disabling the arm");
+        scara_joint_setpoints_t null_speed_setpoint = {
+            .z = {VELOCITY, 0.0},
+            .shoulder = {VELOCITY, 0.0},
+            .elbow = {VELOCITY, 0.0}
+        };
+        return null_speed_setpoint;
+    }
 }

--- a/master-firmware/src/scara/control/scara_joint_controller.c
+++ b/master-firmware/src/scara/control/scara_joint_controller.c
@@ -1,0 +1,15 @@
+#include "scara_joint_controller.h"
+
+scara_joint_setpoints_t scara_joint_controller_process(scara_joint_positions_t desired,
+                                                       scara_joint_positions_t measured)
+{
+    (void)measured;
+
+    scara_joint_setpoints_t setpoints = {
+        .z = {POSITION, desired.z},
+        .shoulder = {POSITION, desired.shoulder},
+        .elbow = {POSITION, desired.elbow}
+    };
+
+    return setpoints;
+}

--- a/master-firmware/src/scara/control/scara_joint_controller.h
+++ b/master-firmware/src/scara/control/scara_joint_controller.h
@@ -2,9 +2,22 @@
 #define SCARA_CONTROL__JOINT_CONTROLLER_H
 
 #include "scara/scara_hardware_interface.h"
+#include "scara/scara_kinematics.h"
+
+typedef struct {
+    float length[2];
+    shoulder_mode_t shoulder_mode;
+} scara_joint_controller_t;
+
+void scara_joint_controller_init(scara_joint_controller_t* controller);
+
+void scara_joint_controller_set_geometry(scara_joint_controller_t *controller,
+                                         float *length,
+                                         shoulder_mode_t shoulder_mode);
 
 scara_joint_setpoints_t
-scara_joint_controller_process(scara_joint_positions_t desired,
+scara_joint_controller_process(scara_joint_controller_t *controller,
+                               position_3d_t desired,
                                scara_joint_positions_t measured);
 
 #endif

--- a/master-firmware/src/scara/control/scara_joint_controller.h
+++ b/master-firmware/src/scara/control/scara_joint_controller.h
@@ -1,0 +1,10 @@
+#ifndef SCARA_CONTROL__JOINT_CONTROLLER_H
+#define SCARA_CONTROL__JOINT_CONTROLLER_H
+
+#include "scara/scara_hardware_interface.h"
+
+scara_joint_setpoints_t
+scara_joint_controller_process(scara_joint_positions_t desired,
+                               scara_joint_positions_t measured);
+
+#endif

--- a/master-firmware/src/scara/scara.c
+++ b/master-firmware/src/scara/scara.c
@@ -102,7 +102,7 @@ void scara_do_trajectory(scara_t *arm, scara_trajectory_t *traj)
 
 bool scara_compute_joint_angles(scara_t* arm, scara_waypoint_t frame, float* alpha, float* beta)
 {
-    point_t target = {.x = frame.position[0], .y = frame.position[1]};
+    point_t target = {.x = frame.position.x, .y = frame.position.y};
 
     point_t p1, p2;
     int kinematics_solution_count = scara_num_possible_elbow_positions(target, arm->length[0], arm->length[1], &p1, &p2);
@@ -162,9 +162,9 @@ void scara_manage(scara_t *arm)
     if (arm->control_mode == CONTROL_JAM_PID_XYA) {
         position_3d_t measured;
         scara_pos(arm, &measured.x, &measured.y, &measured.z, COORDINATE_ARM);
-        position_3d_t desired = {.x = frame.position[0],
-                                 .y = frame.position[1],
-                                 .z = frame.position[2]};
+        position_3d_t desired = {.x = frame.position.x,
+                                 .y = frame.position.y,
+                                 .z = frame.position.z};
 
         scara_joint_setpoints_t joint_setpoints =
             scara_ik_controller_process(&arm->ik_controller, measured, desired,
@@ -176,7 +176,7 @@ void scara_manage(scara_t *arm)
               measured.x, measured.y, joint_setpoints.shoulder.value, joint_setpoints.elbow.value);
     } else {
         scara_joint_positions_t joints_desired = {
-            .z = frame.position[2], .shoulder = alpha, .elbow = beta
+            .z = frame.position.z, .shoulder = alpha, .elbow = beta
         };
         scara_joint_setpoints_t joint_setpoints =
             scara_joint_controller_process(joints_desired, arm->joint_positions);
@@ -188,7 +188,7 @@ void scara_manage(scara_t *arm)
 
 static scara_waypoint_t scara_convert_waypoint_coordinate(scara_t *arm, scara_waypoint_t key)
 {
-    point_t pos = {.x = key.position[0], .y = key.position[1]};
+    point_t pos = {.x = key.position.x, .y = key.position.y};
 
     if (key.coordinate_type == COORDINATE_TABLE) {
         point_t robot_pos;
@@ -203,8 +203,8 @@ static scara_waypoint_t scara_convert_waypoint_coordinate(scara_t *arm, scara_wa
         pos = scara_coordinate_robot2arm(pos, arm->offset_xy, arm->offset_rotation);
     }
 
-    key.position[0] = pos.x;
-    key.position[1] = pos.y;
+    key.position.x = pos.x;
+    key.position.y = pos.y;
     return key;
 }
 
@@ -256,8 +256,8 @@ void scara_pause(scara_t* arm)
         scara_waypoint_t current_pos = scara_position_for_date(arm, arm->time_offset);
         scara_trajectory_delete(&arm->trajectory);
         scara_trajectory_append_point(
-            &arm->trajectory, current_pos.position[0], current_pos.position[1],
-            current_pos.position[2], current_pos.coordinate_type,
+            &arm->trajectory, current_pos.position.x, current_pos.position.y,
+            current_pos.position.z, current_pos.coordinate_type,
             current_pos.date / 1e6, &current_pos.length[0]);
     }
 

--- a/master-firmware/src/scara/scara.c
+++ b/master-firmware/src/scara/scara.c
@@ -162,13 +162,13 @@ void scara_manage(scara_t *arm)
     if (arm->control_mode == CONTROL_JAM_PID_XYA) {
         position_3d_t measured;
         scara_pos(arm, &measured.x, &measured.y, &measured.z, COORDINATE_ARM);
-        position_3d_t desired = {.x = frame.position.x,
-                                 .y = frame.position.y,
-                                 .z = frame.position.z};
+
+        scara_ik_controller_set_geometry(&arm->ik_controller, frame.length);
 
         scara_joint_setpoints_t joint_setpoints =
-            scara_ik_controller_process(&arm->ik_controller, measured, desired,
-                                        arm->joint_positions, frame.length);
+            scara_ik_controller_process(&arm->ik_controller, measured, frame.position,
+                                        arm->joint_positions);
+
         scara_hw_set_joints(&arm->hw_interface, joint_setpoints);
 
         scara_pos(arm, &measured.x, &measured.y, &measured.z, frame.coordinate_type);

--- a/master-firmware/src/scara/scara.c
+++ b/master-firmware/src/scara/scara.c
@@ -173,17 +173,16 @@ void scara_manage(scara_t *arm)
                                arm->joint_positions.elbow, frame.length[0], frame.length[1],
                                &velocity_alpha, &velocity_beta);
 
-        scara_pos(arm, &measured_x, &measured_y, &measured_z, frame.coordinate_type);
-
-        DEBUG("Arm x %.3f y %.3f Arm velocities %.3f %.3f",
-              measured_x, measured_y, velocity_alpha, velocity_beta);
-
         scara_joint_setpoints_t joint_setpoints = {
             .z = {POSITION, frame.position[2]},
             .shoulder = {VELOCITY, velocity_alpha},
             .elbow = {VELOCITY, velocity_beta}
         };
         scara_hw_set_joints(&arm->hw_interface, joint_setpoints);
+
+        scara_pos(arm, &measured_x, &measured_y, &measured_z, frame.coordinate_type);
+        DEBUG("Arm x %.3f y %.3f Arm velocities %.3f %.3f",
+              measured_x, measured_y, joint_setpoints.shoulder.value, joint_setpoints.elbow.value);
     } else {
         scara_joint_positions_t joints_desired = {
             .z = frame.position[2], .shoulder = alpha, .elbow = beta

--- a/master-firmware/src/scara/scara.c
+++ b/master-firmware/src/scara/scara.c
@@ -6,8 +6,8 @@
 #include "scara_trajectories.h"
 #include "scara_utils.h"
 #include "scara_port.h"
-#include "scara_jacobian.h"
 #include "control/scara_joint_controller.h"
+#include "control/scara_inverse_kinematics_controller.h"
 
 static void scara_lock(mutex_t* mutex)
 {
@@ -132,30 +132,6 @@ bool scara_compute_joint_angles(scara_t* arm, scara_waypoint_t frame, float* alp
     }
 
     return true;
-}
-
-scara_joint_setpoints_t scara_ik_controller_process(position_3d_t measured,
-                                                    position_3d_t desired,
-                                                    scara_joint_positions_t joint_positions,
-                                                    float* length,
-                                                    pid_ctrl_t x_pid,
-                                                    pid_ctrl_t y_pid)
-{
-    float consign_x = pid_process(&x_pid, measured.x - desired.x);
-    float consign_y = pid_process(&y_pid, measured.y - desired.y);
-
-    float velocity_alpha, velocity_beta;
-    scara_jacobian_compute(consign_x, consign_y, joint_positions.shoulder,
-                           joint_positions.elbow, length[0], length[1],
-                           &velocity_alpha, &velocity_beta);
-
-    scara_joint_setpoints_t joint_setpoints = {
-        .z = {POSITION, desired.z},
-        .shoulder = {VELOCITY, velocity_alpha},
-        .elbow = {VELOCITY, velocity_beta}
-    };
-
-    return joint_setpoints;
 }
 
 void scara_manage(scara_t *arm)

--- a/master-firmware/src/scara/scara.c
+++ b/master-firmware/src/scara/scara.c
@@ -7,6 +7,7 @@
 #include "scara_utils.h"
 #include "scara_port.h"
 #include "scara_jacobian.h"
+#include "control/scara_joint_controller.h"
 
 static void scara_lock(mutex_t* mutex)
 {
@@ -184,11 +185,11 @@ void scara_manage(scara_t *arm)
         };
         scara_hw_set_joints(&arm->hw_interface, joint_setpoints);
     } else {
-        scara_joint_setpoints_t joint_setpoints = {
-            .z = {POSITION, frame.position[2]},
-            .shoulder = {POSITION, alpha},
-            .elbow = {POSITION, beta}
+        scara_joint_positions_t joints_desired = {
+            .z = frame.position[2], .shoulder = alpha, .elbow = beta
         };
+        scara_joint_setpoints_t joint_setpoints =
+            scara_joint_controller_process(joints_desired, arm->joint_positions);
         scara_hw_set_joints(&arm->hw_interface, joint_setpoints);
     }
 

--- a/master-firmware/src/scara/scara.c
+++ b/master-firmware/src/scara/scara.c
@@ -57,17 +57,18 @@ void scara_ugly_mode_disable(scara_t* arm)
 }
 
 
-void scara_goto(scara_t* arm, float x, float y, float z, scara_coordinate_t system, const float duration)
+void scara_goto(scara_t* arm, position_3d_t pos, scara_coordinate_t system, const float duration)
 {
     scara_trajectory_init(&(arm->trajectory));
-    scara_trajectory_append_point(&(arm->trajectory), x, y, z, system, duration, arm->length);
+    scara_trajectory_append_point(&(arm->trajectory), pos, system, duration, arm->length);
     scara_do_trajectory(arm, &(arm->trajectory));
 }
 
 void scara_move_z(scara_t* arm, float z_new, scara_coordinate_t system, const float duration)
 {
-    position_3d_t current_pos = scara_position(arm, system);
-    scara_goto(arm, current_pos.x, current_pos.y, z_new, system, duration);
+    position_3d_t pos = scara_position(arm, system);
+    pos.z = z_new;
+    scara_goto(arm, pos, system, duration);
 }
 
 position_3d_t scara_position(scara_t* arm, scara_coordinate_t system)
@@ -253,8 +254,7 @@ void scara_pause(scara_t* arm)
         scara_waypoint_t current_pos = scara_position_for_date(arm, arm->time_offset);
         scara_trajectory_delete(&arm->trajectory);
         scara_trajectory_append_point(
-            &arm->trajectory, current_pos.position.x, current_pos.position.y,
-            current_pos.position.z, current_pos.coordinate_type,
+            &arm->trajectory, current_pos.position, current_pos.coordinate_type,
             current_pos.date / 1e6, &current_pos.length[0]);
     }
 

--- a/master-firmware/src/scara/scara.c
+++ b/master-firmware/src/scara/scara.c
@@ -160,16 +160,12 @@ void scara_manage(scara_t *arm)
 
     if (arm->control_mode == CONTROL_JAM_PID_XYA) {
         scara_ik_controller_set_geometry(&arm->ik_controller, frame.length);
-
-        position_3d_t measured = scara_position(arm, COORDINATE_ARM);
-
         scara_joint_setpoints_t joint_setpoints =
-            scara_ik_controller_process(&arm->ik_controller, measured, frame.position,
+            scara_ik_controller_process(&arm->ik_controller, frame.position,
                                         arm->joint_positions);
-
         scara_hw_set_joints(&arm->hw_interface, joint_setpoints);
 
-        measured = scara_position(arm, frame.coordinate_type);
+        position_3d_t measured = scara_position(arm, frame.coordinate_type);
         DEBUG("Arm x %.3f y %.3f Arm velocities %.3f %.3f",
               measured.x, measured.y, joint_setpoints.shoulder.value, joint_setpoints.elbow.value);
     } else {

--- a/master-firmware/src/scara/scara.h
+++ b/master-firmware/src/scara/scara.h
@@ -14,6 +14,7 @@
 #include "scara_hardware_interface.h"
 #include "scara_kinematics.h"
 #include "scara_waypoint.h"
+#include "control/scara_joint_controller.h"
 #include "control/scara_inverse_kinematics_controller.h"
 
 /** Control mode of the scara arm. */
@@ -32,6 +33,7 @@ typedef struct {
     scara_joint_positions_t joint_positions; /**< Cached joint positions */
 
     /* Control system */
+    scara_joint_controller_t joint_controller;
     scara_ik_controller_t ik_controller;
 
     /* Physical parameters. */

--- a/master-firmware/src/scara/scara.h
+++ b/master-firmware/src/scara/scara.h
@@ -69,7 +69,7 @@ void scara_ugly_mode_disable(scara_t* arm);
 
 
 /* Goto position in specified coordinate system */
-void scara_goto(scara_t* arm, float x, float y, float z, scara_coordinate_t system, const float duration);
+void scara_goto(scara_t* arm, position_3d_t pos, scara_coordinate_t system, const float duration);
 
 /* Move arm in axis only */
 void scara_move_z(scara_t* arm, float z, scara_coordinate_t system, const float duration);

--- a/master-firmware/src/scara/scara.h
+++ b/master-firmware/src/scara/scara.h
@@ -75,7 +75,7 @@ void scara_goto(scara_t* arm, float x, float y, float z, scara_coordinate_t syst
 void scara_move_z(scara_t* arm, float z, scara_coordinate_t system, const float duration);
 
 /* Get current arm position */
-void scara_pos(scara_t* arm, float* x, float* y, float* z, scara_coordinate_t system);
+position_3d_t scara_position(scara_t* arm, scara_coordinate_t system);
 
 void scara_do_trajectory(scara_t *arm, scara_trajectory_t *traj);
 

--- a/master-firmware/src/scara/scara.h
+++ b/master-firmware/src/scara/scara.h
@@ -81,8 +81,6 @@ void scara_do_trajectory(scara_t *arm, scara_trajectory_t *traj);
 
 void scara_manage(scara_t *arm);
 
-bool scara_compute_joint_angles(scara_t* arm, scara_waypoint_t frame, float* alpha, float* beta);
-
 scara_waypoint_t scara_position_for_date(scara_t *arm, int32_t date);
 
 void scara_set_related_robot_pos(scara_t *arm, struct robot_position *pos);

--- a/master-firmware/src/scara/scara.h
+++ b/master-firmware/src/scara/scara.h
@@ -14,6 +14,7 @@
 #include "scara_hardware_interface.h"
 #include "scara_kinematics.h"
 #include "scara_waypoint.h"
+#include "control/scara_inverse_kinematics_controller.h"
 
 /** Control mode of the scara arm. */
 typedef enum {
@@ -31,8 +32,7 @@ typedef struct {
     scara_joint_positions_t joint_positions; /**< Cached joint positions */
 
     /* Control system */
-    pid_ctrl_t x_pid;
-    pid_ctrl_t y_pid;
+    scara_ik_controller_t ik_controller;
 
     /* Physical parameters. */
     float length[2];                  /**< Length of the 2 arms elements. */

--- a/master-firmware/src/scara/scara_kinematics.h
+++ b/master-firmware/src/scara/scara_kinematics.h
@@ -1,7 +1,10 @@
 #ifndef SCARA_KINEMATICS_H
 #define SCARA_KINEMATICS_H
 
+#include <stdbool.h>
 #include <aversive/math/geometry/vect_base.h>
+
+#include "scara_waypoint.h"
 
 typedef enum {
     SHOULDER_FRONT,
@@ -34,5 +37,8 @@ point_t scara_forward_kinematics(float alpha, float beta, float length[2]);
 
 float scara_compute_shoulder_angle(point_t elbow, point_t hand);
 float scara_compute_elbow_angle(point_t elbow, point_t hand);
+
+bool scara_compute_joint_angles(position_3d_t position, shoulder_mode_t mode,
+                                float *length, float *alpha, float *beta);
 
 #endif /* SCARA_KINEMATICS_H */

--- a/master-firmware/src/scara/scara_trajectories.c
+++ b/master-firmware/src/scara/scara_trajectories.c
@@ -24,8 +24,8 @@ void scara_trajectory_init(scara_trajectory_t *traj) {
 }
 
 
-void scara_trajectory_append_point(scara_trajectory_t *traj, const float x, const float y, const float z,
-                                   scara_coordinate_t system, const float duration, const float* length)
+void scara_trajectory_append_point(scara_trajectory_t *traj, position_3d_t pos,
+                                   scara_coordinate_t system, float duration, const float* length)
 {
     traj->frame_count += 1;
     if (traj->frame_count >= SCARA_TRAJ_MAX_NUM_FRAMES) {
@@ -36,9 +36,9 @@ void scara_trajectory_append_point(scara_trajectory_t *traj, const float x, cons
         scara_panic();
     }
 
-    traj->frames[traj->frame_count-1].position.x = x;
-    traj->frames[traj->frame_count-1].position.y = y;
-    traj->frames[traj->frame_count-1].position.z = z;
+    traj->frames[traj->frame_count-1].position.x = pos.x;
+    traj->frames[traj->frame_count-1].position.y = pos.y;
+    traj->frames[traj->frame_count-1].position.z = pos.z;
     traj->frames[traj->frame_count-1].coordinate_type = system;
 
     if (traj->frame_count == 1) {

--- a/master-firmware/src/scara/scara_trajectories.c
+++ b/master-firmware/src/scara/scara_trajectories.c
@@ -36,9 +36,9 @@ void scara_trajectory_append_point(scara_trajectory_t *traj, const float x, cons
         scara_panic();
     }
 
-    traj->frames[traj->frame_count-1].position[0] = x;
-    traj->frames[traj->frame_count-1].position[1] = y;
-    traj->frames[traj->frame_count-1].position[2] = z;
+    traj->frames[traj->frame_count-1].position.x = x;
+    traj->frames[traj->frame_count-1].position.y = y;
+    traj->frames[traj->frame_count-1].position.z = z;
     traj->frames[traj->frame_count-1].coordinate_type = system;
 
     if (traj->frame_count == 1) {
@@ -95,9 +95,9 @@ scara_waypoint_t scara_trajectory_interpolate_waypoints(scara_waypoint_t k1, sca
     t = (date - k1.date) / (float)(k2.date - k1.date);
     t = smoothstep(t);
 
-    for (i=0; i<3; i++) {
-        result.position[i] = interpolate(t, k1.position[i], k2.position[i]);
-    }
+    result.position.x = interpolate(t, k1.position.x, k2.position.x);
+    result.position.y = interpolate(t, k1.position.y, k2.position.y);
+    result.position.z = interpolate(t, k1.position.z, k2.position.z);
 
     for (i=0; i<2; i++) {
         result.length[i] = interpolate(t, k1.length[i], k2.length[i]);

--- a/master-firmware/src/scara/scara_trajectories.h
+++ b/master-firmware/src/scara/scara_trajectories.h
@@ -17,8 +17,8 @@ extern "C" {
  * @note This function tests if the given trajectory is empty, and if it is, it assumes the first point
  * date is now.
  */
-void scara_trajectory_append_point(scara_trajectory_t *traj, const float x, const float y, const float z,
-                                   scara_coordinate_t system, const float duration, const float* length);
+void scara_trajectory_append_point(scara_trajectory_t *traj, position_3d_t pos,
+                                   scara_coordinate_t system, float duration, const float* length);
 
 /** Zeroes an scara_trajectory_t structure to avoid problems.
  * @param traj The trajectory to zero.

--- a/master-firmware/src/scara/scara_waypoint.h
+++ b/master-firmware/src/scara/scara_waypoint.h
@@ -13,6 +13,13 @@ typedef enum {
     COORDINATE_TABLE  /**< Coordinate relative to the table (absolute). */
 } scara_coordinate_t;
 
+/** Position in 3D space */
+typedef struct {
+    float x;
+    float y;
+    float z;
+} position_3d_t;
+
 /** This structure holds the data for a single waypoint of an arm trajectory (a waypoint). */
 typedef struct {
     int32_t date;                       /**< waypoint validity date, since the boot of the robot in us. */

--- a/master-firmware/src/scara/scara_waypoint.h
+++ b/master-firmware/src/scara/scara_waypoint.h
@@ -23,7 +23,7 @@ typedef struct {
 /** This structure holds the data for a single waypoint of an arm trajectory (a waypoint). */
 typedef struct {
     int32_t date;                       /**< waypoint validity date, since the boot of the robot in us. */
-    float position[3];                  /**< Position of the arm at the data. */
+    position_3d_t position;                  /**< Position of the arm at the data. */
     scara_coordinate_t coordinate_type; /**< The coordinate system of this trajectory. */
     float length[2];                    /**< The length of the arm to use. */
 } scara_waypoint_t;

--- a/master-firmware/tests/scara.cpp
+++ b/master-firmware/tests/scara.cpp
@@ -432,57 +432,6 @@ TEST(AScaraJacobian, ComputesCorrectlyCloseToSingularity)
     DOUBLES_EQUAL(0.00384607, torque_beta, 1e-3);
 }
 
-
-TEST_GROUP_BASE(AScaraJointAnglesComputer, ArmTestGroupBase)
-{
-    float alpha, beta;
-
-    scara_waypoint_t target(float x, float y)
-    {
-        return {.date = 0, .position = {x, y, 0}, .coordinate_type = COORDINATE_ARM, .length = {arbitraryLengths[0], arbitraryLengths[1]}};
-    }
-};
-
-TEST(AScaraJointAnglesComputer, failsWhenNoSolutionFound)
-{
-    scara_waypoint_t unreachable_target = target(200, 0);
-
-    bool solution_found = scara_compute_joint_angles(&arm, unreachable_target, &alpha, &beta);
-
-    CHECK_FALSE(solution_found);
-}
-
-TEST(AScaraJointAnglesComputer, choosesASolutionWhenMoreThanOnePossibility)
-{
-    scara_waypoint_t ambiguous_target = target(120, 0);
-
-    bool solution_found = scara_compute_joint_angles(&arm, ambiguous_target, &alpha, &beta);
-
-    CHECK_TRUE(solution_found);
-    DOUBLES_EQUAL(0.5, alpha, 0.1);
-    DOUBLES_EQUAL(-1.379634, beta, 0.1);
-}
-
-TEST(AScaraJointAnglesComputer, wrapsBetaWhenLowerThanMinusPi)
-{
-    scara_waypoint_t valid_target = target(-arbitraryLengths[0], arbitraryLengths[1]);
-
-    bool solution_found = scara_compute_joint_angles(&arm, valid_target, &alpha, &beta);
-
-    CHECK_TRUE(solution_found);
-    DOUBLES_EQUAL(0.5 * M_PI, beta, 0.1);
-}
-
-TEST(AScaraJointAnglesComputer, wrapsBetaWhenHigherThanMinusPi)
-{
-    scara_waypoint_t valid_target = target(-arbitraryLengths[0], -arbitraryLengths[1]);
-
-    bool solution_found = scara_compute_joint_angles(&arm, valid_target, &alpha, &beta);
-
-    CHECK_TRUE(solution_found);
-    DOUBLES_EQUAL(- 0.5 * M_PI, beta, 0.1);
-}
-
 TEST_GROUP_BASE(AScaraArmInverseKinematicsController, ArmTestGroupBase)
 {
     void setup()

--- a/master-firmware/tests/scara.cpp
+++ b/master-firmware/tests/scara.cpp
@@ -482,3 +482,25 @@ TEST(AScaraJointAnglesComputer, wrapsBetaWhenHigherThanMinusPi)
     CHECK_TRUE(solution_found);
     DOUBLES_EQUAL(- 0.5 * M_PI, beta, 0.1);
 }
+
+TEST_GROUP_BASE(AScaraArmInverseKinematicsController, ArmTestGroupBase)
+{
+    void setup()
+    {
+        ArmTestGroupBase::setup();
+
+        scara_ugly_mode_disable(&arm); // Run IK controller
+    }
+};
+
+TEST(AScaraArmInverseKinematicsController, sendsSetpointsToJoints)
+{
+    scara_trajectory_init(&traj);
+    scara_trajectory_append_point(&traj, 100, 100, 10, COORDINATE_ARM, 1., arbitraryLengths);
+    scara_do_trajectory(&arm, &traj);
+
+    scara_time_set(8 * 1000000);
+    scara_manage(&arm);
+    CHECK(0 != shoulder_angle);
+    CHECK(0 != elbow_angle);
+}

--- a/master-firmware/tests/scara.cpp
+++ b/master-firmware/tests/scara.cpp
@@ -84,8 +84,8 @@ TEST(AScaraArm, SetsPhysicalParameters)
 
 TEST(AScaraArm, CopiesDataBeforeExecutingTrajectory)
 {
-    scara_trajectory_append_point(&traj, 10, 10, 10, COORDINATE_ARM, 1., arbitraryLengths);
-    scara_trajectory_append_point(&traj, 10, 10, 10, COORDINATE_ARM, 10., arbitraryLengths);
+    scara_trajectory_append_point(&traj, {10, 10, 10}, COORDINATE_ARM, 1., arbitraryLengths);
+    scara_trajectory_append_point(&traj, {10, 10, 10}, COORDINATE_ARM, 10., arbitraryLengths);
 
     scara_do_trajectory(&arm, &traj);
     CHECK_EQUAL(traj.frame_count, arm.trajectory.frame_count);
@@ -102,8 +102,8 @@ TEST(AScaraArm, TrajectoryExecutionIsAtomic)
 
 TEST(AScaraArm, ManageExecutionIsAtomic)
 {
-    scara_trajectory_append_point(&traj, 60, 60, 10, COORDINATE_ARM, 1., arbitraryLengths);
-    scara_trajectory_append_point(&traj, 60, 60, 10, COORDINATE_ARM, 10., arbitraryLengths);
+    scara_trajectory_append_point(&traj, {60, 60, 10}, COORDINATE_ARM, 1., arbitraryLengths);
+    scara_trajectory_append_point(&traj, {60, 60, 10}, COORDINATE_ARM, 10., arbitraryLengths);
     scara_do_trajectory(&arm, &traj);
 
     lock_mocks_enable(true);
@@ -125,7 +125,7 @@ TEST(AScaraArm, ManageExecutionIsAtomicWithEmptyTraj)
 
 TEST(AScaraArm, ManageExecutionIsAtomicWithUnreachableTarget)
 {
-    scara_trajectory_append_point(&traj, 10000, 10000, 10, COORDINATE_ARM, 1., arbitraryLengths);
+    scara_trajectory_append_point(&traj, {10000, 10000, 10}, COORDINATE_ARM, 1., arbitraryLengths);
     scara_do_trajectory(&arm, &traj);
     lock_mocks_enable(true);
     mock().expectOneCall("chMtxLock").withPointerParameter("lock", &arm.lock);
@@ -137,7 +137,7 @@ TEST(AScaraArm, ManageExecutionIsAtomicWithUnreachableTarget)
 TEST(AScaraArm, UpdatesConsignOverTime)
 {
     scara_trajectory_init(&traj);
-    scara_trajectory_append_point(&traj, 100, 100, 10, COORDINATE_ARM, 1., arbitraryLengths);
+    scara_trajectory_append_point(&traj, {100, 100, 10}, COORDINATE_ARM, 1., arbitraryLengths);
     scara_do_trajectory(&arm, &traj);
 
     scara_time_set(8 * 1000000);
@@ -151,8 +151,8 @@ TEST(AScaraArm, ComputesDesiredPointForCurrentTime)
     scara_waypoint_t result;
     const int32_t date = 5 * 1000000;
     scara_time_set(0);
-    scara_trajectory_append_point(&traj, 0, 0, 0, COORDINATE_ARM, 1., arbitraryLengths);
-    scara_trajectory_append_point(&traj, 10, 20, 0, COORDINATE_ARM, 10., arbitraryLengths);
+    scara_trajectory_append_point(&traj, {0, 0, 0}, COORDINATE_ARM, 1., arbitraryLengths);
+    scara_trajectory_append_point(&traj, {10, 20, 0}, COORDINATE_ARM, 10., arbitraryLengths);
     scara_do_trajectory(&arm, &traj);
 
     result = scara_position_for_date(&arm, date);
@@ -163,9 +163,9 @@ TEST(AScaraArm, SelectsAppropriatePointToExecuteForCurrentTime)
 {
     scara_waypoint_t result;
     const int32_t date = 15 * 1000000;
-    scara_trajectory_append_point(&traj, 0, 0, 0, COORDINATE_ARM, 1., arbitraryLengths);
-    scara_trajectory_append_point(&traj, 10, 20, 0, COORDINATE_ARM, 10., arbitraryLengths);
-    scara_trajectory_append_point(&traj, 10, 30, 0, COORDINATE_ARM, 10., arbitraryLengths);
+    scara_trajectory_append_point(&traj, {0, 0, 0}, COORDINATE_ARM, 1., arbitraryLengths);
+    scara_trajectory_append_point(&traj, {10, 20, 0}, COORDINATE_ARM, 10., arbitraryLengths);
+    scara_trajectory_append_point(&traj, {10, 30, 0}, COORDINATE_ARM, 10., arbitraryLengths);
     scara_do_trajectory(&arm, &traj);
 
     result = scara_position_for_date(&arm, date);
@@ -176,9 +176,9 @@ TEST(AScaraArm, SelectsLastTrajectoryPointWhenTimeHasPassedTheEnd)
 {
     scara_waypoint_t result;
     const int32_t date = 25 * 1000000;
-    scara_trajectory_append_point(&traj, 0, 0, 0, COORDINATE_ARM, 1., arbitraryLengths);
-    scara_trajectory_append_point(&traj, 10, 20, 0, COORDINATE_ARM, 10., arbitraryLengths);
-    scara_trajectory_append_point(&traj, 10, 30, 0, COORDINATE_ARM, 10., arbitraryLengths);
+    scara_trajectory_append_point(&traj, {0, 0, 0}, COORDINATE_ARM, 1., arbitraryLengths);
+    scara_trajectory_append_point(&traj, {10, 20, 0}, COORDINATE_ARM, 10., arbitraryLengths);
+    scara_trajectory_append_point(&traj, {10, 30, 0}, COORDINATE_ARM, 10., arbitraryLengths);
     scara_do_trajectory(&arm, &traj);
 
     result = scara_position_for_date(&arm, date);
@@ -190,8 +190,8 @@ TEST(AScaraArm, SelectsCorrectPointWhenTrajectoryPointsSpecifiedInOtherCoordinat
     scara_waypoint_t result;
     const int32_t date = 5 * 1000000;
     arm.offset_rotation = M_PI / 2;
-    scara_trajectory_append_point(&traj, 0, 0, 0, COORDINATE_ARM, 1., arbitraryLengths);
-    scara_trajectory_append_point(&traj, 10, 20, 0, COORDINATE_ROBOT, 10., arbitraryLengths);
+    scara_trajectory_append_point(&traj, {0, 0, 0}, COORDINATE_ARM, 1., arbitraryLengths);
+    scara_trajectory_append_point(&traj, {10, 20, 0}, COORDINATE_ROBOT, 10., arbitraryLengths);
     scara_do_trajectory(&arm, &traj);
 
     result = scara_position_for_date(&arm, date);
@@ -219,8 +219,8 @@ TEST(AScaraArm, SelectsCorrectPointWhenGivenTrajectoryInTableCoordinateSystem)
     position_set(&pos, -10, -10, 0);
 
 
-    scara_trajectory_append_point(&traj, 0, 0, 0, COORDINATE_TABLE, 1., arbitraryLengths);
-    scara_trajectory_append_point(&traj, 10, 20, 0, COORDINATE_TABLE, 10., arbitraryLengths);
+    scara_trajectory_append_point(&traj, {0, 0, 0}, COORDINATE_TABLE, 1., arbitraryLengths);
+    scara_trajectory_append_point(&traj, {10, 20, 0}, COORDINATE_TABLE, 10., arbitraryLengths);
     scara_do_trajectory(&arm, &traj);
 
     result = scara_position_for_date(&arm, date);
@@ -236,8 +236,8 @@ TEST(AScaraArm, TrajectoriesFirstPointTableNotHandledCorrectly)
     scara_waypoint_t result;
     const int32_t date = 15 * 1000000;
     arm.offset_rotation = M_PI / 2;
-    scara_trajectory_append_point(&traj, 0, 0, 0, COORDINATE_ARM, 1, arbitraryLengths);
-    scara_trajectory_append_point(&traj, 10, 20, 0, COORDINATE_ROBOT, 10., arbitraryLengths);
+    scara_trajectory_append_point(&traj, {0, 0, 0}, COORDINATE_ARM, 1, arbitraryLengths);
+    scara_trajectory_append_point(&traj, {10, 20, 0}, COORDINATE_ROBOT, 10., arbitraryLengths);
     scara_do_trajectory(&arm, &traj);
 
     result = scara_position_for_date(&arm, date);
@@ -251,8 +251,8 @@ TEST(AScaraArm, InterpolatesLengthsWhenTheyChangeBetweenWaypoints)
     const int32_t date = 5 * 1000000;
     arm.offset_rotation = M_PI / 2;
     const float arbitraryLongerLengths[2] = {arbitraryLengths[0] * 2, arbitraryLengths[1] * 2};
-    scara_trajectory_append_point(&traj, 0, 0, 0, COORDINATE_ARM, 1., arbitraryLengths);
-    scara_trajectory_append_point(&traj, 0, 0, 0, COORDINATE_ARM, 10., arbitraryLongerLengths);
+    scara_trajectory_append_point(&traj, {0, 0, 0}, COORDINATE_ARM, 1., arbitraryLengths);
+    scara_trajectory_append_point(&traj, {0, 0, 0}, COORDINATE_ARM, 10., arbitraryLongerLengths);
 
     scara_do_trajectory(&arm, &traj);
 
@@ -266,9 +266,9 @@ TEST_GROUP_BASE(AScaraArmPause, ArmTestGroupBase)
 {
     void doTrajectory()
     {
-        scara_trajectory_append_point(&traj, 1, 2, 3, COORDINATE_ARM, 0., arbitraryLengths);
-        scara_trajectory_append_point(&traj, 2, 4, 6, COORDINATE_ARM, 1., arbitraryLengths);
-        scara_trajectory_append_point(&traj, 4, 8, 12, COORDINATE_ARM, 1., arbitraryLengths);
+        scara_trajectory_append_point(&traj, {1, 2, 3}, COORDINATE_ARM, 0., arbitraryLengths);
+        scara_trajectory_append_point(&traj, {2, 4, 6}, COORDINATE_ARM, 1., arbitraryLengths);
+        scara_trajectory_append_point(&traj, {4, 8, 12}, COORDINATE_ARM, 1., arbitraryLengths);
         scara_do_trajectory(&arm, &traj);
 
         scara_time_set(1e6); // reached 2nd waypoint
@@ -496,7 +496,7 @@ TEST_GROUP_BASE(AScaraArmInverseKinematicsController, ArmTestGroupBase)
 TEST(AScaraArmInverseKinematicsController, sendsSetpointsToJoints)
 {
     scara_trajectory_init(&traj);
-    scara_trajectory_append_point(&traj, 100, 100, 10, COORDINATE_ARM, 1., arbitraryLengths);
+    scara_trajectory_append_point(&traj, {100, 100, 10}, COORDINATE_ARM, 1., arbitraryLengths);
     scara_do_trajectory(&arm, &traj);
 
     scara_time_set(8 * 1000000);

--- a/master-firmware/tests/scara.cpp
+++ b/master-firmware/tests/scara.cpp
@@ -156,7 +156,7 @@ TEST(AScaraArm, ComputesDesiredPointForCurrentTime)
     scara_do_trajectory(&arm, &traj);
 
     result = scara_position_for_date(&arm, date);
-    DOUBLES_EQUAL(result.position[0], 5., 0.1);
+    DOUBLES_EQUAL(result.position.x, 5., 0.1);
 }
 
 TEST(AScaraArm, SelectsAppropriatePointToExecuteForCurrentTime)
@@ -169,7 +169,7 @@ TEST(AScaraArm, SelectsAppropriatePointToExecuteForCurrentTime)
     scara_do_trajectory(&arm, &traj);
 
     result = scara_position_for_date(&arm, date);
-    DOUBLES_EQUAL(25, result.position[1], 0.1);
+    DOUBLES_EQUAL(25, result.position.y, 0.1);
 }
 
 TEST(AScaraArm, SelectsLastTrajectoryPointWhenTimeHasPassedTheEnd)
@@ -182,7 +182,7 @@ TEST(AScaraArm, SelectsLastTrajectoryPointWhenTimeHasPassedTheEnd)
     scara_do_trajectory(&arm, &traj);
 
     result = scara_position_for_date(&arm, date);
-    DOUBLES_EQUAL(30, result.position[1], 0.1);
+    DOUBLES_EQUAL(30, result.position.y, 0.1);
 }
 
 TEST(AScaraArm, SelectsCorrectPointWhenTrajectoryPointsSpecifiedInOtherCoordinateSystems)
@@ -195,8 +195,8 @@ TEST(AScaraArm, SelectsCorrectPointWhenTrajectoryPointsSpecifiedInOtherCoordinat
     scara_do_trajectory(&arm, &traj);
 
     result = scara_position_for_date(&arm, date);
-    DOUBLES_EQUAL(10, result.position[0], 0.1);
-    DOUBLES_EQUAL(-5, result.position[1], 0.1);
+    DOUBLES_EQUAL(10, result.position.x, 0.1);
+    DOUBLES_EQUAL(-5, result.position.y, 0.1);
 }
 
 TEST(AScaraArm, SetsRelatedRobotPosition)
@@ -224,8 +224,8 @@ TEST(AScaraArm, SelectsCorrectPointWhenGivenTrajectoryInTableCoordinateSystem)
     scara_do_trajectory(&arm, &traj);
 
     result = scara_position_for_date(&arm, date);
-    DOUBLES_EQUAL(20, result.position[0], 0.1);
-    DOUBLES_EQUAL(-15, result.position[1], 0.1);
+    DOUBLES_EQUAL(20, result.position.x, 0.1);
+    DOUBLES_EQUAL(-15, result.position.y, 0.1);
 }
 
 TEST(AScaraArm, TrajectoriesFirstPointTableNotHandledCorrectly)
@@ -241,8 +241,8 @@ TEST(AScaraArm, TrajectoriesFirstPointTableNotHandledCorrectly)
     scara_do_trajectory(&arm, &traj);
 
     result = scara_position_for_date(&arm, date);
-    DOUBLES_EQUAL(20, result.position[0], 0.1);
-    DOUBLES_EQUAL(-10, result.position[1], 0.1);
+    DOUBLES_EQUAL(20, result.position.x, 0.1);
+    DOUBLES_EQUAL(-10, result.position.y, 0.1);
 }
 
 TEST(AScaraArm, InterpolatesLengthsWhenTheyChangeBetweenWaypoints)
@@ -277,9 +277,9 @@ TEST_GROUP_BASE(AScaraArmPause, ArmTestGroupBase)
 
     void checkFrameEqual(scara_waypoint_t a, scara_waypoint_t b)
     {
-        CHECK_EQUAL(a.position[0], b.position[0]);
-        CHECK_EQUAL(a.position[1], b.position[1]);
-        CHECK_EQUAL(a.position[2], b.position[2]);
+        CHECK_EQUAL(a.position.x, b.position.x);
+        CHECK_EQUAL(a.position.y, b.position.y);
+        CHECK_EQUAL(a.position.z, b.position.z);
         CHECK_EQUAL(a.date, b.date);
         CHECK_EQUAL(a.coordinate_type, b.coordinate_type);
         CHECK_EQUAL(a.length[0], b.length[0]);

--- a/master-firmware/tests/scara_inverse_kinematics_controller.cpp
+++ b/master-firmware/tests/scara_inverse_kinematics_controller.cpp
@@ -1,0 +1,48 @@
+#include <CppUTest/TestHarness.h>
+#include <cmath>
+
+extern "C" {
+#include <scara/control/scara_inverse_kinematics_controller.h>
+}
+
+TEST_GROUP(AScaraIKController)
+{
+    scara_ik_controller_t controller;
+    position_3d_t desired;
+    scara_joint_positions_t measured;
+
+    float armLengths[2] = {10, 10};
+
+    void setup()
+    {
+        scara_ik_controller_init(&controller);
+        scara_ik_controller_set_geometry(&controller, armLengths);
+
+        pid_set_gains(&controller.x_pid, 1, 0, 0);
+        pid_set_gains(&controller.y_pid, 1, 0, 0);
+    }
+};
+
+TEST(AScaraIKController, ReturnsZeroSetpointIfAlreadyAtDesiredPosition)
+{
+    measured = {.z = 0, .shoulder = 0, .elbow = 0.5 * M_PI};
+    desired = {.x = 10, .y = 10, .z = 0};
+
+    auto joint_setpoints = scara_ik_controller_process(&controller, desired, measured);
+
+    CHECK_EQUAL(0, joint_setpoints.z.value);
+    CHECK_EQUAL(0, joint_setpoints.shoulder.value);
+    CHECK_EQUAL(0, joint_setpoints.elbow.value);
+}
+
+TEST(AScaraIKController, ReturnsSetpointToReachDesiredPosition)
+{
+    measured = {.z = 0, .shoulder = 0, .elbow = 0.5 * M_PI};
+    desired = {.x = 12, .y = 10, .z = 2};
+
+    auto joint_setpoints = scara_ik_controller_process(&controller, desired, measured);
+
+    CHECK_TRUE(0 != joint_setpoints.z.value);
+    CHECK_TRUE(0 != joint_setpoints.shoulder.value);
+    CHECK_TRUE(0 != joint_setpoints.elbow.value);
+}

--- a/master-firmware/tests/scara_joint_controller.cpp
+++ b/master-firmware/tests/scara_joint_controller.cpp
@@ -1,4 +1,5 @@
 #include <CppUTest/TestHarness.h>
+#include <cmath>
 
 extern "C" {
 #include <scara/control/scara_joint_controller.h>
@@ -6,36 +7,71 @@ extern "C" {
 
 TEST_GROUP(AScaraJointController)
 {
-    scara_joint_positions_t desired, measured;
+    scara_joint_controller_t controller;
+    position_3d_t desired;
+    scara_joint_positions_t measured;
+
+    float armLengths[2] = {10, 10};
+    shoulder_mode_t shoulder_mode = SHOULDER_BACK;
+
+    void setup()
+    {
+        scara_joint_controller_init(&controller);
+        scara_joint_controller_set_geometry(&controller, armLengths, shoulder_mode);
+    }
+
+    void CHECK_SETPOINT_EQ(joint_setpoint_t a, joint_setpoint_t b)
+    {
+        CHECK_EQUAL(a.mode, b.mode);
+        DOUBLES_EQUAL(a.value, b.value, 1e-3);
+    }
 };
 
 TEST(AScaraJointController, ReturnsZeroSetpointGivenZeroInput)
 {
-    auto joint_setpoints = scara_joint_controller_process(desired, measured);
+    desired = {.x = 20, .y = 0, .z = 0};
 
-    CHECK_EQUAL(0, joint_setpoints.z.value);
-    CHECK_EQUAL(0, joint_setpoints.shoulder.value);
-    CHECK_EQUAL(0, joint_setpoints.elbow.value);
+    auto joint_setpoints =
+        scara_joint_controller_process(&controller, desired, measured);
+
+    CHECK_SETPOINT_EQ({POSITION, 0}, joint_setpoints.z);
+    CHECK_SETPOINT_EQ({POSITION, 0}, joint_setpoints.shoulder);
+    CHECK_SETPOINT_EQ({POSITION, 0}, joint_setpoints.elbow);
 }
 
 TEST(AScaraJointController, SetsJointsToDesiredPositions)
 {
-    desired = {.z = 1, .shoulder = 2, .elbow = 3};
+    desired = {.x = 10, .y = 10, .z = 5};
 
-    auto joint_setpoints = scara_joint_controller_process(desired, measured);
+    auto joint_setpoints =
+        scara_joint_controller_process(&controller, desired, measured);
 
-    CHECK_EQUAL(1, joint_setpoints.z.value);
-    CHECK_EQUAL(2, joint_setpoints.shoulder.value);
-    CHECK_EQUAL(3, joint_setpoints.elbow.value);
+    CHECK_SETPOINT_EQ({POSITION, 5}, joint_setpoints.z);
+    CHECK_SETPOINT_EQ({POSITION, 0.5 * M_PI}, joint_setpoints.shoulder);
+    CHECK_SETPOINT_EQ({POSITION, -0.5 * M_PI}, joint_setpoints.elbow);
 }
 
 TEST(AScaraJointController, IgnoresMeasuredPositions)
 {
     measured = {.z = 1, .shoulder = 2, .elbow = 3};
+    desired = {.x = 20, .y = 0, .z = 0};
 
-    auto joint_setpoints = scara_joint_controller_process(desired, measured);
+    auto joint_setpoints =
+        scara_joint_controller_process(&controller, desired, measured);
 
-    CHECK_EQUAL(0, joint_setpoints.z.value);
-    CHECK_EQUAL(0, joint_setpoints.shoulder.value);
-    CHECK_EQUAL(0, joint_setpoints.elbow.value);
+    CHECK_SETPOINT_EQ({POSITION, 0}, joint_setpoints.z);
+    CHECK_SETPOINT_EQ({POSITION, 0}, joint_setpoints.shoulder);
+    CHECK_SETPOINT_EQ({POSITION, 0}, joint_setpoints.elbow);
+}
+
+TEST(AScaraJointController, SetsJointVelocitiesToZeroIfDestinationUnreachable)
+{
+    desired = {.x = 25, .y = 0, .z = 0};
+
+    auto joint_setpoints =
+        scara_joint_controller_process(&controller, desired, measured);
+
+    CHECK_SETPOINT_EQ({VELOCITY, 0}, joint_setpoints.z);
+    CHECK_SETPOINT_EQ({VELOCITY, 0}, joint_setpoints.shoulder);
+    CHECK_SETPOINT_EQ({VELOCITY, 0}, joint_setpoints.elbow);
 }

--- a/master-firmware/tests/scara_joint_controller.cpp
+++ b/master-firmware/tests/scara_joint_controller.cpp
@@ -1,0 +1,41 @@
+#include <CppUTest/TestHarness.h>
+
+extern "C" {
+#include <scara/control/scara_joint_controller.h>
+}
+
+TEST_GROUP(AScaraJointController)
+{
+    scara_joint_positions_t desired, measured;
+};
+
+TEST(AScaraJointController, ReturnsZeroSetpointGivenZeroInput)
+{
+    auto joint_setpoints = scara_joint_controller_process(desired, measured);
+
+    CHECK_EQUAL(0, joint_setpoints.z.value);
+    CHECK_EQUAL(0, joint_setpoints.shoulder.value);
+    CHECK_EQUAL(0, joint_setpoints.elbow.value);
+}
+
+TEST(AScaraJointController, SetsJointsToDesiredPositions)
+{
+    desired = {.z = 1, .shoulder = 2, .elbow = 3};
+
+    auto joint_setpoints = scara_joint_controller_process(desired, measured);
+
+    CHECK_EQUAL(1, joint_setpoints.z.value);
+    CHECK_EQUAL(2, joint_setpoints.shoulder.value);
+    CHECK_EQUAL(3, joint_setpoints.elbow.value);
+}
+
+TEST(AScaraJointController, IgnoresMeasuredPositions)
+{
+    measured = {.z = 1, .shoulder = 2, .elbow = 3};
+
+    auto joint_setpoints = scara_joint_controller_process(desired, measured);
+
+    CHECK_EQUAL(0, joint_setpoints.z.value);
+    CHECK_EQUAL(0, joint_setpoints.shoulder.value);
+    CHECK_EQUAL(0, joint_setpoints.elbow.value);
+}

--- a/master-firmware/tests/scara_kinematics_integration.cpp
+++ b/master-firmware/tests/scara_kinematics_integration.cpp
@@ -96,8 +96,8 @@ TEST(kinematicsTestGroup, DoesNotOscillateAroundZero)
     while (scara_time_get() < traj.frames[traj.frame_count-1].date) {
         frame = scara_position_for_date(&arm, scara_time_get());
 
-        target.x = frame.position[0];
-        target.y = frame.position[1];
+        target.x = frame.position.x;
+        target.y = frame.position.y;
 
         position_count = scara_num_possible_elbow_positions(target,
                                  frame.length[0], frame.length[1],

--- a/master-firmware/tests/scara_kinematics_integration.cpp
+++ b/master-firmware/tests/scara_kinematics_integration.cpp
@@ -89,8 +89,8 @@ TEST(kinematicsTestGroup, DoesNotOscillateAroundZero)
     point_t target;
     int position_count;
 
-    scara_trajectory_append_point(&traj, 100,  1, 10, COORDINATE_ARM, 1., arbitraryLengths);
-    scara_trajectory_append_point(&traj, 100, -1, 10, COORDINATE_ARM, 10., arbitraryLengths);
+    scara_trajectory_append_point(&traj, {100,  1, 10}, COORDINATE_ARM, 1., arbitraryLengths);
+    scara_trajectory_append_point(&traj, {100, -1, 10}, COORDINATE_ARM, 10., arbitraryLengths);
     scara_do_trajectory(&arm, &traj);
 
     while (scara_time_get() < traj.frames[traj.frame_count-1].date) {

--- a/master-firmware/tests/scara_trajectories.cpp
+++ b/master-firmware/tests/scara_trajectories.cpp
@@ -27,7 +27,7 @@ TEST_GROUP(AnArmTrajectory)
     {
         for (int i = 0; i < number_of_points; i++)
         {
-            scara_trajectory_append_point(&traj, 10, 10, 10, COORDINATE_ARM, i + 1, arbitraryLengths);
+            scara_trajectory_append_point(&traj, {10, 10, 10}, COORDINATE_ARM, i + 1, arbitraryLengths);
         }
     }
 };
@@ -51,9 +51,9 @@ TEST(AnArmTrajectory, AppendsMultiplePoints)
 
 TEST(AnArmTrajectory, ComputesDateCorrectly)
 {
-    scara_trajectory_append_point(&traj, 10, 10, 10, COORDINATE_ARM, 1., arbitraryLengths);
-    scara_trajectory_append_point(&traj, 10, 10, 10, COORDINATE_ARM, 10., arbitraryLengths);
-    scara_trajectory_append_point(&traj, 10, 10, 10, COORDINATE_ARM, 15., arbitraryLengths);
+    scara_trajectory_append_point(&traj, {10, 10, 10}, COORDINATE_ARM, 1., arbitraryLengths);
+    scara_trajectory_append_point(&traj, {10, 10, 10}, COORDINATE_ARM, 10., arbitraryLengths);
+    scara_trajectory_append_point(&traj, {10, 10, 10}, COORDINATE_ARM, 15., arbitraryLengths);
 
     CHECK_EQUAL(traj.frames[1].date, 10*1000000);
     CHECK_EQUAL(traj.frames[2].date, 25*1000000);
@@ -95,8 +95,8 @@ TEST(AnArmTrajectory, IsNotFinishedWhenGivenPoints)
 
 TEST(AnArmTrajectory, IsFinishedWhenTrajectoryIsOutdated)
 {
-    scara_trajectory_append_point(&traj, 10, 10, 10, COORDINATE_ARM, 1., arbitraryLengths);
-    scara_trajectory_append_point(&traj, 10, 10, 10, COORDINATE_ARM, 10., arbitraryLengths);
+    scara_trajectory_append_point(&traj, {10, 10, 10}, COORDINATE_ARM, 1., arbitraryLengths);
+    scara_trajectory_append_point(&traj, {10, 10, 10}, COORDINATE_ARM, 10., arbitraryLengths);
     scara_time_set(20*1000000);
 
     CHECK_EQUAL(1, scara_trajectory_finished(&traj));
@@ -106,8 +106,8 @@ TEST(AnArmTrajectory, InterpolatesWaypoints)
 {
     const int32_t interpolation_date = 5 * 1000000; // microseconds
     scara_waypoint_t result;
-    scara_trajectory_append_point(&traj, 0, 0, 0, COORDINATE_ARM, 1., arbitraryLengths);
-    scara_trajectory_append_point(&traj, 10, 20, 30, COORDINATE_ARM, 10., arbitraryLengths);
+    scara_trajectory_append_point(&traj, {0, 0, 0}, COORDINATE_ARM, 1., arbitraryLengths);
+    scara_trajectory_append_point(&traj, {10, 20, 30}, COORDINATE_ARM, 10., arbitraryLengths);
 
     result = scara_trajectory_interpolate_waypoints(traj.frames[0], traj.frames[1], interpolation_date);
 

--- a/master-firmware/tests/scara_trajectories.cpp
+++ b/master-firmware/tests/scara_trajectories.cpp
@@ -75,10 +75,10 @@ TEST(AnArmTrajectory, CopiesTrajectory)
     scara_trajectory_copy(&copy, &traj);
 
     CHECK_EQUAL(traj.frame_count, copy.frame_count);
-    CHECK_EQUAL(traj.frames[0].position[0], copy.frames[0].position[0]);
+    CHECK_EQUAL(traj.frames[0].position.x, copy.frames[0].position.x);
 
     /* Check that it is a full copy. */
-    CHECK(traj.frames[0].position != copy.frames[0].position);
+    CHECK(traj.frames != copy.frames);
 }
 
 TEST(AnArmTrajectory, IsFinishedWhenGivenNoPoints)
@@ -114,9 +114,9 @@ TEST(AnArmTrajectory, InterpolatesWaypoints)
     CHECK_EQUAL(interpolation_date, result.date);
     CHECK_EQUAL(COORDINATE_ARM, result.coordinate_type);
 
-    DOUBLES_EQUAL(5., result.position[0], 0.1);
-    DOUBLES_EQUAL(10., result.position[1], 0.1);
-    DOUBLES_EQUAL(15., result.position[2], 0.1);
+    DOUBLES_EQUAL(5., result.position.x, 0.1);
+    DOUBLES_EQUAL(10., result.position.y, 0.1);
+    DOUBLES_EQUAL(15., result.position.z, 0.1);
 
     CHECK_TRUE(result.length[0] > 0.0);
     CHECK_TRUE(result.length[1] > 0.0);

--- a/master-firmware/tests/test_strategy_helpers.cpp
+++ b/master-firmware/tests/test_strategy_helpers.cpp
@@ -58,11 +58,11 @@ TEST(ArmSetTrajectory, SetsGivenPointInTrajectory)
 {
     strategy_set_arm_trajectory(&arm, &trajectory[0], sizeof(trajectory) / sizeof(arm_waypoint_t));
 
-    CHECK_EQUAL(100, arm.trajectory.frames[1].position[0]);
-    CHECK_EQUAL(0, arm.trajectory.frames[1].position[1]);
+    CHECK_EQUAL(100, arm.trajectory.frames[1].position.x);
+    CHECK_EQUAL(0, arm.trajectory.frames[1].position.y);
 
-    CHECK_EQUAL(100, arm.trajectory.frames[2].position[0]);
-    CHECK_EQUAL(100, arm.trajectory.frames[2].position[1]);
+    CHECK_EQUAL(100, arm.trajectory.frames[2].position.x);
+    CHECK_EQUAL(100, arm.trajectory.frames[2].position.y);
 }
 
 TEST(ArmSetTrajectory, SetsTimeCorrectly)

--- a/master-firmware/tests/test_strategy_helpers.cpp
+++ b/master-firmware/tests/test_strategy_helpers.cpp
@@ -24,9 +24,9 @@ TEST_GROUP(ArmSetTrajectory)
     struct robot_position pos;
 
     arm_waypoint_t trajectory[3] = {
-        {.x=0, .y=0, .z=0, .coord=COORDINATE_TABLE, .dt=1000},
-        {.x=100, .y=0, .z=0, .coord=COORDINATE_TABLE, .dt=1000},
-        {.x=100, .y=100, .z=0, .coord=COORDINATE_TABLE, .dt=1000},
+        {.pos={.x =   0, .y =   0, .z = 0}, .coord=COORDINATE_TABLE, .dt=1000},
+        {.pos={.x = 100, .y =   0, .z = 0}, .coord=COORDINATE_TABLE, .dt=1000},
+        {.pos={.x = 100, .y = 100, .z = 0}, .coord=COORDINATE_TABLE, .dt=1000},
     };
 
     void setup()


### PR DESCRIPTION
In this PR, we split the two arm controllers we use:
- Joint controller
- Inverse kinematics controller

There is a common "interface to the controllers":
- initialization of the controller
- geometry setting
- process that takes a desired position (in cartesian space), a measured position (in joint space), and returns joint setpoints

Some unit tests cover the basic behavior of the two controllers, they also serve as documentation for the boilerplate needed to run them.