### PR TITLE
Add compiler flag to output stack usage per function

### DIFF
--- a/master-firmware/Makefile
+++ b/master-firmware/Makefile
@@ -6,7 +6,7 @@
 # Compiler options here.
 ifeq ($(USE_OPT),)
   USE_OPT = -O2 -ggdb -fomit-frame-pointer -falign-functions=16
-  USE_OPT += -frename-registers -freorder-blocks -fconserve-stack
+  USE_OPT += -frename-registers -freorder-blocks -fconserve-stack -fstack-usage
   USE_OPT += -fstack-protector-all -L .
 endif
 


### PR DESCRIPTION
This uses the `-fstack-usage` option introduced in GCC 6.1. The output is one `.su` file per module in `build/obj`, and it shows the maximum stack usage for each function.

Example:
```
strategy_helpers.c:17:6:strategy_auto_position          48    static
strategy_helpers.c:67:6:strategy_align_y                40    static
strategy_helpers.c:85:10:strategy_set_arm_trajectory    56    static
```