### PR TITLE
CVRA Studio - MVP 1.5: Live plot of PID loop feedbacks

### DIFF
--- a/tools/studio/network/NodeStatusMonitor.py
+++ b/tools/studio/network/NodeStatusMonitor.py
@@ -1,0 +1,40 @@
+import logging
+
+import uavcan
+
+
+class NodeStatusMonitor:
+    def __init__(self, node):
+        self.logger = logging.getLogger('NodeStatusMonitor')
+        self.known_nodes = {}
+        self.node = node
+        self.node.add_handler(uavcan.protocol.NodeStatus, self._node_status_callback)
+        self.on_new_node = None
+
+    def set_on_new_node_callback(self, on_new_node):
+        self.on_new_node = on_new_node
+
+    def node_id_to_name(self, node_id):
+        if node_id in self.known_nodes.keys():
+            if 'name' in self.known_nodes[node_id].keys():
+                return self.known_nodes[node_id]['name']
+        return None
+
+    def _node_status_callback(self, event):
+        node_id = event.transfer.source_node_id
+        if node_id not in self.known_nodes:
+            self.known_nodes[node_id] = {}
+            self.node.request(uavcan.protocol.GetNodeInfo.Request(), node_id, self._response_callback)
+        self.known_nodes[node_id]['status'] = event.message
+
+    def _response_callback(self, event):
+        if not event:
+            raise RuntimeError("Remote call timeout")
+
+        board = event.transfer.source_node_id
+        name = str(event.response.name)
+        self.known_nodes[board]['name'] = name
+        self.logger.info('Detected new node {} ({})'.format(self.known_nodes[board]['name'], board))
+
+        if self.on_new_node is not None:
+            self.on_new_node()

--- a/tools/studio/network/UavcanNode.py
+++ b/tools/studio/network/UavcanNode.py
@@ -1,0 +1,35 @@
+import threading
+import time
+import uavcan
+
+class UavcanNode:
+    def __init__(self, interface, node_id):
+        self.handlers = []
+        self.node_lock = threading.RLock()
+        self.node = uavcan.make_node(interface, node_id=node_id)
+
+    def add_handler(self, topic, callback):
+        self.handlers.append(self.node.add_handler(topic, callback))
+
+    def request(self, request, node_id, callback):
+        with self.node_lock:
+            self.node.request(request, node_id, callback)
+
+    def spin(self):
+        threading.Thread(target=self._uavcan_thread).start()
+
+    def _uavcan_thread(self):
+        while True:
+            try:
+                with self.node_lock:
+                    self.node.spin(0.1)
+                time.sleep(0.01)
+            except uavcan.UAVCANException as ex:
+                print('Node error:', ex)
+                self._uavcan_exit()
+                return
+
+    def _uavcan_exit(self):
+        for handler in self.handlers:
+            handler.remove()
+

--- a/tools/studio/node.py
+++ b/tools/studio/node.py
@@ -1,0 +1,57 @@
+import argparse
+import random
+import time
+import uavcan
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("interface", help="Serial port or SocketCAN interface")
+    parser.add_argument("id", help="UAVCAN node ID", type=int)
+    parser.add_argument("name", help="UAVCAN node name", type=str)
+    parser.add_argument("--dsdl", "-d", help="DSDL path")
+
+    return parser.parse_args()
+
+def step(scale, divider=1, max_value=1, min_value=0):
+    return max_value if (round(time.time() / divider)) % 2 else min_value
+
+def main():
+    args = parse_args()
+    if args.dsdl is not None:
+        uavcan.load_dsdl(args.dsdl)
+
+    node_info = uavcan.protocol.GetNodeInfo.Response(name=args.name)
+    node = uavcan.make_node(args.interface, node_id=args.id, node_info=node_info)
+
+    def publish(msg):
+        node.broadcast(msg, priority=uavcan.TRANSFER_PRIORITY_LOWEST)
+
+    def publish_current():
+        publish(uavcan.thirdparty.cvra.motor.feedback.CurrentPID(
+            current_setpoint=step(scale=1, divider=0.5),
+            current=random.uniform(0, 1)))
+
+    def publish_velocity():
+        publish(uavcan.thirdparty.cvra.motor.feedback.VelocityPID(
+            velocity_setpoint=step(scale=1, divider=1),
+            velocity=random.uniform(0, 1)))
+
+    def publish_position():
+        publish(uavcan.thirdparty.cvra.motor.feedback.PositionPID(
+            position_setpoint=step(scale=1, divider=2),
+            position=random.uniform(0, 1)))
+
+    if args.dsdl is not None:
+        handle_current = node.periodic(0.01, publish_current)
+        handle_velocity = node.periodic(0.03, publish_velocity)
+        handle_position = node.periodic(0.1, publish_position)
+
+    while True:
+        try:
+            node.spin(1)
+        except uavcan.UAVCANException as ex:
+            print('Node error:', ex)
+
+if __name__ == '__main__':
+    main()
+

--- a/tools/studio/node_discovery.py
+++ b/tools/studio/node_discovery.py
@@ -5,36 +5,7 @@ import threading
 import time
 import uavcan
 
-class UavcanNode:
-    def __init__(self, interface, node_id):
-        self.handlers = []
-        self.node_lock = threading.RLock()
-        self.node = uavcan.make_node(interface, node_id=node_id)
-
-    def add_handler(self, topic, callback):
-        self.handlers.append(self.node.add_handler(topic, callback))
-
-    def request(self, request, node_id, callback):
-        with self.node_lock:
-            self.node.request(request, node_id, callback)
-
-    def spin(self):
-        threading.Thread(target=self._uavcan_thread).start()
-
-    def _uavcan_thread(self):
-        while True:
-            try:
-                with self.node_lock:
-                    self.node.spin(0.1)
-                time.sleep(0.01)
-            except uavcan.UAVCANException as ex:
-                print('Node error:', ex)
-                self._uavcan_exit()
-                return
-
-    def _uavcan_exit(self):
-        for handler in self.handlers:
-            handler.remove()
+from network.UavcanNode import UavcanNode
 
 class NodeStatusModel:
     def __init__(self, node):

--- a/tools/studio/node_discovery.py
+++ b/tools/studio/node_discovery.py
@@ -3,30 +3,11 @@ import datetime
 import sys
 import threading
 import time
+
 import uavcan
 
 from network.UavcanNode import UavcanNode
-
-class NodeStatusModel:
-    def __init__(self, node):
-        self.known_nodes = {}
-        self.node = node
-        self.node.add_handler(uavcan.protocol.NodeStatus, self._node_status_callback)
-
-    def _node_status_callback(self, event):
-        node_id = event.transfer.source_node_id
-        if node_id not in self.known_nodes:
-            self.known_nodes[node_id] = {}
-            self.node.request(uavcan.protocol.GetNodeInfo.Request(), node_id, self._response_callback)
-        self.known_nodes[node_id]['status'] = event.message
-
-    def _response_callback(self, event):
-        if not event:
-            raise RuntimeError("Remote call timeout")
-
-        board = event.transfer.source_node_id
-        name = str(event.response.name)
-        self.known_nodes[board]['name'] = name
+from network.NodeStatusMonitor import NodeStatusMonitor
 
 class NodeStatusViewer:
     def __init__(self):
@@ -98,7 +79,7 @@ def main():
 
     node = UavcanNode(interface=args.interface, node_id=args.node_id)
 
-    model = NodeStatusModel(node)
+    model = NodeStatusMonitor(node)
     viewer = NodeStatusViewer()
     controller = NodeStatusController(model, viewer)
 

--- a/tools/studio/node_selector.py
+++ b/tools/studio/node_selector.py
@@ -1,0 +1,106 @@
+import argparse
+import datetime
+import sys
+import threading
+import time
+import uavcan
+from network.UavcanNode import UavcanNode
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("interface", help="Serial port or SocketCAN interface")
+    parser.add_argument("--dsdl", "-d", help="DSDL path", required=True)
+    parser.add_argument("--node_id", "-n", help="UAVCAN Node ID", default=127)
+
+    return parser.parse_args()
+
+import pyqtgraph as pg
+from pyqtgraph.Qt import QtCore, QtGui
+class NodeStatusMonitor:
+    def __init__(self, node):
+        self.known_nodes = {}
+        self.node = node
+        self.node.add_handler(uavcan.protocol.NodeStatus, self._node_status_callback)
+        self.on_new_node = None
+
+    def set_on_new_node_callback(self, on_new_node):
+        self.on_new_node = on_new_node
+
+    def _node_status_callback(self, event):
+        node_id = event.transfer.source_node_id
+        if node_id not in self.known_nodes:
+            self.known_nodes[node_id] = {}
+            self.node.request(uavcan.protocol.GetNodeInfo.Request(), node_id, self._response_callback)
+        self.known_nodes[node_id]['status'] = event.message
+
+    def _response_callback(self, event):
+        if not event:
+            raise RuntimeError("Remote call timeout")
+
+        board = event.transfer.source_node_id
+        name = str(event.response.name)
+        self.known_nodes[board]['name'] = name
+
+        if self.on_new_node is not None:
+            self.on_new_node()
+
+class NodeSelectViewer(QtGui.QWidget):
+    def __init__(self, parent = None):
+        super(NodeSelectViewer, self).__init__(parent)
+
+        layout = QtGui.QHBoxLayout()
+
+        self.combo_box = pg.ComboBox()
+        layout.addWidget(self.combo_box)
+
+        self.setLayout(layout)
+        self.setWindowTitle("Node Selector")
+
+    def set_nodes(self, nodes):
+        try:
+            self.combo_box.clear()
+            self.combo_box.addItems(nodes)
+        except:
+            pass
+        self.combo_box.update()
+
+    def set_callback(self, callback):
+        self.combo_box.currentIndexChanged.connect(callback)
+
+class NodeSelectController:
+    def __init__(self, model, viewer):
+        self.model = model
+        self.viewer = viewer
+
+        self.nodes = []
+        self.model.set_on_new_node_callback(self.update_selection)
+
+        self.viewer.set_callback(lambda i: print("Current index", i, "selection changed to", self.nodes[i]))
+        self.viewer.show()
+
+    def update_selection(self):
+        known_nodes = self.model.known_nodes
+        nodes_with_name = {k: v for k, v in known_nodes.items() if 'name' in v.keys()}
+        self.nodes = list(nodes_with_name[node]['name'] for node in nodes_with_name)
+        self.viewer.set_nodes(self.nodes)
+
+def qt_loop():
+    import sys
+    if (sys.flags.interactive != 1) or not hasattr(QtCore, 'PYQT_VERSION'):
+        QtGui.QApplication.instance().exec_()
+
+def main():
+    args = parse_args()
+    uavcan.load_dsdl(args.dsdl)
+
+    node = UavcanNode(interface=args.interface, node_id=args.node_id)
+
+    app = QtGui.QApplication(sys.argv)
+
+    controller = NodeSelectController(model=NodeStatusMonitor(node), viewer=NodeSelectViewer())
+
+    node.spin()
+    qt_loop()
+
+if __name__ == '__main__':
+    main()

--- a/tools/studio/node_selector.py
+++ b/tools/studio/node_selector.py
@@ -3,12 +3,14 @@ import datetime
 import sys
 import threading
 import time
-import uavcan
 
+import uavcan
 from pyqtgraph.Qt import QtCore, QtGui
 
 from network.UavcanNode import UavcanNode
+from network.NodeStatusMonitor import NodeStatusMonitor
 from viewers.Selector import SelectorWidget
+
 
 def parse_args():
     parser = argparse.ArgumentParser(description=__doc__)
@@ -17,34 +19,6 @@ def parse_args():
     parser.add_argument("--node_id", "-n", help="UAVCAN Node ID", default=127)
 
     return parser.parse_args()
-
-class NodeStatusMonitor:
-    def __init__(self, node):
-        self.known_nodes = {}
-        self.node = node
-        self.node.add_handler(uavcan.protocol.NodeStatus, self._node_status_callback)
-        self.on_new_node = None
-
-    def set_on_new_node_callback(self, on_new_node):
-        self.on_new_node = on_new_node
-
-    def _node_status_callback(self, event):
-        node_id = event.transfer.source_node_id
-        if node_id not in self.known_nodes:
-            self.known_nodes[node_id] = {}
-            self.node.request(uavcan.protocol.GetNodeInfo.Request(), node_id, self._response_callback)
-        self.known_nodes[node_id]['status'] = event.message
-
-    def _response_callback(self, event):
-        if not event:
-            raise RuntimeError("Remote call timeout")
-
-        board = event.transfer.source_node_id
-        name = str(event.response.name)
-        self.known_nodes[board]['name'] = name
-
-        if self.on_new_node is not None:
-            self.on_new_node()
 
 class NodeSelectController:
     def __init__(self, model, viewer):

--- a/tools/studio/node_selector.py
+++ b/tools/studio/node_selector.py
@@ -4,7 +4,11 @@ import sys
 import threading
 import time
 import uavcan
+
+from pyqtgraph.Qt import QtCore, QtGui
+
 from network.UavcanNode import UavcanNode
+from viewers.Selector import SelectorWidget
 
 def parse_args():
     parser = argparse.ArgumentParser(description=__doc__)
@@ -14,8 +18,6 @@ def parse_args():
 
     return parser.parse_args()
 
-import pyqtgraph as pg
-from pyqtgraph.Qt import QtCore, QtGui
 class NodeStatusMonitor:
     def __init__(self, node):
         self.known_nodes = {}
@@ -43,29 +45,6 @@ class NodeStatusMonitor:
 
         if self.on_new_node is not None:
             self.on_new_node()
-
-class NodeSelectViewer(QtGui.QWidget):
-    def __init__(self, parent = None):
-        super(NodeSelectViewer, self).__init__(parent)
-
-        layout = QtGui.QHBoxLayout()
-
-        self.combo_box = pg.ComboBox()
-        layout.addWidget(self.combo_box)
-
-        self.setLayout(layout)
-        self.setWindowTitle("Node Selector")
-
-    def set_nodes(self, nodes):
-        try:
-            self.combo_box.clear()
-            self.combo_box.addItems(nodes)
-        except:
-            pass
-        self.combo_box.update()
-
-    def set_callback(self, callback):
-        self.combo_box.currentIndexChanged.connect(callback)
 
 class NodeSelectController:
     def __init__(self, model, viewer):
@@ -97,7 +76,7 @@ def main():
 
     app = QtGui.QApplication(sys.argv)
 
-    controller = NodeSelectController(model=NodeStatusMonitor(node), viewer=NodeSelectViewer())
+    controller = NodeSelectController(model=NodeStatusMonitor(node), viewer=SelectorWidget(title='Node Selector'))
 
     node.spin()
     qt_loop()

--- a/tools/studio/pid_plot.py
+++ b/tools/studio/pid_plot.py
@@ -42,28 +42,89 @@ class PidViewer(QtGui.QWidget):
         self.setWindowTitle("PID Plotter")
         self.show()
 
-class PidPlotController:
-    def __init__(self, node):
-        self.logger = logging.getLogger('PidPlotController')
-        self.node = node
-        self.model = NodeStatusMonitor(node)
-        self.viewer = PidViewer()
-        self.curve = self.viewer.plot.getPort()
+class PidFeedbackRecorder():
+    nodes = []
+    on_new_node_callback = None
+    tracked_node = None
 
-        self.data = self._empty_pid_data()
-        self.node_to_plot = None
+    PID_LOOPS = ['Current', 'Velocity', 'Position']
+    tracked_pid_loop = PID_LOOPS[0]
+
+    EMPTY_DATA = { 'setpoint': { 'time': np.array([]), 'value': np.array([]) },
+                   'measured': { 'time': np.array([]), 'value': np.array([]) }, }
+    data = EMPTY_DATA
+
+    def __init__(self, node):
+        self.logger = logging.getLogger('PidFeedbackRecorder')
+        self.node = node
+        self.data_lock = threading.RLock()
+
+        self.monitor = NodeStatusMonitor(node)
+        self.monitor.set_on_new_node_callback(self._update_nodes)
+
+        self.clear()
         self.node.add_handler(uavcan.thirdparty.cvra.motor.feedback.CurrentPID, self._current_pid_callback)
         self.node.add_handler(uavcan.thirdparty.cvra.motor.feedback.VelocityPID, self._velocity_pid_callback)
         self.node.add_handler(uavcan.thirdparty.cvra.motor.feedback.PositionPID, self._position_pid_callback)
 
-        self.nodes = []
-        self.model.set_on_new_node_callback(self.update_selection)
+    def on_new_node(self, callback):
+        self.on_new_node = callback
+
+    def node_id_to_name(self, node_id):
+        return self.monitor.node_id_to_name(node_id)
+
+    def clear(self):
+        with self.data_lock:
+            self.data = self.EMPTY_DATA
+
+    def _update_nodes(self):
+        known_nodes = self.monitor.known_nodes
+        nodes_with_name = {k: v for k, v in known_nodes.items() if 'name' in v.keys()}
+        self.nodes = list(nodes_with_name[node]['name'] for node in nodes_with_name)
+
+        if self.on_new_node:
+            self.on_new_node()
+
+    def _current_pid_callback(self, event):
+        if self.tracked_pid_loop == 'Current':
+            self._pid_callback(node_id=event.transfer.source_node_id,
+                               setpoint=event.message.current_setpoint,
+                               measured=event.message.current)
+
+    def _velocity_pid_callback(self, event):
+        if self.tracked_pid_loop == 'Velocity':
+            self._pid_callback(node_id=event.transfer.source_node_id,
+                               setpoint=event.message.velocity_setpoint,
+                               measured=event.message.velocity)
+
+    def _position_pid_callback(self, event):
+        if self.tracked_pid_loop == 'Position':
+            self._pid_callback(node_id=event.transfer.source_node_id,
+                               setpoint=event.message.position_setpoint,
+                               measured=event.message.position)
+
+    def _pid_callback(self, node_id, setpoint, measured):
+        node_name = self.monitor.node_id_to_name(node_id)
+        if self.tracked_node is not None and self.tracked_node == node_name:
+            current_time = time.time()
+            self.data['setpoint']['time'] = np.append(self.data['setpoint']['time'], current_time)
+            self.data['measured']['time'] = np.append(self.data['measured']['time'], current_time)
+            self.data['setpoint']['value'] = np.append(self.data['setpoint']['value'], setpoint)
+            self.data['measured']['value'] = np.append(self.data['measured']['value'], measured)
+
+class PidPlotController:
+    def __init__(self, node):
+        self.logger = logging.getLogger('PidPlotController')
+        self.node = node
+        self.model = PidFeedbackRecorder(node)
+        self.viewer = PidViewer()
+        self.curve = self.viewer.plot.getPort()
+
+        self.model.on_new_node(self.update_selection)
 
         self.viewer.node_selector.set_callback(self._change_selected_node)
 
-        self.pid_loops = ['Current', 'Velocity', 'Position']
-        self.pid_loop_to_plot = self.pid_loops[0]
-        self.viewer.pid_loop_selector.set_nodes(self.pid_loops)
+        self.viewer.pid_loop_selector.set_nodes(self.model.PID_LOOPS)
         self.viewer.pid_loop_selector.set_callback(self._change_selected_pid_loop)
 
         threading.Thread(target=self.run).start()
@@ -71,67 +132,22 @@ class PidPlotController:
     def run(self):
         self.logger.info('PID widget started')
         while True:
-            self.curve.put(self.data)
+            self.curve.put(self.model.data)
             time.sleep(0.2)
 
     def update_selection(self):
         self.logger.debug('New node detected, updating available nodes list')
-        known_nodes = self.model.known_nodes
-        nodes_with_name = {k: v for k, v in known_nodes.items() if 'name' in v.keys()}
-        self.nodes = list(nodes_with_name[node]['name'] for node in nodes_with_name)
-        self.viewer.node_selector.set_nodes(self.nodes)
-
-    def _current_pid_callback(self, event):
-        if self.pid_loop_to_plot == 'Current':
-            self._pid_callback(node_id=event.transfer.source_node_id,
-                               setpoint=event.message.current_setpoint,
-                               measured=event.message.current)
-
-    def _velocity_pid_callback(self, event):
-        if self.pid_loop_to_plot == 'Velocity':
-            self._pid_callback(node_id=event.transfer.source_node_id,
-                               setpoint=event.message.velocity_setpoint,
-                               measured=event.message.velocity)
-
-    def _position_pid_callback(self, event):
-        if self.pid_loop_to_plot == 'Position':
-            self._pid_callback(node_id=event.transfer.source_node_id,
-                               setpoint=event.message.position_setpoint,
-                               measured=event.message.position)
-
-    def _pid_callback(self, node_id, setpoint, measured):
-        node_name = self.model.node_id_to_name(node_id)
-
-        if self.node_to_plot is None or self.node_to_plot != node_name:
-            return
-
-        current_time = time.time()
-        self.data['setpoint']['time'] = np.append(self.data['setpoint']['time'], current_time)
-        self.data['measured']['time'] = np.append(self.data['measured']['time'], current_time)
-        self.data['setpoint']['value'] = np.append(self.data['setpoint']['value'], setpoint)
-        self.data['measured']['value'] = np.append(self.data['measured']['value'], measured)
+        self.viewer.node_selector.set_nodes(self.model.nodes)
 
     def _change_selected_node(self, i):
-        self.node_to_plot = self.nodes[i]
-        self.data = self._empty_pid_data()
-        self.logger.info('Selected node {}'.format(self.node_to_plot))
+        self.model.tracked_node = self.model.nodes[i]
+        self.model.clear()
+        self.logger.info('Selected node {}'.format(self.model.tracked_node))
 
     def _change_selected_pid_loop(self, i):
-        self.pid_loop_to_plot = self.pid_loops[i]
-        self.data = self._empty_pid_data()
-        self.logger.info('Selected PID loop {}'.format(self.pid_loop_to_plot))
-
-    def _empty_pid_data(self):
-        return {
-            'setpoint': {
-                'time': np.array([]),
-                'value': np.array([]),
-            },
-            'measured': {
-                'time': np.array([]),
-                'value': np.array([]),
-            },
-        }
+        self.model.tracked_pid_loop = self.model.PID_LOOPS[i]
+        self.model.clear()
+        self.logger.info('Selected PID loop {}'.format(self.model.tracked_pid_loop))
 
 def main():
     args = parse_args()

--- a/tools/studio/pid_plot.py
+++ b/tools/studio/pid_plot.py
@@ -18,6 +18,7 @@ def parse_args():
     parser.add_argument("interface", help="Serial port or SocketCAN interface")
     parser.add_argument("--dsdl", "-d", help="DSDL path", required=True)
     parser.add_argument("--node_id", "-n", help="UAVCAN Node ID", default=127)
+    parser.add_argument('--verbose', '-v', action='count', default=0)
 
     return parser.parse_args()
 
@@ -135,7 +136,7 @@ class PidPlotController:
 
 def main():
     args = parse_args()
-    logging.basicConfig(level=logging.INFO)
+    logging.basicConfig(level=max(logging.CRITICAL - (10 * args.verbose), 0))
 
     uavcan.load_dsdl(args.dsdl)
     node = UavcanNode(interface=args.interface, node_id=args.node_id)

--- a/tools/studio/pid_plot.py
+++ b/tools/studio/pid_plot.py
@@ -1,0 +1,143 @@
+import argparse
+import sys
+import threading
+import time
+import uavcan
+
+import numpy as np
+import pyqtgraph as pg
+from pyqtgraph.Qt import QtCore, QtGui
+
+from network.UavcanNode import UavcanNode
+from viewers.LivePlotter import LivePlotter
+from viewers.Selector import Selector
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("interface", help="Serial port or SocketCAN interface")
+    parser.add_argument("--dsdl", "-d", help="DSDL path", required=True)
+    parser.add_argument("--node_id", "-n", help="UAVCAN Node ID", default=127)
+
+    return parser.parse_args()
+
+class PidViewer(QtGui.QWidget):
+    def __init__(self, parent = None):
+        super(PidViewer, self).__init__(parent)
+
+        layout = QtGui.QVBoxLayout()
+
+        self.node_selector = Selector()
+        layout.addWidget(self.node_selector)
+        self.plot = LivePlotter(buffer_size=30)
+        layout.addWidget(self.plot.widget)
+
+        self.setLayout(layout)
+        self.setWindowTitle("PID Plotter")
+        self.show()
+
+class NodeStatusMonitor:
+    def __init__(self, node):
+        self.known_nodes = {}
+        self.node = node
+        self.node.add_handler(uavcan.protocol.NodeStatus, self._node_status_callback)
+        self.on_new_node = None
+
+    def set_on_new_node_callback(self, on_new_node):
+        self.on_new_node = on_new_node
+
+    def node_id_to_name(self, node_id):
+        if node_id in self.known_nodes.keys():
+            if 'name' in self.known_nodes[node_id].keys():
+                return self.known_nodes[node_id]['name']
+        return None
+
+    def _node_status_callback(self, event):
+        node_id = event.transfer.source_node_id
+        if node_id not in self.known_nodes:
+            self.known_nodes[node_id] = {}
+            self.node.request(uavcan.protocol.GetNodeInfo.Request(), node_id, self._response_callback)
+        self.known_nodes[node_id]['status'] = event.message
+
+    def _response_callback(self, event):
+        if not event:
+            raise RuntimeError("Remote call timeout")
+
+        board = event.transfer.source_node_id
+        name = str(event.response.name)
+        self.known_nodes[board]['name'] = name
+
+        if self.on_new_node is not None:
+            self.on_new_node()
+
+class PidPlotController:
+    def __init__(self, model, viewer):
+        self.model = model
+        self.viewer = viewer
+        self.curve = self.viewer.plot.getPort()
+
+        self.data = self._empty_pid_data()
+        self.node_to_plot = None
+        self.model.node.add_handler(uavcan.thirdparty.cvra.motor.feedback.CurrentPID, self._current_pid_callback)
+
+        self.nodes = []
+        self.model.set_on_new_node_callback(self.update_selection)
+
+        self.viewer.node_selector.set_callback(self._change_selected_node)
+
+        threading.Thread(target=self.run).start()
+
+    def run(self):
+        while True:
+            self.curve.put(self.data)
+            time.sleep(1)
+
+    def update_selection(self):
+        known_nodes = self.model.known_nodes
+        nodes_with_name = {k: v for k, v in known_nodes.items() if 'name' in v.keys()}
+        self.nodes = list(nodes_with_name[node]['name'] for node in nodes_with_name)
+        self.viewer.node_selector.set_nodes(self.nodes)
+
+    def _current_pid_callback(self, event):
+        node_id = event.transfer.source_node_id
+        if self.node_to_plot is not None and self.node_to_plot == self.model.node_id_to_name(node_id):
+            self.data['setpoint']['time'] = np.append(self.data['setpoint']['time'], time.time())
+            self.data['measured']['time'] = np.append(self.data['measured']['time'], time.time())
+
+            self.data['setpoint']['value'] = np.append(self.data['setpoint']['value'], event.message.current_setpoint)
+            self.data['measured']['value'] = np.append(self.data['measured']['value'], event.message.current)
+
+    def _change_selected_node(self, i):
+        print("Current index", i, "selection changed to", self.nodes[i])
+        self.node_to_plot = self.nodes[i]
+        self.data = self._empty_pid_data()
+
+    def _empty_pid_data(self):
+        return {
+            'setpoint': {
+                'time': np.array([]),
+                'value': np.array([]),
+            },
+            'measured': {
+                'time': np.array([]),
+                'value': np.array([]),
+            },
+        }
+
+def main():
+    args = parse_args()
+    uavcan.load_dsdl(args.dsdl)
+
+    node = UavcanNode(interface=args.interface, node_id=args.node_id)
+
+    app = QtGui.QApplication(sys.argv)
+    app.setFont(QtGui.QFont('Open Sans', pointSize=20))
+
+    controller = PidPlotController(model=NodeStatusMonitor(node), viewer=PidViewer())
+
+    node.spin()
+
+    if (sys.flags.interactive != 1) or not hasattr(QtCore, 'PYQT_VERSION'):
+        QtGui.QApplication.instance().exec_()
+
+if __name__ == '__main__':
+    main()

--- a/tools/studio/pid_plot.py
+++ b/tools/studio/pid_plot.py
@@ -31,7 +31,11 @@ class PidViewer(QtGui.QWidget):
 
         self.node_selector = Selector()
         layout.addWidget(self.node_selector)
-        self.plot = LivePlotter(buffer_size=30)
+
+        self.pid_loop_selector = Selector()
+        layout.addWidget(self.pid_loop_selector)
+
+        self.plot = LivePlotter(buffer_size=300)
         layout.addWidget(self.plot.widget)
 
         self.setLayout(layout)
@@ -39,20 +43,28 @@ class PidViewer(QtGui.QWidget):
         self.show()
 
 class PidPlotController:
-    def __init__(self, model, viewer):
+    def __init__(self, node):
         self.logger = logging.getLogger('PidPlotController')
-        self.model = model
-        self.viewer = viewer
+        self.node = node
+        self.model = NodeStatusMonitor(node)
+        self.viewer = PidViewer()
         self.curve = self.viewer.plot.getPort()
 
         self.data = self._empty_pid_data()
         self.node_to_plot = None
-        self.model.node.add_handler(uavcan.thirdparty.cvra.motor.feedback.CurrentPID, self._current_pid_callback)
+        self.node.add_handler(uavcan.thirdparty.cvra.motor.feedback.CurrentPID, self._current_pid_callback)
+        self.node.add_handler(uavcan.thirdparty.cvra.motor.feedback.VelocityPID, self._velocity_pid_callback)
+        self.node.add_handler(uavcan.thirdparty.cvra.motor.feedback.PositionPID, self._position_pid_callback)
 
         self.nodes = []
         self.model.set_on_new_node_callback(self.update_selection)
 
         self.viewer.node_selector.set_callback(self._change_selected_node)
+
+        self.pid_loops = ['Current', 'Velocity', 'Position']
+        self.pid_loop_to_plot = self.pid_loops[0]
+        self.viewer.pid_loop_selector.set_nodes(self.pid_loops)
+        self.viewer.pid_loop_selector.set_callback(self._change_selected_pid_loop)
 
         threading.Thread(target=self.run).start()
 
@@ -60,7 +72,7 @@ class PidPlotController:
         self.logger.info('PID widget started')
         while True:
             self.curve.put(self.data)
-            time.sleep(1)
+            time.sleep(0.2)
 
     def update_selection(self):
         self.logger.debug('New node detected, updating available nodes list')
@@ -70,21 +82,44 @@ class PidPlotController:
         self.viewer.node_selector.set_nodes(self.nodes)
 
     def _current_pid_callback(self, event):
-        node_id = event.transfer.source_node_id
-        node_name = self.model.node_id_to_name(node_id)
-        self.logger.debug('Received current PID feedback from node {} ({})'.format(node_name, node_id))
-        if self.node_to_plot is not None and self.node_to_plot == node_name:
-            self.data['setpoint']['time'] = np.append(self.data['setpoint']['time'], time.time())
-            self.data['measured']['time'] = np.append(self.data['measured']['time'], time.time())
+        if self.pid_loop_to_plot == 'Current':
+            self._pid_callback(node_id=event.transfer.source_node_id,
+                               setpoint=event.message.current_setpoint,
+                               measured=event.message.current)
 
-            self.data['setpoint']['value'] = np.append(self.data['setpoint']['value'], event.message.current_setpoint)
-            self.data['measured']['value'] = np.append(self.data['measured']['value'], event.message.current)
+    def _velocity_pid_callback(self, event):
+        if self.pid_loop_to_plot == 'Velocity':
+            self._pid_callback(node_id=event.transfer.source_node_id,
+                               setpoint=event.message.velocity_setpoint,
+                               measured=event.message.velocity)
+
+    def _position_pid_callback(self, event):
+        if self.pid_loop_to_plot == 'Position':
+            self._pid_callback(node_id=event.transfer.source_node_id,
+                               setpoint=event.message.position_setpoint,
+                               measured=event.message.position)
+
+    def _pid_callback(self, node_id, setpoint, measured):
+        node_name = self.model.node_id_to_name(node_id)
+
+        if self.node_to_plot is None or self.node_to_plot != node_name:
+            return
+
+        current_time = time.time()
+        self.data['setpoint']['time'] = np.append(self.data['setpoint']['time'], current_time)
+        self.data['measured']['time'] = np.append(self.data['measured']['time'], current_time)
+        self.data['setpoint']['value'] = np.append(self.data['setpoint']['value'], setpoint)
+        self.data['measured']['value'] = np.append(self.data['measured']['value'], measured)
 
     def _change_selected_node(self, i):
-        self.logger.debug('Current index {} selection changed to {}'.format(i, self.nodes[i]))
         self.node_to_plot = self.nodes[i]
         self.data = self._empty_pid_data()
         self.logger.info('Selected node {}'.format(self.node_to_plot))
+
+    def _change_selected_pid_loop(self, i):
+        self.pid_loop_to_plot = self.pid_loops[i]
+        self.data = self._empty_pid_data()
+        self.logger.info('Selected PID loop {}'.format(self.pid_loop_to_plot))
 
     def _empty_pid_data(self):
         return {
@@ -102,13 +137,13 @@ def main():
     args = parse_args()
     logging.basicConfig(level=max(logging.CRITICAL - (10 * args.verbose), 0))
 
-    uavcan.load_dsdl(args.dsdl)
-    node = UavcanNode(interface=args.interface, node_id=args.node_id)
-
     app = QtGui.QApplication(sys.argv)
     app.setFont(QtGui.QFont('Open Sans', pointSize=20))
 
-    controller = PidPlotController(model=NodeStatusMonitor(node), viewer=PidViewer())
+    uavcan.load_dsdl(args.dsdl)
+    node = UavcanNode(interface=args.interface, node_id=args.node_id)
+
+    controller = PidPlotController(node=node)
 
     node.spin()
 

--- a/tools/studio/pid_plot.py
+++ b/tools/studio/pid_plot.py
@@ -10,6 +10,7 @@ import pyqtgraph as pg
 from pyqtgraph.Qt import QtCore, QtGui
 
 from network.UavcanNode import UavcanNode
+from network.NodeStatusMonitor import NodeStatusMonitor
 from viewers.LivePlotter import LivePlotter
 from viewers.Selector import Selector
 
@@ -36,43 +37,6 @@ class PidViewer(QtGui.QWidget):
         self.setLayout(layout)
         self.setWindowTitle("PID Plotter")
         self.show()
-
-class NodeStatusMonitor:
-    def __init__(self, node):
-        self.logger = logging.getLogger('NodeStatusMonitor')
-        self.known_nodes = {}
-        self.node = node
-        self.node.add_handler(uavcan.protocol.NodeStatus, self._node_status_callback)
-        self.on_new_node = None
-
-    def set_on_new_node_callback(self, on_new_node):
-        self.on_new_node = on_new_node
-
-    def node_id_to_name(self, node_id):
-        if node_id in self.known_nodes.keys():
-            if 'name' in self.known_nodes[node_id].keys():
-                return self.known_nodes[node_id]['name']
-        return None
-
-    def _node_status_callback(self, event):
-        node_id = event.transfer.source_node_id
-        if node_id not in self.known_nodes:
-            self.known_nodes[node_id] = {}
-            self.node.request(uavcan.protocol.GetNodeInfo.Request(), node_id, self._response_callback)
-        self.known_nodes[node_id]['status'] = event.message
-
-    def _response_callback(self, event):
-        if not event:
-            raise RuntimeError("Remote call timeout")
-
-        board = event.transfer.source_node_id
-        name = str(event.response.name)
-        self.known_nodes[board]['name'] = name
-        self.logger.info('Detected new node {} ({})'.format(self.known_nodes[board]['name'], board))
-
-        if self.on_new_node is not None:
-            self.on_new_node()
-
 
 class PidPlotController:
     def __init__(self, model, viewer):

--- a/tools/studio/plot.py
+++ b/tools/studio/plot.py
@@ -25,14 +25,14 @@ class QtPlotter:
     def update(self):
         for q, plt in self.ports:
             try:
-                data, color = q.get(block=False)
+                data = q.get(block=False)
                 plt.clear()
                 for index, variable in enumerate(data['data']):
                     plt.plot(
                         np.asarray(data['time'][-self.buffer_size:]).flatten(),
                         np.asarray(data['data'][str(variable)][-self.buffer_size:]).flatten(),
                         pen=(index, len(data['data'])), symbol="o",
-                        symbolPen=pg.mkPen({'color': color, 'width': 2}),
+                        symbolPen=pg.mkPen({'color': "#00FFFF", 'width': 2}),
                         symbolSize=1
                     )
             except queue.Empty:
@@ -73,7 +73,7 @@ class Controller:
 
     def run(self):
         while True:
-            self.curve.put((self.model.get_data(), "#00FFFF"))
+            self.curve.put(self.model.get_data())
             time.sleep(1)
 
 def main():

--- a/tools/studio/plot.py
+++ b/tools/studio/plot.py
@@ -28,8 +28,8 @@ class QtPlotter:
                 data, color = q.get(block=False)
                 plt.clear()
                 plt.setData(
-                    np.asarray(data[0, :]).flatten(),
-                    np.asarray(data[1, :]).flatten(), pen=None, symbol="o",
+                    np.asarray(data['x']).flatten(),
+                    np.asarray(data['y']).flatten(), pen=(1,1), symbol="o",
                     symbolPen=pg.mkPen({'color': color, 'width': 2}),
                     symbolSize=1
                 )
@@ -42,8 +42,13 @@ def qt_loop():
         QtGui.QApplication.instance().exec_()
 
 class Model:
-    def data(self):
-        return np.random.random(size=(2, 10))
+    def __init__(self):
+        self.data = {'x': np.array([0]), 'y': np.array([0])}
+
+    def get_data(self):
+        self.data['x'] = np.append(self.data['x'], self.data['x'][-1] + 1)
+        self.data['y'] = np.append(self.data['y'], np.random.random(size=(1,1)))
+        return self.data
 
 class Controller:
     def __init__(self):
@@ -54,7 +59,7 @@ class Controller:
 
     def run(self):
         while True:
-            self.curve.put((self.model.data(), "#00FFFF"))
+            self.curve.put((self.model.get_data(), "#00FFFF"))
             time.sleep(1)
 
 def main():

--- a/tools/studio/plot.py
+++ b/tools/studio/plot.py
@@ -1,15 +1,12 @@
-import numpy as np
-import pyqtgraph as pg
-from pyqtgraph.Qt import QtCore, QtGui
 import queue
 import threading
 import time
-from viewers.QtPlotter import QtPlotter
 
-def qt_loop():
-    import sys
-    if (sys.flags.interactive != 1) or not hasattr(QtCore, 'PYQT_VERSION'):
-        QtGui.QApplication.instance().exec_()
+import numpy as np
+import pyqtgraph as pg
+from pyqtgraph.Qt import QtCore, QtGui
+
+from viewers.LivePlotter import LivePlotter
 
 class Model:
     def __init__(self):
@@ -38,10 +35,11 @@ class Model:
 
 class Controller:
     def __init__(self):
-        self.viewer = QtPlotter(buffer_size=100)
+        self.viewer = LivePlotter(buffer_size=100)
         self.curve = self.viewer.getPort()
         self.model = Model()
         threading.Thread(target=self.run).start()
+        self.viewer.widget.show()
 
     def run(self):
         while True:
@@ -49,8 +47,14 @@ class Controller:
             time.sleep(1)
 
 def main():
+    import sys
+    app = QtGui.QApplication(sys.argv)
+
     plot_controller = Controller()
-    qt_loop()
+
+    if (sys.flags.interactive != 1) or not hasattr(QtCore, 'PYQT_VERSION'):
+        QtGui.QApplication.instance().exec_()
+
 
 if __name__ == "__main__":
     main()

--- a/tools/studio/plot.py
+++ b/tools/studio/plot.py
@@ -1,0 +1,61 @@
+import numpy as np
+import pyqtgraph as pg
+from pyqtgraph.Qt import QtCore, QtGui
+import queue
+from threading import Thread
+
+class QtPlotter:
+    def __init__(self):
+        self.ports = []
+        self.timer = pg.QtCore.QTimer()
+        self.win = pg.GraphicsWindow()
+        self.ax = self.win.addPlot()
+        self.timer.timeout.connect(self.update)
+        self.timer.start(0)
+        self.ax.setAspectLocked(True)
+
+    def getPort(self):
+        q = queue.Queue()
+        plt = self.ax.plot()
+
+        self.ports.append((q, plt))
+        return q
+
+    def update(self):
+        for q, plt in self.ports:
+            try:
+                data, color = q.get(block=False)
+                plt.clear()
+                plt.setData(
+                    np.asarray(data[0, :]).flatten(),
+                    np.asarray(data[1, :]).flatten(), pen=None, symbol="o",
+                    symbolPen=pg.mkPen({'color': color, 'width': 2}),
+                    symbolSize=1
+                )
+            except queue.Empty:
+                pass
+
+def qtLoop():
+    import sys
+    if (sys.flags.interactive != 1) or not hasattr(QtCore, 'PYQT_VERSION'):
+        QtGui.QApplication.instance().exec_()
+
+
+def example():
+    import time
+    plotter = QtPlotter()
+    curve = plotter.getPort()
+
+    def producer():
+        while True:
+            curve.put((np.random.random(size=(2, 10)), "#00FFFF"))
+            time.sleep(1)
+
+    p = Thread(target=producer)
+    p.daemon = True
+    p.start()
+
+    qtLoop()
+
+if __name__ == "__main__":
+    example()

--- a/tools/studio/plot.py
+++ b/tools/studio/plot.py
@@ -27,11 +27,11 @@ class QtPlotter:
             try:
                 data = q.get(block=False)
                 plt.clear()
-                for index, variable in enumerate(data['data']):
+                for index, variable in enumerate(data):
                     plt.plot(
-                        np.asarray(data['time'][-self.buffer_size:]).flatten(),
-                        np.asarray(data['data'][str(variable)][-self.buffer_size:]).flatten(),
-                        pen=(index, len(data['data'])), symbol="o",
+                        np.asarray(data[variable]['time'][-self.buffer_size:]).flatten(),
+                        np.asarray(data[variable]['value'][-self.buffer_size:]).flatten(),
+                        pen=(index, len(data)), symbol="o",
                         symbolPen=pg.mkPen({'color': "#00FFFF", 'width': 2}),
                         symbolSize=1
                     )
@@ -46,11 +46,14 @@ def qt_loop():
 class Model:
     def __init__(self):
         self.data = {
-            'time': np.array([0]),
-            'data': {
-                'x': np.array([0]),
-                'y': np.array([0]),
-            }
+            'x': {
+                'time': np.array([0]),
+                'value': np.array([0]),
+            },
+            'y': {
+                'time': np.array([0]),
+                'value': np.array([0]),
+            },
         }
         threading.Thread(target=self.run).start()
 
@@ -59,9 +62,10 @@ class Model:
 
     def run(self):
         while True:
-            self.data['time'] = np.append(self.data['time'], self.data['time'][-1] + 0.1)
-            self.data['data']['x'] = np.append(self.data['data']['x'], np.random.random(size=(1,1)))
-            self.data['data']['y'] = np.append(self.data['data']['y'], np.random.random(size=(1,1)))
+            self.data['x']['time'] = np.append(self.data['x']['time'], self.data['x']['time'][-1] + 0.1)
+            self.data['y']['time'] = np.append(self.data['y']['time'], self.data['y']['time'][-1] + 0.1)
+            self.data['x']['value'] = np.append(self.data['x']['value'], np.random.random(size=(1,1)))
+            self.data['y']['value'] = np.append(self.data['y']['value'], np.random.random(size=(1,1)))
             time.sleep(0.1)
 
 class Controller:

--- a/tools/studio/plot.py
+++ b/tools/studio/plot.py
@@ -18,8 +18,7 @@ class QtPlotter:
 
     def getPort(self):
         q = queue.Queue()
-        plt = self.ax.plot()
-
+        plt = self.ax
         self.ports.append((q, plt))
         return q
 
@@ -28,12 +27,14 @@ class QtPlotter:
             try:
                 data, color = q.get(block=False)
                 plt.clear()
-                plt.setData(
-                    np.asarray(data['time'][-self.buffer_size:]).flatten(),
-                    np.asarray(data['data'][-self.buffer_size:]).flatten(), pen=(1,1), symbol="o",
-                    symbolPen=pg.mkPen({'color': color, 'width': 2}),
-                    symbolSize=1
-                )
+                for index, variable in enumerate(data['data']):
+                    plt.plot(
+                        np.asarray(data['time'][-self.buffer_size:]).flatten(),
+                        np.asarray(data['data'][str(variable)][-self.buffer_size:]).flatten(),
+                        pen=(index, len(data['data'])), symbol="o",
+                        symbolPen=pg.mkPen({'color': color, 'width': 2}),
+                        symbolSize=1
+                    )
             except queue.Empty:
                 pass
 
@@ -44,7 +45,13 @@ def qt_loop():
 
 class Model:
     def __init__(self):
-        self.data = {'time': np.array([0]), 'data': np.array([0])}
+        self.data = {
+            'time': np.array([0]),
+            'data': {
+                'x': np.array([0]),
+                'y': np.array([0]),
+            }
+        }
         threading.Thread(target=self.run).start()
 
     def get_data(self):
@@ -52,8 +59,9 @@ class Model:
 
     def run(self):
         while True:
-            self.data['time'] = np.append(self.data['time'], self.data['time'][-1] + 1)
-            self.data['data'] = np.append(self.data['data'], np.random.random(size=(1,1)))
+            self.data['time'] = np.append(self.data['time'], self.data['time'][-1] + 0.1)
+            self.data['data']['x'] = np.append(self.data['data']['x'], np.random.random(size=(1,1)))
+            self.data['data']['y'] = np.append(self.data['data']['y'], np.random.random(size=(1,1)))
             time.sleep(0.1)
 
 class Controller:

--- a/tools/studio/plot.py
+++ b/tools/studio/plot.py
@@ -2,7 +2,8 @@ import numpy as np
 import pyqtgraph as pg
 from pyqtgraph.Qt import QtCore, QtGui
 import queue
-from threading import Thread
+import threading
+import time
 
 class QtPlotter:
     def __init__(self):
@@ -35,27 +36,30 @@ class QtPlotter:
             except queue.Empty:
                 pass
 
-def qtLoop():
+def qt_loop():
     import sys
     if (sys.flags.interactive != 1) or not hasattr(QtCore, 'PYQT_VERSION'):
         QtGui.QApplication.instance().exec_()
 
+class Model:
+    def data(self):
+        return np.random.random(size=(2, 10))
 
-def example():
-    import time
-    plotter = QtPlotter()
-    curve = plotter.getPort()
+class Controller:
+    def __init__(self):
+        self.viewer = QtPlotter()
+        self.curve = self.viewer.getPort()
+        self.model = Model()
+        threading.Thread(target=self.run).start()
 
-    def producer():
+    def run(self):
         while True:
-            curve.put((np.random.random(size=(2, 10)), "#00FFFF"))
+            self.curve.put((self.model.data(), "#00FFFF"))
             time.sleep(1)
 
-    p = Thread(target=producer)
-    p.daemon = True
-    p.start()
-
-    qtLoop()
+def main():
+    plot_controller = Controller()
+    qt_loop()
 
 if __name__ == "__main__":
-    example()
+    main()

--- a/tools/studio/plot.py
+++ b/tools/studio/plot.py
@@ -4,39 +4,7 @@ from pyqtgraph.Qt import QtCore, QtGui
 import queue
 import threading
 import time
-
-class QtPlotter:
-    def __init__(self, buffer_size):
-        self.ports = []
-        self.timer = pg.QtCore.QTimer()
-        self.win = pg.GraphicsWindow()
-        self.ax = self.win.addPlot()
-        self.timer.timeout.connect(self.update)
-        self.timer.start(0)
-        self.ax.setAspectLocked(True)
-        self.buffer_size = buffer_size
-
-    def getPort(self):
-        q = queue.Queue()
-        plt = self.ax
-        self.ports.append((q, plt))
-        return q
-
-    def update(self):
-        for q, plt in self.ports:
-            try:
-                data = q.get(block=False)
-                plt.clear()
-                for index, variable in enumerate(data):
-                    plt.plot(
-                        np.asarray(data[variable]['time'][-self.buffer_size:]).flatten(),
-                        np.asarray(data[variable]['value'][-self.buffer_size:]).flatten(),
-                        pen=(index, len(data)), symbol="o",
-                        symbolPen=pg.mkPen({'color': "#00FFFF", 'width': 2}),
-                        symbolSize=1
-                    )
-            except queue.Empty:
-                pass
+from viewers.QtPlotter import QtPlotter
 
 def qt_loop():
     import sys

--- a/tools/studio/requirements.txt
+++ b/tools/studio/requirements.txt
@@ -1,0 +1,6 @@
+monotonic==1.4
+numpy==1.13.3
+PyQt5==5.10
+pyqtgraph==0.10.0
+sip==4.19.7
+uavcan==1.0.0.dev29

--- a/tools/studio/viewers/LivePlotter.py
+++ b/tools/studio/viewers/LivePlotter.py
@@ -3,12 +3,12 @@ import pyqtgraph as pg
 from pyqtgraph.Qt import QtCore
 import queue
 
-class QtPlotter:
+class LivePlotter:
     def __init__(self, buffer_size):
         self.ports = []
         self.timer = pg.QtCore.QTimer()
-        self.win = pg.GraphicsWindow()
-        self.ax = self.win.addPlot()
+        self.widget = pg.PlotWidget()
+        self.ax = self.widget.getPlotItem()
         self.timer.timeout.connect(self.update)
         self.timer.start(0)
         self.ax.setAspectLocked(True)

--- a/tools/studio/viewers/LivePlotter.py
+++ b/tools/studio/viewers/LivePlotter.py
@@ -1,7 +1,8 @@
+import queue
+
 import numpy as np
 import pyqtgraph as pg
 from pyqtgraph.Qt import QtCore
-import queue
 
 class LivePlotter:
     def __init__(self, buffer_size):

--- a/tools/studio/viewers/QtPlotter.py
+++ b/tools/studio/viewers/QtPlotter.py
@@ -1,0 +1,37 @@
+import numpy as np
+import pyqtgraph as pg
+from pyqtgraph.Qt import QtCore
+import queue
+
+class QtPlotter:
+    def __init__(self, buffer_size):
+        self.ports = []
+        self.timer = pg.QtCore.QTimer()
+        self.win = pg.GraphicsWindow()
+        self.ax = self.win.addPlot()
+        self.timer.timeout.connect(self.update)
+        self.timer.start(0)
+        self.ax.setAspectLocked(True)
+        self.buffer_size = buffer_size
+
+    def getPort(self):
+        q = queue.Queue()
+        plt = self.ax
+        self.ports.append((q, plt))
+        return q
+
+    def update(self):
+        for q, plt in self.ports:
+            try:
+                data = q.get(block=False)
+                plt.clear()
+                for index, variable in enumerate(data):
+                    plt.plot(
+                        np.asarray(data[variable]['time'][-self.buffer_size:]).flatten(),
+                        np.asarray(data[variable]['value'][-self.buffer_size:]).flatten(),
+                        pen=(index, len(data)), symbol="o",
+                        symbolPen=pg.mkPen({'color': "#00FFFF", 'width': 2}),
+                        symbolSize=1
+                    )
+            except queue.Empty:
+                pass

--- a/tools/studio/viewers/QtPlotter.py
+++ b/tools/studio/viewers/QtPlotter.py
@@ -12,6 +12,7 @@ class QtPlotter:
         self.timer.timeout.connect(self.update)
         self.timer.start(0)
         self.ax.setAspectLocked(True)
+        self.ax.addLegend()
         self.buffer_size = buffer_size
 
     def getPort(self):
@@ -24,11 +25,16 @@ class QtPlotter:
         for q, plt in self.ports:
             try:
                 data = q.get(block=False)
+
                 plt.clear()
+                self.ax.legend.scene().removeItem(self.ax.legend)
+
+                self.ax.addLegend()
                 for index, variable in enumerate(data):
                     plt.plot(
                         np.asarray(data[variable]['time'][-self.buffer_size:]).flatten(),
                         np.asarray(data[variable]['value'][-self.buffer_size:]).flatten(),
+                        name=variable,
                         pen=(index, len(data)), symbol="o",
                         symbolPen=pg.mkPen({'color': "#00FFFF", 'width': 2}),
                         symbolSize=1

--- a/tools/studio/viewers/Selector.py
+++ b/tools/studio/viewers/Selector.py
@@ -1,0 +1,34 @@
+from pyqtgraph.Qt import QtGui
+
+class Selector(QtGui.QComboBox):
+    def __init__(self):
+        super(Selector, self).__init__()
+
+    def set_nodes(self, nodes):
+        try:
+            self.clear()
+            self.addItems(nodes)
+        except:
+            pass
+        self.update()
+
+    def set_callback(self, callback):
+        self.currentIndexChanged.connect(callback)
+
+class SelectorWidget(QtGui.QWidget):
+    def __init__(self, parent=None, title=''):
+        super(SelectorWidget, self).__init__(parent)
+
+        layout = QtGui.QHBoxLayout()
+
+        self.node_selector = Selector()
+        layout.addWidget(self.node_selector)
+
+        self.setLayout(layout)
+        self.setWindowTitle(title)
+
+    def set_nodes(self, nodes):
+        self.node_selector.set_nodes(nodes)
+
+    def set_callback(self, callback):
+        self.node_selector.set_callback(callback)


### PR DESCRIPTION
This PR adds a live plotter that can plot any dictionary of time series in the form of 
```py
data = {
    'variable': {
        'time': np.array([1, 2, 3, ...]),
        'value': np.array([0, 1, 0, ...])
    },
}
```
fed to the plotter via queue.
This viewer is tied to a PID feedback listener that tracks all motors on the CAN bus and subscribes to the three PID loop feedback messages.

The result looks like this
[![](https://s1.webmshare.com/t/GmbG8.jpg)](https://webmshare.com/play/GmbG8)

Things to do after this PR:
- [ ] Add a widget for parameter display and update before we have a fully functional PID tuner. I think I'll go for a generic parameter handler so we can set all board parameters.
- [ ] Make a proper python package out of this.
- [ ] Add support for messages from the master board (either over Protobuf+UDP or UAVCAN+CAN). And plot the robot position on a map for example.
