### PR TITLE
Arm blocking detection

### DIFF
--- a/master-firmware/package.yml
+++ b/master-firmware/package.yml
@@ -136,6 +136,7 @@ tests:
     - tests/test_base_helpers.cpp
     - tests/test_strategy_helpers.cpp
     - tests/test_strategy.cpp
+    - tests/aversive/test_blocking_detection_manager.cpp
 
 templates:
     app_src.mk.jinja: app_src.mk

--- a/master-firmware/src/arms/arm_trajectory_manager.h
+++ b/master-firmware/src/arms/arm_trajectory_manager.h
@@ -13,10 +13,10 @@ extern "C" {
 #define ARM_TRAJ_MANAGER_FREQUENCY 20
 
 enum arm_traj_state {
-    ARM_READY=0,    /** Done, waiting for new goal */
-    ARM_MOVING,     /** Moving towards goal */
-    ARM_BLOCKED_XY, /** Blocked in xy plane, can't reach target position */
-    ARM_BLOCKED_Z, /** Blocked in z axis, can't reach target position */
+    ARM_READY       = (1u << 0), /** Done, waiting for new goal */
+    ARM_MOVING      = (1u << 1), /** Moving towards goal */
+    ARM_BLOCKED_XY  = (1u << 2), /** Blocked in xy plane, can't reach target position */
+    ARM_BLOCKED_Z   = (1u << 3), /** Blocked in z axis, can't reach target position */
 };
 
 struct arm_traj_manager {
@@ -38,7 +38,20 @@ void arm_traj_manager_set_blocking_detection_xy(struct arm_traj_manager *manager
                                                 int error_count_threshold);
 void arm_traj_manager_set_blocking_detection_z(struct arm_traj_manager *manager, int error_threshold_mm,
                                                int error_count_threshold);
+
 void arm_traj_wait_for_end(void);
+
+/** Returns when ongoing arm trajectory is finished for the reasons specified
+ *  For example when goal is reached (i.e. arm ready for next command)
+ * @note This is a blocking function call
+ * @warning Will not return if you misspecify the reasons to watch
+ *          (ie. the reason watched never occurs)
+ *
+ * @param watched_events bitmask of the end reasons to watch for
+ *
+ * @return arm trajectory event that caused end
+ */
+int arm_traj_wait_for_event(int watched_events);
 
 void arm_trajectory_manager_start(scara_t* arm);
 

--- a/master-firmware/src/arms/arm_trajectory_manager.h
+++ b/master-firmware/src/arms/arm_trajectory_manager.h
@@ -5,6 +5,8 @@
 extern "C" {
 #endif
 
+#include "blocking_detection_manager/blocking_detection_manager.h"
+
 #include "scara/scara_waypoint.h"
 #include "scara/scara.h"
 
@@ -13,12 +15,17 @@ extern "C" {
 enum arm_traj_state {
     ARM_READY=0,    /** Done, waiting for new goal */
     ARM_MOVING,     /** Moving towards goal */
+    ARM_BLOCKED_XY, /** Blocked in xy plane, can't reach target position */
+    ARM_BLOCKED_Z, /** Blocked in z axis, can't reach target position */
 };
 
 struct arm_traj_manager {
     enum arm_traj_state state;  /** Status of the arm, either following a
                                     trajectory or waiting for the next goal. */
     position_3d_t tol_mm;       /** Tolerance on x/y/z position in mm */
+
+    struct blocking_detection blocking_detection_manager_xy; // Blocking detection in xy plane
+    struct blocking_detection blocking_detection_manager_z;  // Blocking detection in z axis
 };
 
 extern struct arm_traj_manager main_arm_traj_manager;
@@ -27,6 +34,10 @@ void arm_traj_manager_init(struct arm_traj_manager* manager);
 void arm_traj_manager_set_tolerances(struct arm_traj_manager *manager,
                                      float x_tol_mm, float y_tol_mm,
                                      float z_tol_mm);
+void arm_traj_manager_set_blocking_detection_xy(struct arm_traj_manager *manager, int error_threshold_mm,
+                                                int error_count_threshold);
+void arm_traj_manager_set_blocking_detection_z(struct arm_traj_manager *manager, int error_threshold_mm,
+                                               int error_count_threshold);
 void arm_traj_wait_for_end(void);
 
 void arm_trajectory_manager_start(scara_t* arm);

--- a/master-firmware/src/aversive/blocking_detection_manager/blocking_detection_manager.c
+++ b/master-firmware/src/aversive/blocking_detection_manager/blocking_detection_manager.c
@@ -31,10 +31,9 @@
 
 
 /** init module, give the robot system to use as a parameter */
-void bd_init(struct blocking_detection * bd, struct cs *cs)
+void bd_init(struct blocking_detection * bd)
 {
     memset(bd, 0, sizeof(*bd));
-    bd->cs = cs;
 }
 
 
@@ -56,10 +55,8 @@ void bd_set_thresholds(struct blocking_detection *bd, uint32_t err_thres, uint16
 
 
 /** function to be called periodically */
-void bd_manage(struct blocking_detection * bd)
+void bd_manage(struct blocking_detection * bd, uint32_t err)
 {
-    uint32_t err = fabs(cs_get_error(bd->cs));
-
     if (bd->err_thres == 0) {
         return;
     }

--- a/master-firmware/src/aversive/blocking_detection_manager/blocking_detection_manager.h
+++ b/master-firmware/src/aversive/blocking_detection_manager/blocking_detection_manager.h
@@ -26,7 +26,6 @@
 #define BLOCKING_DETECTION_MANAGER_H_
 
 #include <stdint.h>
-#include <control_system_manager/control_system_manager.h>
 
 
 /**@brief Detect blocking based on motor current.
@@ -41,19 +40,18 @@
  * of the motor)
  */
 
-/**@brief Stores the Control System and other values for blocking detection.
+/**@brief Stores settings for blocking detection.
  *
  */
 struct blocking_detection {
-    struct cs *cs;      /**< Control system */
     uint16_t cpt_thres; /**< Number of err_thres surpasses to trigger blocking */
     uint16_t cpt;       /**< Number of times that the current surpassed the threshold */
     uint32_t err_thres; /**< Current threshold */
     uint32_t err_max;   /**< Highest current measured */
 };
 
-/** init module, give the cs as parameter */
-void bd_init(struct blocking_detection *bd, struct cs *cs);
+/** init module */
+void bd_init(struct blocking_detection *bd);
 
 
 void bd_set_thresholds(struct blocking_detection *bd, uint32_t err_thres, uint16_t cpt_thres);
@@ -62,7 +60,7 @@ void bd_set_thresholds(struct blocking_detection *bd, uint32_t err_thres, uint16
 void bd_reset(struct blocking_detection *bd);
 
 /** function to be called periodically */
-void bd_manage(struct blocking_detection *bd);
+void bd_manage(struct blocking_detection *bd, uint32_t err);
 
 /** get value of blocking detection */
 uint8_t bd_get(struct blocking_detection *bd);

--- a/master-firmware/src/base/base_controller.c
+++ b/master-firmware/src/base/base_controller.c
@@ -84,8 +84,8 @@ void robot_init(void)
     trajectory_set_windows(&robot.traj, 15., 5., 30.);
 
     /* Initialize blocking detection managers */
-    bd_init(&robot.angle_bd, &robot.angle_cs);
-    bd_init(&robot.distance_bd, &robot.distance_cs);
+    bd_init(&robot.angle_bd);
+    bd_init(&robot.distance_bd);
 
     /* Set calibration side */
     robot.calibration_direction = (enum direction_t)config_get_integer("master/calibration_direction");
@@ -130,8 +130,8 @@ static THD_FUNCTION(base_ctrl_thd, arg)
         }
 
         /* Blocking detection manage */
-        bd_manage(&robot.angle_bd);
-        bd_manage(&robot.distance_bd);
+        bd_manage(&robot.angle_bd, abs(cs_get_error(&robot.angle_cs)));
+        bd_manage(&robot.distance_bd, abs(cs_get_error(&robot.distance_cs)));
 
         /* Collision detected */
         if (bd_get(&robot.distance_bd)) {

--- a/master-firmware/src/commands.c
+++ b/master-firmware/src/commands.c
@@ -1323,6 +1323,31 @@ static void cmd_hand_dist(BaseSequentialStream *chp, int argc, char *argv[])
     }
 }
 
+#include "arms/arm_trajectory_manager.h"
+
+static void cmd_arm_bd(BaseSequentialStream *chp, int argc, char *argv[])
+{
+    if (argc != 3) {
+        chprintf(chp, "Usage: arm_bd xy|z error_threshold_mm error_count_threshold\r\n");
+        return;
+    }
+
+    int error_threshold_mm = atoi(argv[1]);
+    int error_count_threshold = atoi(argv[2]);
+
+    if (strcmp("xy", argv[0]) == 0) {
+        arm_traj_manager_set_blocking_detection_xy(&main_arm_traj_manager, error_threshold_mm, error_count_threshold);
+        chprintf(chp, "Set %s Arm blocking detector to error_threshold_mm: %d error_count_threshold: %d\r\n", argv[0],
+                 error_threshold_mm, error_count_threshold);
+    } else if (strcmp("z", argv[0]) == 0) {
+        arm_traj_manager_set_blocking_detection_z(&main_arm_traj_manager, error_threshold_mm, error_count_threshold);
+        chprintf(chp, "Set %s Arm blocking detector to error_threshold_mm: %d error_count_threshold: %d\r\n", argv[0],
+                 error_threshold_mm, error_count_threshold);
+    } else {
+        chprintf(chp, "Unknown Arm blocking detection %s only xy or z supported\r\n", argv[0]);
+    }
+}
+
 const ShellCommand commands[] = {
     {"crashme", cmd_crashme},
     {"config_tree", cmd_config_tree},
@@ -1377,5 +1402,6 @@ const ShellCommand commands[] = {
     {"push_y", cmd_push_y},
     {"canio", cmd_canio},
     {"dist", cmd_hand_dist},
+    {"arm_bd", cmd_arm_bd},
     {NULL, NULL}
 };

--- a/master-firmware/src/strategy.cpp
+++ b/master-firmware/src/strategy.cpp
@@ -242,6 +242,20 @@ void strat_scara_goto_blocking(position_3d_t pos, scara_coordinate_t system, vel
     arm_traj_wait_for_end();
 }
 
+void strat_scara_push_x(float dx, scara_coordinate_t system, velocity_3d_t max_vel)
+{
+    const position_3d_t last_pos = scara_position(&main_arm, system);
+    scara_goto(&main_arm, {last_pos.x + dx, last_pos.y, last_pos.z}, system, max_vel);
+    arm_traj_wait_for_event(ARM_READY | ARM_BLOCKED_XY);
+}
+
+void strat_scara_push_y(float dy, scara_coordinate_t system, velocity_3d_t max_vel)
+{
+    const position_3d_t last_pos = scara_position(&main_arm, system);
+    scara_goto(&main_arm, {last_pos.x, last_pos.y + dy, last_pos.z}, system, max_vel);
+    arm_traj_wait_for_event(ARM_READY | ARM_BLOCKED_XY);
+}
+
 void strat_pick_cube(point_t xy, float z_start)
 {
     const position_3d_t last_pos = scara_position(&main_arm, COORDINATE_ARM);
@@ -357,7 +371,7 @@ void strat_push_switch_on(float x, float y, float z, float y_push)
     const position_3d_t last_pos = scara_position(&main_arm, COORDINATE_TABLE);
     strat_scara_goto_blocking({x,      y, last_pos.z}, COORDINATE_TABLE, {300, 300, 300});
     strat_scara_goto_blocking({x,      y,          z}, COORDINATE_TABLE, {300, 300, 300});
-    strat_scara_goto_blocking({x, y_push,          z}, COORDINATE_TABLE, {300, 300, 300});
+    strat_scara_push_y(                        y_push, COORDINATE_TABLE, {300, 300, 300});
     strat_scara_goto_blocking({x,      y,          z}, COORDINATE_TABLE, {300, 300, 300});
     strat_scara_goto_blocking({x,      y, last_pos.z}, COORDINATE_TABLE, {300, 300, 300});
 }
@@ -378,7 +392,7 @@ struct TurnSwitchOn : public actions::TurnSwitchOn {
             return false;
         }
 
-        strat_push_switch_on(MIRROR_X(m_color, 1130), 50, 150, -15);
+        strat_push_switch_on(MIRROR_X(m_color, 1130), 50, 130, -120);
 
         state.switch_on = true;
         return true;

--- a/master-firmware/tests/aversive/test_blocking_detection_manager.cpp
+++ b/master-firmware/tests/aversive/test_blocking_detection_manager.cpp
@@ -1,7 +1,6 @@
 #include <CppUTest/TestHarness.h>
 
 extern "C" {
-#include "control_system_manager/control_system_manager.h"
 #include "blocking_detection_manager/blocking_detection_manager.h"
 }
 
@@ -11,62 +10,60 @@ extern "C" {
 TEST_GROUP(ABlockingDetectionManager)
 {
     blocking_detection blocking_detection_manager;
-    cs control_system;
 
     void setup()
     {
-        cs_init(&control_system);
-        bd_init(&blocking_detection_manager, &control_system);
+        bd_init(&blocking_detection_manager);
         bd_set_thresholds(&blocking_detection_manager, ERROR_THRESHOLD, ERROR_COUNT_THRESHOLD);
     }
 };
 
 TEST(ABlockingDetectionManager, isNotBlockedWhenErrorThresholdIsZero)
 {
-    control_system.error_value = ERROR_THRESHOLD + 1;
+    const auto errorAboveThreshold = ERROR_THRESHOLD + 1;
     bd_set_thresholds(&blocking_detection_manager, 0, ERROR_COUNT_THRESHOLD);
 
-    bd_manage(&blocking_detection_manager);
+    bd_manage(&blocking_detection_manager, errorAboveThreshold);
 
     CHECK_FALSE(bd_get(&blocking_detection_manager));
 }
 
 TEST(ABlockingDetectionManager, isNotBlockedWhenErrorCountThresholdIsZero)
 {
-    control_system.error_value = ERROR_THRESHOLD + 1;
+    const auto errorAboveThreshold = ERROR_THRESHOLD + 1;
     bd_set_thresholds(&blocking_detection_manager, ERROR_THRESHOLD, 0);
 
-    bd_manage(&blocking_detection_manager);
+    bd_manage(&blocking_detection_manager, errorAboveThreshold);
 
     CHECK_FALSE(bd_get(&blocking_detection_manager));
 }
 
 TEST(ABlockingDetectionManager, isNotBlockedWhenErrorIsZero)
 {
-    control_system.error_value = 0;
+    const auto nullError = 0;
 
-    bd_manage(&blocking_detection_manager);
+    bd_manage(&blocking_detection_manager, nullError);
 
     CHECK_FALSE(bd_get(&blocking_detection_manager));
 }
 
 TEST(ABlockingDetectionManager, isBlockedWhenErrorAboveThreshold)
 {
-    control_system.error_value = ERROR_THRESHOLD + 1;
+    const auto errorAboveThreshold = ERROR_THRESHOLD + 1;
 
-    bd_manage(&blocking_detection_manager);
+    bd_manage(&blocking_detection_manager, errorAboveThreshold);
 
     CHECK_TRUE(bd_get(&blocking_detection_manager));
 }
 
 TEST(ABlockingDetectionManager, isBlockedWhenErrorAboveThresholdForRepeatedNumberOfTimes)
 {
-    control_system.error_value = ERROR_THRESHOLD + 1;
+    const auto errorAboveThreshold = ERROR_THRESHOLD + 1;
     const auto countThreshold = 42;
     bd_set_thresholds(&blocking_detection_manager, ERROR_THRESHOLD, countThreshold);
 
     for (int i = 0; i < countThreshold; i++) {
-        bd_manage(&blocking_detection_manager);
+        bd_manage(&blocking_detection_manager, errorAboveThreshold);
     }
 
     CHECK_TRUE(bd_get(&blocking_detection_manager));

--- a/master-firmware/tests/aversive/test_blocking_detection_manager.cpp
+++ b/master-firmware/tests/aversive/test_blocking_detection_manager.cpp
@@ -1,0 +1,73 @@
+#include <CppUTest/TestHarness.h>
+
+extern "C" {
+#include "control_system_manager/control_system_manager.h"
+#include "blocking_detection_manager/blocking_detection_manager.h"
+}
+
+#define ERROR_THRESHOLD         10
+#define ERROR_COUNT_THRESHOLD   1
+
+TEST_GROUP(ABlockingDetectionManager)
+{
+    blocking_detection blocking_detection_manager;
+    cs control_system;
+
+    void setup()
+    {
+        cs_init(&control_system);
+        bd_init(&blocking_detection_manager, &control_system);
+        bd_set_thresholds(&blocking_detection_manager, ERROR_THRESHOLD, ERROR_COUNT_THRESHOLD);
+    }
+};
+
+TEST(ABlockingDetectionManager, isNotBlockedWhenErrorThresholdIsZero)
+{
+    control_system.error_value = ERROR_THRESHOLD + 1;
+    bd_set_thresholds(&blocking_detection_manager, 0, ERROR_COUNT_THRESHOLD);
+
+    bd_manage(&blocking_detection_manager);
+
+    CHECK_FALSE(bd_get(&blocking_detection_manager));
+}
+
+TEST(ABlockingDetectionManager, isNotBlockedWhenErrorCountThresholdIsZero)
+{
+    control_system.error_value = ERROR_THRESHOLD + 1;
+    bd_set_thresholds(&blocking_detection_manager, ERROR_THRESHOLD, 0);
+
+    bd_manage(&blocking_detection_manager);
+
+    CHECK_FALSE(bd_get(&blocking_detection_manager));
+}
+
+TEST(ABlockingDetectionManager, isNotBlockedWhenErrorIsZero)
+{
+    control_system.error_value = 0;
+
+    bd_manage(&blocking_detection_manager);
+
+    CHECK_FALSE(bd_get(&blocking_detection_manager));
+}
+
+TEST(ABlockingDetectionManager, isBlockedWhenErrorAboveThreshold)
+{
+    control_system.error_value = ERROR_THRESHOLD + 1;
+
+    bd_manage(&blocking_detection_manager);
+
+    CHECK_TRUE(bd_get(&blocking_detection_manager));
+}
+
+TEST(ABlockingDetectionManager, isBlockedWhenErrorAboveThresholdForRepeatedNumberOfTimes)
+{
+    control_system.error_value = ERROR_THRESHOLD + 1;
+    const auto countThreshold = 42;
+    bd_set_thresholds(&blocking_detection_manager, ERROR_THRESHOLD, countThreshold);
+
+    for (int i = 0; i < countThreshold; i++) {
+        bd_manage(&blocking_detection_manager);
+    }
+
+    CHECK_TRUE(bd_get(&blocking_detection_manager));
+}

--- a/master-firmware/tests/test_trajectory_helpers.cpp
+++ b/master-firmware/tests/test_trajectory_helpers.cpp
@@ -285,8 +285,8 @@ TEST_GROUP(TrajectoryHasEnded)
         cs_set_consign_filter(&robot.distance_cs, quadramp_do_filter, &robot.distance_qr);
         cs_set_consign_filter(&robot.angle_cs, quadramp_do_filter, &robot.angle_qr);
 
-        bd_init(&robot.distance_bd, &robot.distance_cs);
-        bd_init(&robot.angle_bd, &robot.angle_cs);
+        bd_init(&robot.distance_bd);
+        bd_init(&robot.angle_bd);
         bd_set_thresholds(&robot.distance_bd, 1, 1);
         bd_set_thresholds(&robot.angle_bd, 1, 1);
 
@@ -327,8 +327,8 @@ TEST_GROUP(TrajectoryHasEnded)
     {
         cs_manage(&robot.distance_cs);
         cs_manage(&robot.angle_cs);
-        bd_manage(&robot.distance_bd);
-        bd_manage(&robot.angle_bd);
+        bd_manage(&robot.distance_bd, abs(cs_get_error(&robot.distance_cs)));
+        bd_manage(&robot.angle_bd, abs(cs_get_error(&robot.angle_cs)));
         trajectory_manager_xy_event(&robot.traj);
     }
 


### PR DESCRIPTION
Solves #103

Refactors blocking detection manager from aversive to not depend on control system manager, and reuses it to detect when arm is blocked in xy or z. I also use to push the interruptor and return on blocking detection in XY.

Tested and working on hardware.