### PR TITLE
Count score from GOAP state

### DIFF
--- a/master-firmware/package.yml
+++ b/master-firmware/package.yml
@@ -103,6 +103,7 @@ source:
     - src/lever/lever.c
     - src/base/base_helpers.c
     - src/strategy/state.cpp
+    - src/strategy/score.cpp
 
 include_directories:
     - src/
@@ -146,6 +147,7 @@ tests:
     - tests/aversive/test_blocking_detection_manager.cpp
     - tests/aversive/test_geometry_discrete_circles.cpp
     - tests/aversive/test_geometry_polygon_intersection.cpp
+    - tests/strategy/test_score.cpp
 
 templates:
     app_src.mk.jinja: app_src.mk

--- a/master-firmware/package.yml
+++ b/master-firmware/package.yml
@@ -63,6 +63,7 @@ target.arm:
     - src/pca9685_pwm.c
     - src/lever/lever_module.c
     - src/parameter_port.c
+    - src/strategy/score_counter.cpp
 
 source:
     - src/unix_timestamp.c

--- a/master-firmware/src/commands.c
+++ b/master-firmware/src/commands.c
@@ -1372,16 +1372,6 @@ static void cmd_motor_sin(BaseSequentialStream *chp, int argc, char *argv[])
     }
 }
 
-static void cmd_score_increment(BaseSequentialStream *chp, int argc, char *argv[])
-{
-    if (argc != 1) {
-        chprintf(chp, "Usage: score increment\r\n");
-        return;
-    }
-    int inc = atoi(argv[0]);
-    strategy_score_increase(inc);
-}
-
 static void cmd_push_the_bee(BaseSequentialStream *chp, int argc, char *argv[])
 {
     if (argc != 5) {
@@ -1457,7 +1447,6 @@ const ShellCommand commands[] = {
     {"dist", cmd_hand_dist},
     {"arm_bd", cmd_arm_bd},
     {"motor_sin", cmd_motor_sin},
-    {"score", cmd_score_increment},
     {"bee", cmd_push_the_bee},
     {NULL, NULL}
 };

--- a/master-firmware/src/priorities.h
+++ b/master-firmware/src/priorities.h
@@ -20,6 +20,7 @@
 #define ARM_TRAJ_MANAGER_PRIO                   (NORMALPRIO)
 #define LEVER_MODULE_PRIO                       (NORMALPRIO)
 #define STRATEGY_PRIO                           (NORMALPRIO)
+#define SCORE_COUNTER_PRIO                      (NORMALPRIO)
 #define ENCODER_PRIO                            (NORMALPRIO)
 #define STREAM_PRIO                             (NORMALPRIO)
 #define INTERFACE_PANEL_PRIO                    (NORMALPRIO)

--- a/master-firmware/src/strategy/actions.h
+++ b/master-firmware/src/strategy/actions.h
@@ -59,7 +59,7 @@ struct PickupBlocks : public goap::Action<RobotState> {
 struct TurnSwitchOn : public goap::Action<RobotState> {
     bool can_run(RobotState state)
     {
-        return state.arms_are_deployed == false;
+        return state.arms_are_deployed == false && state.panel_on_map;
     }
 
     RobotState plan_effects(RobotState state)
@@ -73,7 +73,7 @@ struct TurnSwitchOn : public goap::Action<RobotState> {
 struct DeployTheBee : public goap::Action<RobotState> {
     bool can_run(RobotState state)
     {
-        return state.arms_are_deployed == false;
+        return state.arms_are_deployed == false && state.bee_on_map;
     }
 
     RobotState plan_effects(RobotState state)

--- a/master-firmware/src/strategy/score.cpp
+++ b/master-firmware/src/strategy/score.cpp
@@ -4,3 +4,8 @@ int score_count_bee(const RobotState& state)
 {
     return state.bee_deployed ? 50 : 0;
 }
+
+int score_count_switch(const RobotState& state)
+{
+    return state.switch_on ? 25 : 0;
+}

--- a/master-firmware/src/strategy/score.cpp
+++ b/master-firmware/src/strategy/score.cpp
@@ -1,5 +1,15 @@
 #include "score.h"
 
+int score_count_bee_on_map(const RobotState& state)
+{
+    return state.bee_on_map ? 5 : 0;
+}
+
+int score_count_panel_on_map(const RobotState& state)
+{
+    return state.panel_on_map ? 5 : 0;
+}
+
 int score_count_bee(const RobotState& state)
 {
     return state.bee_deployed ? 50 : 0;

--- a/master-firmware/src/strategy/score.cpp
+++ b/master-firmware/src/strategy/score.cpp
@@ -1,0 +1,6 @@
+#include "score.h"
+
+int score_count_bee(const RobotState& state)
+{
+    return state.bee_deployed ? 50 : 0;
+}

--- a/master-firmware/src/strategy/score.h
+++ b/master-firmware/src/strategy/score.h
@@ -1,0 +1,16 @@
+#ifndef SCORE_H
+#define SCORE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "strategy/state.h"
+
+int score_count_bee(const RobotState& state);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SCORE_H */

--- a/master-firmware/src/strategy/score.h
+++ b/master-firmware/src/strategy/score.h
@@ -7,6 +7,9 @@ extern "C" {
 
 #include "strategy/state.h"
 
+int score_count_bee_on_map(const RobotState& state);
+int score_count_panel_on_map(const RobotState& state);
+
 int score_count_bee(const RobotState& state);
 int score_count_switch(const RobotState& state);
 

--- a/master-firmware/src/strategy/score.h
+++ b/master-firmware/src/strategy/score.h
@@ -8,6 +8,7 @@ extern "C" {
 #include "strategy/state.h"
 
 int score_count_bee(const RobotState& state);
+int score_count_switch(const RobotState& state);
 
 #ifdef __cplusplus
 }

--- a/master-firmware/src/strategy/score_counter.cpp
+++ b/master-firmware/src/strategy/score_counter.cpp
@@ -31,7 +31,12 @@ static THD_FUNCTION(score_counter_thd, arg)
         messagebus_topic_wait(strategy_state_topic, &state, sizeof(state));
         NOTICE("Received strategy state");
 
-        int score = 5 + 5 + score_count_bee(state) + score_count_switch(state);
+        int score = 0;
+        score += score_count_bee_on_map(state);
+        score += score_count_panel_on_map(state);
+        score += score_count_bee(state);
+        score += score_count_switch(state);
+
         messagebus_topic_publish(&score_topic, &score, sizeof(score));
 
         chThdSleepMilliseconds(1000 / SCORE_COUNTER_FREQUENCY);

--- a/master-firmware/src/strategy/score_counter.cpp
+++ b/master-firmware/src/strategy/score_counter.cpp
@@ -1,0 +1,46 @@
+#include <ch.h>
+#include <hal.h>
+#include <error/error.h>
+
+#include "main.h"
+#include "priorities.h"
+
+#include "strategy/score.h"
+#include "strategy/score_counter.h"
+#include "strategy/state.h"
+
+#define SCORE_COUNTER_STACKSIZE 1024
+
+static THD_FUNCTION(score_counter_thd, arg)
+{
+    (void)arg;
+    chRegSetThreadName(__FUNCTION__);
+
+    static messagebus_topic_t score_topic;
+    static MUTEX_DECL(score_topic_lock);
+    static CONDVAR_DECL(score_topic_condvar);
+    static int _score;
+    messagebus_topic_init(&score_topic, &score_topic_lock, &score_topic_condvar, &_score, sizeof(_score));
+    messagebus_advertise_topic(&bus, &score_topic, "/score");
+
+    RobotState state;
+    messagebus_topic_t* strategy_state_topic = messagebus_find_topic_blocking(&bus, "/state");
+
+    NOTICE("Score initialized");
+    while (true) {
+        messagebus_topic_wait(strategy_state_topic, &state, sizeof(state));
+        NOTICE("Received strategy state");
+
+        int score = 5 + 5 + score_count_bee(state) + score_count_switch(state);
+        messagebus_topic_publish(&score_topic, &score, sizeof(score));
+
+        chThdSleepMilliseconds(1000 / SCORE_COUNTER_FREQUENCY);
+    }
+}
+
+void score_counter_start()
+{
+    static THD_WORKING_AREA(score_counter_thd_wa, SCORE_COUNTER_STACKSIZE);
+    chThdCreateStatic(score_counter_thd_wa, sizeof(score_counter_thd_wa),
+                      SCORE_COUNTER_PRIO, score_counter_thd, NULL);
+}

--- a/master-firmware/src/strategy/score_counter.cpp
+++ b/master-firmware/src/strategy/score_counter.cpp
@@ -38,8 +38,6 @@ static THD_FUNCTION(score_counter_thd, arg)
         score += score_count_switch(state);
 
         messagebus_topic_publish(&score_topic, &score, sizeof(score));
-
-        chThdSleepMilliseconds(1000 / SCORE_COUNTER_FREQUENCY);
     }
 }
 

--- a/master-firmware/src/strategy/score_counter.h
+++ b/master-firmware/src/strategy/score_counter.h
@@ -1,0 +1,16 @@
+#ifndef SCORE_COUNTER_H
+#define SCORE_COUNTER_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define SCORE_COUNTER_FREQUENCY 10
+
+void score_counter_start();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SCORE_COUNTER_H */

--- a/master-firmware/src/strategy/score_counter.h
+++ b/master-firmware/src/strategy/score_counter.h
@@ -5,8 +5,6 @@
 extern "C" {
 #endif
 
-#define SCORE_COUNTER_FREQUENCY 10
-
 void score_counter_start();
 
 #ifdef __cplusplus

--- a/master-firmware/src/strategy/state.h
+++ b/master-firmware/src/strategy/state.h
@@ -2,6 +2,9 @@
 #define STRATEGY_STATE_H
 
 struct RobotState {
+    bool bee_on_map{true};
+    bool panel_on_map{true};
+
     bool arms_are_indexed{false};
     bool arms_are_deployed{true};
     bool has_blocks{false};

--- a/master-firmware/src/strategy/state.h
+++ b/master-firmware/src/strategy/state.h
@@ -2,7 +2,6 @@
 #define STRATEGY_STATE_H
 
 struct RobotState {
-    int score{0};
     bool arms_are_indexed{false};
     bool arms_are_deployed{true};
     bool has_blocks{false};

--- a/master-firmware/tests/strategy/test_score.cpp
+++ b/master-firmware/tests/strategy/test_score.cpp
@@ -7,6 +7,30 @@ TEST_GROUP(AScore)
     RobotState state;
 };
 
+TEST(AScore, doesNotcountBeeWhenNotOnMap)
+{
+    state.bee_on_map = false;
+
+    CHECK_EQUAL(0, score_count_bee_on_map(state));
+};
+
+TEST(AScore, countsBeeWhenOnMap)
+{
+    CHECK_EQUAL(5, score_count_bee_on_map(state));
+};
+
+TEST(AScore, doesNotcountPanelWhenNotOnMap)
+{
+    state.panel_on_map = false;
+
+    CHECK_EQUAL(0, score_count_panel_on_map(state));
+};
+
+TEST(AScore, countsPanelWhenOnMap)
+{
+    CHECK_EQUAL(5, score_count_panel_on_map(state));
+};
+
 TEST(AScore, doesNotcountBeeWhenNotDeployed)
 {
     CHECK_EQUAL(0, score_count_bee(state));

--- a/master-firmware/tests/strategy/test_score.cpp
+++ b/master-firmware/tests/strategy/test_score.cpp
@@ -1,0 +1,20 @@
+#include <CppUTest/TestHarness.h>
+
+#include "strategy/score.h"
+
+TEST_GROUP(AScore)
+{
+    RobotState state;
+};
+
+TEST(AScore, doesNotcountBeeWhenNotDeployed)
+{
+    CHECK_EQUAL(0, score_count_bee(state));
+};
+
+TEST(AScore, countsBeeWhenDeployed)
+{
+    state.bee_deployed = true;
+
+    CHECK_EQUAL(50, score_count_bee(state));
+};

--- a/master-firmware/tests/strategy/test_score.cpp
+++ b/master-firmware/tests/strategy/test_score.cpp
@@ -18,3 +18,15 @@ TEST(AScore, countsBeeWhenDeployed)
 
     CHECK_EQUAL(50, score_count_bee(state));
 };
+
+TEST(AScore, doesNotcountSwitchWhenNotDeployed)
+{
+    CHECK_EQUAL(0, score_count_switch(state));
+};
+
+TEST(AScore, countsSwitchWhenDeployed)
+{
+    state.switch_on = true;
+
+    CHECK_EQUAL(25, score_count_switch(state));
+};

--- a/master-firmware/tests/test_strategy.cpp
+++ b/master-firmware/tests/test_strategy.cpp
@@ -83,6 +83,20 @@ TEST(Strategy, CanPushInterruptor)
     CHECK_TRUE(len > 0);
     CHECK_TRUE(switch_goal.is_reached(state));
 }
+TEST(Strategy, CanNotPushTheInterruptorWhenPanelIsNotOnTheMap)
+{
+    const int max_path_len = 10;
+    goap::Action<RobotState> *path[max_path_len] = {nullptr};
+    auto actions = availableActions();
+    goap::Planner<RobotState> planner(actions.data(), actions.size());
+
+    state.panel_on_map = false;
+    SwitchGoal switch_goal;
+    int len = planner.plan(state, switch_goal, path, max_path_len);
+
+    CHECK_EQUAL(-1, len);
+}
+
 
 TEST(Strategy, CanPushTheBee)
 {
@@ -99,6 +113,20 @@ TEST(Strategy, CanPushTheBee)
 
     CHECK_TRUE(len > 0);
     CHECK_TRUE(bee_goal.is_reached(state));
+}
+
+TEST(Strategy, CanNotPushTheBeeWhenBeeIsNotOnTheMap)
+{
+    const int max_path_len = 10;
+    goap::Action<RobotState> *path[max_path_len] = {nullptr};
+    auto actions = availableActions();
+    goap::Planner<RobotState> planner(actions.data(), actions.size());
+
+    state.bee_on_map = false;
+    BeeGoal bee_goal;
+    int len = planner.plan(state, bee_goal, path, max_path_len);
+
+    CHECK_EQUAL(-1, len);
 }
 
 TEST(Strategy, CanPickupCubes)


### PR DESCRIPTION
Solves #109.
Also adds constraint on actions to turn the switch on and deploy the bee to only be feasible in the panel and the bee are on the map. We can disable these actions by changing this state.