### PR TITLE
Fix goap memory use issue

### DIFF
--- a/lib/goap/goap.hpp
+++ b/lib/goap/goap.hpp
@@ -104,7 +104,22 @@ public:
                 if (action->can_run(current->state)) {
                     // Cannot allocate a new node, abort
                     if (free_nodes == nullptr) {
-                        return -2;
+                        // Garbage collect the node that is most unlikely to be
+                        // visited (i.e. lowest priority)
+                        VisitedState<State> *gc, *gc_prev = nullptr;
+                        for (gc = open; gc && gc->next; gc = gc->next) {
+                            gc_prev = gc;
+                        }
+
+                        if (!gc) {
+                            return -2;
+                        }
+
+                        if (gc_prev) {
+                            gc_prev->next = nullptr;
+                        }
+
+                        free_nodes = gc;
                     }
 
                     auto neighbor = list_pop_head(free_nodes);

--- a/master-firmware/tests/test_strategy.cpp
+++ b/master-firmware/tests/test_strategy.cpp
@@ -107,7 +107,7 @@ TEST(Strategy, CanNotPushTheInterruptorWhenPanelIsNotOnTheMap)
     SwitchGoal switch_goal;
     int len = planner.plan(state, switch_goal, path, max_path_len);
 
-    CHECK_EQUAL(-2, len);
+    CHECK_TRUE(len < 0);
 }
 
 
@@ -139,7 +139,7 @@ TEST(Strategy, CanNotPushTheBeeWhenBeeIsNotOnTheMap)
     BeeGoal bee_goal;
     int len = planner.plan(state, bee_goal, path, max_path_len);
 
-    CHECK_EQUAL(-2, len);
+    CHECK_TRUE(len < 0);
 }
 
 TEST(Strategy, CanPickupCubes)
@@ -164,7 +164,7 @@ TEST(Strategy, CanDepositCubes)
     const int max_path_len = 10;
     goap::Action<RobotState> *path[max_path_len] = {nullptr};
     auto actions = availableActions();
-    goap::Planner<RobotState, 200> planner(actions.data(), actions.size());
+    goap::Planner<RobotState> planner(actions.data(), actions.size());
 
     DepositCubesGoal goal;
     int len = planner.plan(state, goal, path, max_path_len);
@@ -181,7 +181,7 @@ TEST(Strategy, CanBuildTower)
     const int max_path_len = 10;
     goap::Action<RobotState> *path[max_path_len] = {nullptr};
     auto actions = availableActions();
-    goap::Planner<RobotState, 200> planner(actions.data(), actions.size());
+    goap::Planner<RobotState> planner(actions.data(), actions.size());
 
     BuildTowerGoal goal;
     int len = planner.plan(state, goal, path, max_path_len);


### PR DESCRIPTION
Basically, once we get out of free nodes, we discard the least likely
states (i.e. those with the lowest priority). This does not guarantee
convergence, but makes it more likely in most cases.