### PR TITLE
Build a tower

### DIFF
--- a/lib/goap/goap.hpp
+++ b/lib/goap/goap.hpp
@@ -104,7 +104,22 @@ public:
                 if (action->can_run(current->state)) {
                     // Cannot allocate a new node, abort
                     if (free_nodes == nullptr) {
-                        return -2;
+                        // Garbage collect the node that is most unlikely to be
+                        // visited (i.e. lowest priority)
+                        VisitedState<State> *gc, *gc_prev = nullptr;
+                        for (gc = open; gc && gc->next; gc = gc->next) {
+                            gc_prev = gc;
+                        }
+
+                        if (!gc) {
+                            return -2;
+                        }
+
+                        if (gc_prev) {
+                            gc_prev->next = nullptr;
+                        }
+
+                        free_nodes = gc;
                     }
 
                     auto neighbor = list_pop_head(free_nodes);

--- a/lib/goap/goap.hpp
+++ b/lib/goap/goap.hpp
@@ -168,6 +168,12 @@ public:
         return *this;
     }
 
+    Distance shouldBeEqual(int target, int var)
+    {
+        distance += abs(var - target);
+        return *this;
+    }
+
     operator int() {
         return distance;
     }

--- a/lib/goap/tests/goap_test.cpp
+++ b/lib/goap/tests/goap_test.cpp
@@ -274,3 +274,10 @@ TEST(InternalDistanceGroup, CanAlsoComputeOpposite)
     int d = goap::Distance().shouldBeFalse(true).shouldBeFalse(false);
     CHECK_EQUAL(1, d);
 }
+
+TEST(InternalDistanceGroup, CanComputeDistanceFromTargetInteger)
+{
+    CHECK_EQUAL(0, goap::Distance().shouldBeEqual(5, 5));
+    CHECK_EQUAL(2, goap::Distance().shouldBeEqual(5, 3));
+    CHECK_EQUAL(2, goap::Distance().shouldBeEqual(5, 7));
+}

--- a/master-firmware/src/commands.c
+++ b/master-firmware/src/commands.c
@@ -1393,6 +1393,20 @@ static void cmd_push_the_bee(BaseSequentialStream *chp, int argc, char *argv[])
     strat_push_the_bee(start, end, bee_height);
 }
 
+static void cmd_check_dist(BaseSequentialStream *chp, int argc, char *argv[])
+{
+    if (argc != 1) {
+        chprintf(chp, "Usage: check_dist expected\r\n");
+        return;
+    }
+    float expected = atof(argv[0]);
+    if (strat_check_distance_to_hand_lower_than(expected)) {
+        chprintf(chp, "Success: Measured distance was lower than %f\r\n", expected);
+    } else {
+        chprintf(chp, "Failure: Measured distance was higher than %f\r\n", expected);
+    }
+}
+
 
 const ShellCommand commands[] = {
     {"crashme", cmd_crashme},
@@ -1451,5 +1465,6 @@ const ShellCommand commands[] = {
     {"arm_bd", cmd_arm_bd},
     {"motor_sin", cmd_motor_sin},
     {"bee", cmd_push_the_bee},
+    {"check_dist", cmd_check_dist},
     {NULL, NULL}
 };

--- a/master-firmware/src/commands.c
+++ b/master-firmware/src/commands.c
@@ -1259,7 +1259,11 @@ static void cmd_pick_cube(BaseSequentialStream *chp, int argc, char *argv[])
     float z_start = atof(argv[2]);
 
     chprintf(chp, "Picking cube at x:%f y:%f z:65(%f)\r\n", xy.x, xy.y, z_start);
-    strat_pick_cube(xy, z_start);
+    if (strat_pick_cube(xy, z_start)) {
+        chprintf(chp, "Mission success \\o/\r\nPicked up requested cube, awaiting new orders, master.\r\n");
+    } else {
+        chprintf(chp, "Mission failed :(\r\nThe cube was a lie!\r\n");
+    }
 }
 
 static void cmd_deposit_cube(BaseSequentialStream *chp, int argc, char *argv[])

--- a/master-firmware/src/commands.c
+++ b/master-firmware/src/commands.c
@@ -1273,8 +1273,11 @@ static void cmd_deposit_cube(BaseSequentialStream *chp, int argc, char *argv[])
     int num_cubes = atoi(argv[2]);
 
     chprintf(chp, "Depositing cube on tower x:%f y:%f holding %f cubes\r\n", x, y, num_cubes);
-    strat_deposit_cube(x, y, num_cubes);
-    chprintf(chp, "Tower now has %f cubes\r\n", num_cubes + 1);
+    if (strat_deposit_cube(x, y, num_cubes)) {
+        chprintf(chp, "Mission success :)\nTower now has %d cubes\r\n", num_cubes + 1);
+    } else {
+        chprintf(chp, "Mission failed :(\n");
+    }
 }
 
 

--- a/master-firmware/src/robot_helpers/eurobot2018.h
+++ b/master-firmware/src/robot_helpers/eurobot2018.h
@@ -1,0 +1,13 @@
+#ifndef EUROBOT2018_H
+#define EUROBOT2018_H
+
+/** Blocks color */
+enum block_color {
+    BLOCK_YELLOW = 0,
+    BLOCK_GREEN,
+    BLOCK_BLUE,
+    BLOCK_RED,
+    BLOCK_BLACK,
+};
+
+#endif /* EUROBOT2018_H */

--- a/master-firmware/src/robot_helpers/strategy_helpers.h
+++ b/master-firmware/src/robot_helpers/strategy_helpers.h
@@ -10,21 +10,13 @@ extern "C" {
 #include "blocking_detection_manager/blocking_detection_manager.h"
 #include "base/base_controller.h"
 #include "math/lie_groups.h"
+#include "robot_helpers/eurobot2018.h"
 
 /** Team color
  */
 enum strat_color_t {
     YELLOW=0,
     BLUE
-};
-
-/** Blocks color */
-enum block_color {
-    BLOCK_YELLOW = 0, // ( 0,  0)
-    BLOCK_GREEN,      // ( l,  0)
-    BLOCK_BLUE,       // ( 0,  l)
-    BLOCK_RED,        // (-l,  0)
-    BLOCK_BLACK,      // ( 0, -l)
 };
 
 /** Lever side */

--- a/master-firmware/src/strategy.cpp
+++ b/master-firmware/src/strategy.cpp
@@ -575,6 +575,7 @@ void strategy_debra_play_game(void)
     BuildTowerLevel build_tower_lvl1(color, 0);
     BuildTowerLevel build_tower_lvl2(color, 1);
     BuildTowerLevel build_tower_lvl3(color, 2);
+    BuildTowerLevel build_tower_lvl4(color, 3);
 
     const int max_path_len = 10;
     goap::Action<RobotState> *path[max_path_len] = {nullptr};
@@ -591,6 +592,7 @@ void strategy_debra_play_game(void)
         &build_tower_lvl1,
         &build_tower_lvl2,
         &build_tower_lvl3,
+        &build_tower_lvl4,
     };
 
     static goap::Planner<RobotState> planner(actions, sizeof(actions) / sizeof(actions[0]));

--- a/master-firmware/src/strategy.cpp
+++ b/master-firmware/src/strategy.cpp
@@ -558,10 +558,10 @@ void strategy_debra_play_game(void)
     PickupCubesGoal pickup_cubes_goal;
     BuildTowerGoal build_tower_goal;
     goap::Goal<RobotState>* goals[] = {
+        // &pickup_cubes_goal,
+        &build_tower_goal,
         &switch_goal,
         &bee_goal,
-        &pickup_cubes_goal,
-        &build_tower_goal,
     };
 
     IndexArms index_arms;

--- a/master-firmware/src/strategy.cpp
+++ b/master-firmware/src/strategy.cpp
@@ -279,13 +279,14 @@ void strat_deposit_cube(float x, float y, int num_cubes_in_tower)
 {
     const float z = (num_cubes_in_tower + 1) * 70.;
     const float margin_z = 20;
+    const float safe_z = fmaxf(z + margin_z, 140.f);
 
     scara_hold_position(&main_arm, COORDINATE_ARM);
     arm_traj_wait_for_end();
 
     const position_3d_t last_pos = scara_position(&main_arm, COORDINATE_ARM);
-    strat_scara_goto_blocking({last_pos.x, last_pos.y, z + margin_z}, COORDINATE_ARM, {300, 300, 300});
-    strat_scara_goto_blocking({x, y, z + margin_z}, COORDINATE_TABLE, {300, 300, 300});
+    strat_scara_goto_blocking({last_pos.x, last_pos.y, safe_z}, COORDINATE_ARM, {300, 300, 300});
+    strat_scara_goto_blocking({x, y, safe_z}, COORDINATE_TABLE, {300, 300, 300});
     strat_scara_goto_blocking({x, y, z}, COORDINATE_TABLE, {300, 300, 300});
     strategy_wait_ms(2000);
 

--- a/master-firmware/src/strategy.cpp
+++ b/master-firmware/src/strategy.cpp
@@ -309,9 +309,8 @@ bool strat_deposit_cube(float x, float y, int num_cubes_in_tower)
 
     const position_3d_t last_pos = scara_position(&main_arm, COORDINATE_ARM);
     strat_scara_goto_blocking({last_pos.x, last_pos.y, safe_z}, COORDINATE_ARM, {300, 300, 300});
-    strat_scara_goto_blocking({x, y, safe_z}, COORDINATE_TABLE, {300, 300, 300});
-    strat_scara_goto_blocking({x, y, z}, COORDINATE_TABLE, {300, 300, 300});
-    strategy_wait_ms(2000);
+    strat_scara_goto_blocking({x, y, safe_z}, COORDINATE_TABLE, {150, 150, 150});
+    strat_scara_goto_blocking({x, y, z}, COORDINATE_TABLE, {150, 150, 150});
 
     hand_set_pump(&main_hand, PUMP_REVERSE);
     strat_scara_goto_blocking({x, y, z + margin_z}, COORDINATE_TABLE, {300, 300, 300});

--- a/master-firmware/src/strategy.h
+++ b/master-firmware/src/strategy.h
@@ -10,7 +10,7 @@ void strategy_start(void);
 bool strategy_goto_avoid(int x_mm, int y_mm, int a_deg, int traj_end_flags);
 
 void strat_pick_cube(point_t xy, float z_start);
-void strat_deposit_cube(float x, float y, int num_cubes_in_tower);
+bool strat_deposit_cube(float x, float y, int num_cubes_in_tower);
 
 void strat_push_switch_on(float x, float y, float z, float y_push);
 void strat_push_the_bee(point_t start, point_t end, float bee_height);

--- a/master-firmware/src/strategy.h
+++ b/master-firmware/src/strategy.h
@@ -10,7 +10,7 @@ void strategy_start(void);
 bool strategy_goto_avoid(int x_mm, int y_mm, int a_deg, int traj_end_flags);
 
 bool strat_check_distance_to_hand_lower_than(float expected_value);
-void strat_pick_cube(point_t xy, float z_start);
+bool strat_pick_cube(point_t xy, float z_start);
 bool strat_deposit_cube(float x, float y, int num_cubes_in_tower);
 
 void strat_push_switch_on(float x, float y, float z, float y_push);

--- a/master-firmware/src/strategy.h
+++ b/master-firmware/src/strategy.h
@@ -9,6 +9,7 @@ void strategy_start(void);
 
 bool strategy_goto_avoid(int x_mm, int y_mm, int a_deg, int traj_end_flags);
 
+bool strat_check_distance_to_hand_lower_than(float expected_value);
 void strat_pick_cube(point_t xy, float z_start);
 bool strat_deposit_cube(float x, float y, int num_cubes_in_tower);
 

--- a/master-firmware/src/strategy/actions.h
+++ b/master-firmware/src/strategy/actions.h
@@ -84,6 +84,48 @@ struct DeployTheBee : public goap::Action<RobotState> {
     }
 };
 
+struct DepositCubes : public goap::Action<RobotState> {
+    bool can_run(RobotState state)
+    {
+        return state.lever_full_left || state.lever_full_right;
+    }
+
+    RobotState plan_effects(RobotState state)
+    {
+        if (state.lever_full_right == true) {
+            state.lever_full_right = false;
+        } else {
+            state.lever_full_left = false;
+        }
+
+        for (auto& cube_ready : state.cubes_ready_for_construction) {
+            cube_ready = true;
+        }
+
+        return state;
+    }
+};
+
+struct BuildTowerLevel : public goap::Action<RobotState> {
+    int level;
+    BuildTowerLevel(int lvl) : level(lvl) {}
+
+    bool can_run(RobotState state)
+    {
+      return state.arms_are_deployed == false && state.tower_level == level &&
+             state.cubes_ready_for_construction[state.tower_sequence[level]];
+    }
+
+    RobotState plan_effects(RobotState state)
+    {
+        state.arms_are_deployed = true;
+        state.cubes_ready_for_construction[state.tower_sequence[level]] = false;
+        state.tower_level += 1;
+        return state;
+    }
+};
+
 } // namespace actions
 
 #endif /* STRATEGY_ACTIONS_H */
+

--- a/master-firmware/src/strategy/actions.h
+++ b/master-firmware/src/strategy/actions.h
@@ -87,7 +87,15 @@ struct DeployTheBee : public goap::Action<RobotState> {
 struct DepositCubes : public goap::Action<RobotState> {
     bool can_run(RobotState state)
     {
-        return state.lever_full_left || state.lever_full_right;
+        auto no_cubes_in_construction_zone = [](const RobotState& state) -> bool {
+            for (const auto& cube_in_construction_zone : state.cubes_ready_for_construction) {
+                if (cube_in_construction_zone) {
+                    return false;
+                }
+            }
+            return true;
+        };
+        return (state.lever_full_left || state.lever_full_right) && no_cubes_in_construction_zone(state);
     }
 
     RobotState plan_effects(RobotState state)

--- a/master-firmware/src/strategy/actions.h
+++ b/master-firmware/src/strategy/actions.h
@@ -112,7 +112,7 @@ struct BuildTowerLevel : public goap::Action<RobotState> {
 
     bool can_run(RobotState state)
     {
-      return state.arms_are_deployed == false && state.tower_level == level &&
+      return state.tower_level == level &&
              state.cubes_ready_for_construction[state.tower_sequence[level]];
     }
 

--- a/master-firmware/src/strategy/goals.h
+++ b/master-firmware/src/strategy/goals.h
@@ -37,7 +37,7 @@ struct PickupCubesGoal : goap::Goal<RobotState> {
 struct BuildTowerGoal : goap::Goal<RobotState> {
     virtual int distance_to(const RobotState &state) const
     {
-        return goap::Distance().shouldBeEqual(3, state.tower_level);
+        return goap::Distance().shouldBeEqual(4, state.tower_level);
     }
 };
 

--- a/master-firmware/src/strategy/goals.h
+++ b/master-firmware/src/strategy/goals.h
@@ -34,4 +34,11 @@ struct PickupCubesGoal : goap::Goal<RobotState> {
     }
 };
 
+struct BuildTowerGoal : goap::Goal<RobotState> {
+    virtual int distance_to(const RobotState &state) const
+    {
+        return goap::Distance().shouldBeEqual(3, state.tower_level);
+    }
+};
+
 #endif /* STRATEGY_GOALS_H */

--- a/master-firmware/src/strategy/score.cpp
+++ b/master-firmware/src/strategy/score.cpp
@@ -19,3 +19,12 @@ int score_count_switch(const RobotState& state)
 {
     return state.switch_on ? 25 : 0;
 }
+
+int score_count_tower(const RobotState& state)
+{
+    int score = 0;
+    for (int lvl = 0; lvl <= state.tower_level; lvl++) {
+        score += lvl;
+    }
+    return score;
+}

--- a/master-firmware/src/strategy/score.h
+++ b/master-firmware/src/strategy/score.h
@@ -13,6 +13,8 @@ int score_count_panel_on_map(const RobotState& state);
 int score_count_bee(const RobotState& state);
 int score_count_switch(const RobotState& state);
 
+int score_count_tower(const RobotState& state);
+
 #ifdef __cplusplus
 }
 #endif

--- a/master-firmware/src/strategy/score_counter.cpp
+++ b/master-firmware/src/strategy/score_counter.cpp
@@ -36,6 +36,7 @@ static THD_FUNCTION(score_counter_thd, arg)
         score += score_count_panel_on_map(state);
         score += score_count_bee(state);
         score += score_count_switch(state);
+        score += score_count_tower(state);
 
         messagebus_topic_publish(&score_topic, &score, sizeof(score));
     }

--- a/master-firmware/src/strategy/state.h
+++ b/master-firmware/src/strategy/state.h
@@ -23,6 +23,7 @@ struct RobotState {
 
     enum block_color tower_sequence[3] = {BLOCK_BLACK, BLOCK_BLUE, BLOCK_GREEN};
     bool cubes_ready_for_construction[5] = {false, false, false, false, false}; // YELLOW, GREEN, BLUE, RED, BLACK
+    int cubes_pos[5][2] = {{0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}};
     int tower_level{0};
 };
 

--- a/master-firmware/src/strategy/state.h
+++ b/master-firmware/src/strategy/state.h
@@ -21,7 +21,7 @@ struct RobotState {
         {850, 540}, {300, 1190}, {1100, 1500}, {1900, 1500}, {2700, 1190}, {2150, 540},
     };
 
-    enum block_color tower_sequence[3] = {BLOCK_BLACK, BLOCK_BLUE, BLOCK_GREEN};
+    enum block_color tower_sequence[5] = {BLOCK_YELLOW, BLOCK_BLACK, BLOCK_BLUE, BLOCK_GREEN, BLOCK_RED};
     bool cubes_ready_for_construction[5] = {false, false, false, false, false}; // YELLOW, GREEN, BLUE, RED, BLACK
     int cubes_pos[5][2] = {{0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}};
     int tower_level{0};

--- a/master-firmware/src/strategy/state.h
+++ b/master-firmware/src/strategy/state.h
@@ -1,6 +1,8 @@
 #ifndef STRATEGY_STATE_H
 #define STRATEGY_STATE_H
 
+#include "robot_helpers/eurobot2018.h"
+
 struct RobotState {
     bool bee_on_map{true};
     bool panel_on_map{true};
@@ -18,6 +20,10 @@ struct RobotState {
     int blocks_pos[6][2] = {
         {850, 540}, {300, 1190}, {1100, 1500}, {1900, 1500}, {2700, 1190}, {2150, 540},
     };
+
+    enum block_color tower_sequence[3] = {BLOCK_BLACK, BLOCK_BLUE, BLOCK_GREEN};
+    bool cubes_ready_for_construction[5] = {false, false, false, false, false}; // YELLOW, GREEN, BLUE, RED, BLACK
+    int tower_level{0};
 };
 
 bool operator==(const RobotState& lhs, const RobotState& rhs);

--- a/master-firmware/tests/strategy/test_score.cpp
+++ b/master-firmware/tests/strategy/test_score.cpp
@@ -54,3 +54,45 @@ TEST(AScore, countsSwitchWhenDeployed)
 
     CHECK_EQUAL(25, score_count_switch(state));
 };
+
+TEST(AScore, countsTowerOfLevelZero)
+{
+    state.tower_level = 0;
+
+    CHECK_EQUAL(0, score_count_tower(state));
+};
+
+TEST(AScore, countsTowerOfLevelOne)
+{
+    state.tower_level = 1;
+
+    CHECK_EQUAL(1, score_count_tower(state));
+};
+
+TEST(AScore, countsTowerOfLevelTwo)
+{
+    state.tower_level = 2;
+
+    CHECK_EQUAL(3, score_count_tower(state));
+};
+
+TEST(AScore, countsTowerOfLevelThree)
+{
+    state.tower_level = 3;
+
+    CHECK_EQUAL(6, score_count_tower(state));
+};
+
+TEST(AScore, countsTowerOfLevelFour)
+{
+    state.tower_level = 4;
+
+    CHECK_EQUAL(10, score_count_tower(state));
+};
+
+TEST(AScore, countsTowerOfLevelFive)
+{
+    state.tower_level = 5;
+
+    CHECK_EQUAL(15, score_count_tower(state));
+};

--- a/master-firmware/tests/test_strategy.cpp
+++ b/master-firmware/tests/test_strategy.cpp
@@ -107,7 +107,7 @@ TEST(Strategy, CanNotPushTheInterruptorWhenPanelIsNotOnTheMap)
     SwitchGoal switch_goal;
     int len = planner.plan(state, switch_goal, path, max_path_len);
 
-    CHECK_EQUAL(-2, len);
+    CHECK_TRUE(len < 0);
 }
 
 
@@ -139,7 +139,7 @@ TEST(Strategy, CanNotPushTheBeeWhenBeeIsNotOnTheMap)
     BeeGoal bee_goal;
     int len = planner.plan(state, bee_goal, path, max_path_len);
 
-    CHECK_EQUAL(-2, len);
+    CHECK_TRUE(len < 0);
 }
 
 TEST(Strategy, CanPickupCubes)
@@ -164,7 +164,7 @@ TEST(Strategy, CanBuildTower)
     const int max_path_len = 10;
     goap::Action<RobotState> *path[max_path_len] = {nullptr};
     auto actions = availableActions();
-    goap::Planner<RobotState,200> planner(actions.data(), actions.size());
+    goap::Planner<RobotState> planner(actions.data(), actions.size());
 
     BuildTowerGoal goal;
     int len = planner.plan(state, goal, path, max_path_len);

--- a/master-firmware/tests/test_strategy.cpp
+++ b/master-firmware/tests/test_strategy.cpp
@@ -43,7 +43,7 @@ TEST_GROUP(Strategy) {
     TurnSwitchOn turn_switch_on;
     DeployTheBee deploy_the_bee;
     DepositCubes deposit_cubes;
-    BuildTowerLevel build_tower_lvl1{0}, build_tower_lvl2{1}, build_tower_lvl3{2};
+    BuildTowerLevel build_tower_lvl1{0}, build_tower_lvl2{1}, build_tower_lvl3{2}, build_tower_lvl4{3};
 
     std::vector<goap::Action<RobotState>*> availableActions()
     {
@@ -59,6 +59,7 @@ TEST_GROUP(Strategy) {
             &build_tower_lvl1,
             &build_tower_lvl2,
             &build_tower_lvl3,
+            &build_tower_lvl4,
         };
     }
 };


### PR DESCRIPTION
This PR implements tower building, with some error handling:
- to avoid picking cubes where there are none
- to abort building a tower if we fail to build a level

Also covers the score computation from state. The sequence of colors is stored in the state, and can be set using the beacon input at some point. The arm trajectories are slightly better, we still need to tune the controllers more aggressively, but at least it should be more robust to failure.

This is currently limited to a single tower of 4 levels, i'll work next on building more towers. 