### PR TITLE
Build towers using color sequence from computer vision results

### DIFF
--- a/config_order.yaml
+++ b/config_order.yaml
@@ -34,20 +34,20 @@ master:
                 speed: # in rad / s
                     init: 0.75
                     slow: 0.75
-                    fast: 2.
+                    fast: 3.
                 acceleration: # in rad / s^2
                     init: 1.57
                     slow: 1.57
-                    fast: 6.
+                    fast: 10.
             distance:
                 speed: # in m / s
                     init: 0.1
                     slow: 0.2
-                    fast: 0.3
+                    fast: 0.5
                 acceleration: # in m / s^2
                     init: 0.15
                     slow: 0.5
-                    fast: 1.
+                    fast: 1.5
     lever:
         right:
             offset_x: 0.    # in mm

--- a/master-firmware/package.yml
+++ b/master-firmware/package.yml
@@ -73,6 +73,7 @@ source:
     - src/base/map.c
     - src/robot_helpers/math_helpers.c
     - src/robot_helpers/beacon_helpers.c
+    - src/robot_helpers/eurobot2018.c
     - src/robot_helpers/trajectory_helpers.c
     - src/robot_helpers/strategy_helpers.c
     - src/aversive/blocking_detection_manager/blocking_detection_manager.c
@@ -149,6 +150,7 @@ tests:
     - tests/aversive/test_geometry_discrete_circles.cpp
     - tests/aversive/test_geometry_polygon_intersection.cpp
     - tests/strategy/test_score.cpp
+    - tests/test_eurobot2018.cpp
 
 templates:
     app_src.mk.jinja: app_src.mk

--- a/master-firmware/package.yml
+++ b/master-firmware/package.yml
@@ -64,6 +64,7 @@ target.arm:
     - src/lever/lever_module.c
     - src/parameter_port.c
     - src/strategy/score_counter.cpp
+    - src/strategy/color_sequence_server.c
 
 source:
     - src/unix_timestamp.c

--- a/master-firmware/src/priorities.h
+++ b/master-firmware/src/priorities.h
@@ -15,6 +15,7 @@
 #define BASE_CONTROLLER_PRIO                    (NORMALPRIO)
 #define TRAJECTORY_MANAGER_PRIO                 (NORMALPRIO)
 #define MAP_SERVER_PRIO                         (NORMALPRIO)
+#define COLOR_SEQUENCE_SERVER_PRIO              (NORMALPRIO)
 #define ARMS_CONTROLLER_PRIO                    (NORMALPRIO)
 #define ARM_TRAJ_MANAGER_PRIO                   (NORMALPRIO)
 #define LEVER_MODULE_PRIO                       (NORMALPRIO)

--- a/master-firmware/src/robot_helpers/eurobot2018.c
+++ b/master-firmware/src/robot_helpers/eurobot2018.c
@@ -1,5 +1,16 @@
 #include "eurobot2018.h"
 
+/** Cubes color to string */
+const char* cube_color_name(enum cube_color color)
+{
+    if      (color == CUBE_YELLOW) { return "YELLOW"; }
+    else if (color == CUBE_GREEN)  { return "GREEN"; }
+    else if (color == CUBE_BLUE)   { return "BLUE"; }
+    else if (color == CUBE_ORANGE) { return "ORANGE"; }
+    else if (color == CUBE_BLACK)  { return "BLACK"; }
+    else                           { return "UNKNOWN"; }
+}
+
 enum cube_color cube_color_from_character(char c)
 {
     if      (c == 'Y') { return CUBE_YELLOW; }

--- a/master-firmware/src/robot_helpers/eurobot2018.c
+++ b/master-firmware/src/robot_helpers/eurobot2018.c
@@ -1,3 +1,5 @@
+#include <stdbool.h>
+
 #include "eurobot2018.h"
 
 /** Cubes color to string */
@@ -26,5 +28,31 @@ void cube_color_from_string(char* string, int string_len, enum cube_color* color
     for (int i = 0; i < string_len; i++)
     {
         colors[i] = cube_color_from_character(string[i]);
+    }
+}
+
+static bool color_in_sequence(enum cube_color* colors, int num_colors, enum cube_color color)
+{
+    for (int i = 0; i < num_colors; i++) {
+        if (colors[i] == color) {
+            return true;
+        }
+    }
+    return false;
+}
+
+void cube_color_fill_unknown(enum cube_color* colors, int num_colors)
+{
+    for (int i = 0; i < num_colors; i++) {
+        if (colors[i] != CUBE_UNKNOWN) {
+            continue;
+        }
+
+        for (int j = 0; j < (int)CUBE_UNKNOWN; j++) {
+            if (!color_in_sequence(colors, num_colors, (enum cube_color)j)) {
+                colors[i] = (enum cube_color)j;
+                break;
+            }
+        }
     }
 }

--- a/master-firmware/src/robot_helpers/eurobot2018.c
+++ b/master-firmware/src/robot_helpers/eurobot2018.c
@@ -10,9 +10,9 @@ enum cube_color cube_color_from_character(char c)
     else /* Unknown */ { return CUBE_UNKNOWN; }
 }
 
-void cube_color_from_string(char* string, enum cube_color* colors)
+void cube_color_from_string(char* string, int string_len, enum cube_color* colors)
 {
-    for (int i = 0; i < 3; i++)
+    for (int i = 0; i < string_len; i++)
     {
         colors[i] = cube_color_from_character(string[i]);
     }

--- a/master-firmware/src/robot_helpers/eurobot2018.c
+++ b/master-firmware/src/robot_helpers/eurobot2018.c
@@ -5,7 +5,7 @@ enum cube_color cube_color_from_character(char c)
     if      (c == 'Y') { return CUBE_YELLOW; }
     else if (c == 'G') { return CUBE_GREEN; }
     else if (c == 'B') { return CUBE_BLUE; }
-    else if (c == 'R') { return CUBE_RED; }
+    else if (c == 'O') { return CUBE_ORANGE; }
     else if (c == 'K') { return CUBE_BLACK; }
     else /* Unknown */ { return CUBE_UNKNOWN; }
 }

--- a/master-firmware/src/robot_helpers/eurobot2018.c
+++ b/master-firmware/src/robot_helpers/eurobot2018.c
@@ -1,0 +1,19 @@
+#include "eurobot2018.h"
+
+enum cube_color cube_color_from_character(char c)
+{
+    if      (c == 'Y') { return CUBE_YELLOW; }
+    else if (c == 'G') { return CUBE_GREEN; }
+    else if (c == 'B') { return CUBE_BLUE; }
+    else if (c == 'R') { return CUBE_RED; }
+    else if (c == 'K') { return CUBE_BLACK; }
+    else /* Unknown */ { return CUBE_UNKNOWN; }
+}
+
+void cube_color_from_string(char* string, enum cube_color* colors)
+{
+    for (int i = 0; i < 3; i++)
+    {
+        colors[i] = cube_color_from_character(string[i]);
+    }
+}

--- a/master-firmware/src/robot_helpers/eurobot2018.h
+++ b/master-firmware/src/robot_helpers/eurobot2018.h
@@ -10,7 +10,7 @@ enum cube_color {
     CUBE_YELLOW = 0,
     CUBE_GREEN,
     CUBE_BLUE,
-    CUBE_RED,
+    CUBE_ORANGE,
     CUBE_BLACK,
     CUBE_UNKNOWN, // Unknow color
 };

--- a/master-firmware/src/robot_helpers/eurobot2018.h
+++ b/master-firmware/src/robot_helpers/eurobot2018.h
@@ -15,6 +15,9 @@ enum cube_color {
     CUBE_UNKNOWN, // Unknow color
 };
 
+/** Get color name from enum */
+const char* cube_color_name(enum cube_color color);
+
 /** Retrieve color from character */
 enum cube_color cube_color_from_character(char c);
 

--- a/master-firmware/src/robot_helpers/eurobot2018.h
+++ b/master-firmware/src/robot_helpers/eurobot2018.h
@@ -17,7 +17,9 @@ enum cube_color {
 
 /** Retrieve color from character */
 enum cube_color cube_color_from_character(char c);
-void cube_color_from_string(char* string, enum cube_color* colors);
+
+/** Retrieve colors from string, length of colors should exceed string_len */
+void cube_color_from_string(char* string, int string_len, enum cube_color* colors);
 
 #ifdef __cplusplus
 }

--- a/master-firmware/src/robot_helpers/eurobot2018.h
+++ b/master-firmware/src/robot_helpers/eurobot2018.h
@@ -1,6 +1,10 @@
 #ifndef EUROBOT2018_H
 #define EUROBOT2018_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /** Cubes color */
 enum cube_color {
     CUBE_YELLOW = 0,
@@ -8,6 +12,15 @@ enum cube_color {
     CUBE_BLUE,
     CUBE_RED,
     CUBE_BLACK,
+    CUBE_UNKNOWN, // Unknow color
 };
+
+/** Retrieve color from character */
+enum cube_color cube_color_from_character(char c);
+void cube_color_from_string(char* string, enum cube_color* colors);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* EUROBOT2018_H */

--- a/master-firmware/src/robot_helpers/eurobot2018.h
+++ b/master-firmware/src/robot_helpers/eurobot2018.h
@@ -24,6 +24,12 @@ enum cube_color cube_color_from_character(char c);
 /** Retrieve colors from string, length of colors should exceed string_len */
 void cube_color_from_string(char* string, int string_len, enum cube_color* colors);
 
+/** Fill unknown colors in sequence with default from valid colors
+ * Only works for a sequence of 5 since there are 5 valid colors
+ * and they can only appear once in a block of cubes.
+ */
+void cube_color_fill_unknown(enum cube_color* colors, int num_colors);
+
 #ifdef __cplusplus
 }
 #endif

--- a/master-firmware/src/robot_helpers/strategy_helpers.c
+++ b/master-firmware/src/robot_helpers/strategy_helpers.c
@@ -92,7 +92,7 @@ static point_t cube_pos_in_block_frame(enum cube_color color)
     switch(color) {
         case CUBE_GREEN:    return point(  cube_size,            0);
         case CUBE_BLUE:     return point(           0,   cube_size);
-        case CUBE_RED:      return point(- cube_size,            0);
+        case CUBE_ORANGE:   return point(- cube_size,            0);
         case CUBE_BLACK:    return point(           0, - cube_size);
         case CUBE_YELLOW:
         default:            return point(           0,           0);

--- a/master-firmware/src/strategy.cpp
+++ b/master-firmware/src/strategy.cpp
@@ -549,10 +549,21 @@ struct BuildTowerLevel : actions::BuildTowerLevel {
     }
 };
 
+void strategy_read_color_sequence(RobotState& state)
+{
+    messagebus_topic_t* colors_topic = messagebus_find_topic_blocking(&bus, "/colors");
+    messagebus_topic_read(colors_topic, &state.tower_sequence[0], sizeof(state.tower_sequence));
+    NOTICE("Tower sequence is: %s %s %s %s %s",
+           cube_color_name(state.tower_sequence[0]),
+           cube_color_name(state.tower_sequence[1]),
+           cube_color_name(state.tower_sequence[2]),
+           cube_color_name(state.tower_sequence[3]),
+           cube_color_name(state.tower_sequence[4]));
+}
 
 void strategy_order_play_game(enum strat_color_t color, RobotState& state)
 {
-    messagebus_topic_t*state_topic = messagebus_find_topic_blocking(&bus, "/state");
+    messagebus_topic_t* state_topic = messagebus_find_topic_blocking(&bus, "/state");
 
     InitGoal init_goal;
 
@@ -642,6 +653,7 @@ void strategy_order_play_game(enum strat_color_t color, RobotState& state)
     /* Wait for starter to begin */
     wait_for_starter();
     trajectory_game_timer_reset();
+    strategy_read_color_sequence(state);
 
     NOTICE("Starting game...");
     auto goals_are_reached = [&goals](const RobotState& state) {

--- a/master-firmware/src/strategy.cpp
+++ b/master-firmware/src/strategy.cpp
@@ -30,6 +30,7 @@
 #include "strategy/goals.h"
 #include "strategy/state.h"
 #include "strategy/score_counter.h"
+#include "strategy/color_sequence_server.h"
 
 
 static enum strat_color_t wait_for_color_selection(void);
@@ -730,6 +731,7 @@ void strategy_play_game(void *p)
     enum strat_color_t color = wait_for_color_selection();
     map_server_start(color);
     score_counter_start();
+    color_sequence_server_start();
 
 #ifdef DEBRA
     NOTICE("First, Order...");

--- a/master-firmware/src/strategy.cpp
+++ b/master-firmware/src/strategy.cpp
@@ -555,6 +555,14 @@ void strategy_read_color_sequence(RobotState& state)
     messagebus_topic_t* colors_topic = messagebus_find_topic_blocking(&bus, "/colors");
 
     messagebus_topic_read(colors_topic, &state.tower_sequence[0], tower_sequence_len);
+
+    if (state.tower_sequence[0] != CUBE_UNKNOWN &&
+        state.tower_sequence[1] != CUBE_UNKNOWN &&
+        state.tower_sequence[2] != CUBE_UNKNOWN) {
+        NOTICE("Received a valid color sequence");
+        state.tower_sequence_known = true;
+    }
+
     cube_color_fill_unknown(&state.tower_sequence[0], tower_sequence_len);
 
     NOTICE("Tower sequence is: %s %s %s %s %s",

--- a/master-firmware/src/strategy.cpp
+++ b/master-firmware/src/strategy.cpp
@@ -551,8 +551,12 @@ struct BuildTowerLevel : actions::BuildTowerLevel {
 
 void strategy_read_color_sequence(RobotState& state)
 {
+    int tower_sequence_len = sizeof(state.tower_sequence) / sizeof(enum cube_color);
     messagebus_topic_t* colors_topic = messagebus_find_topic_blocking(&bus, "/colors");
-    messagebus_topic_read(colors_topic, &state.tower_sequence[0], sizeof(state.tower_sequence));
+
+    messagebus_topic_read(colors_topic, &state.tower_sequence[0], tower_sequence_len);
+    cube_color_fill_unknown(&state.tower_sequence[0], tower_sequence_len);
+
     NOTICE("Tower sequence is: %s %s %s %s %s",
            cube_color_name(state.tower_sequence[0]),
            cube_color_name(state.tower_sequence[1]),

--- a/master-firmware/src/strategy.cpp
+++ b/master-firmware/src/strategy.cpp
@@ -517,7 +517,7 @@ struct BuildTowerLevel : actions::BuildTowerLevel {
         NOTICE("Building a tower level %d at %d %d", level, x_mm, y_mm);
 
         if (level == 0) {
-            if (!strategy_goto_avoid(MIRROR_X(m_color, x_mm), y_mm, MIRROR_A(m_color, -225), TRAJ_FLAGS_ALL)) {
+            if (!strategy_goto_avoid(MIRROR_X(m_color, x_mm), y_mm, MIRROR_A(m_color, -215), TRAJ_FLAGS_ALL)) {
                 return false;
             }
         }
@@ -534,8 +534,8 @@ struct BuildTowerLevel : actions::BuildTowerLevel {
             return false;
         }
 
-        const int tower_x_mm = x_mm - 30;
-        const int tower_y_mm = y_mm - 210;
+        const int tower_x_mm = x_mm + 30;
+        const int tower_y_mm = y_mm - 240;
         if (!strat_deposit_cube(MIRROR_X(m_color, tower_x_mm), tower_y_mm, level)) {
             WARNING("Tower building did not go as expected");
             return false;

--- a/master-firmware/src/strategy/color_sequence_server.c
+++ b/master-firmware/src/strategy/color_sequence_server.c
@@ -39,9 +39,15 @@ static THD_FUNCTION(color_sequence_server_thd, arg) {
     NOTICE("Color sequence server up, listening over BT");
 
     while (true) {
-        size_t len = sdAsynchronousRead(&SD2, buffer, sizeof(buffer));
+        // Wait for the sync character
+        do {
+            sdRead(&SD2, buffer, 1);
+        } while(buffer[0] != '@');
 
-        if (len < 3) {
+        // Read the color sequence
+        sdRead(&SD2, buffer, 4);
+
+        if (buffer[3] == '\n') {
             cube_color_from_string((char*)buffer, 3, colors);
             messagebus_topic_publish(&colors_topic, &colors[0], sizeof(colors));
 

--- a/master-firmware/src/strategy/color_sequence_server.c
+++ b/master-firmware/src/strategy/color_sequence_server.c
@@ -39,14 +39,21 @@ static THD_FUNCTION(color_sequence_server_thd, arg) {
     NOTICE("Color sequence server up, listening over BT");
 
     while (true) {
-        chThdSleepMilliseconds(1000 / COLOR_SEQUENCE_SERVER_FREQUENCY);
-
         size_t len = sdAsynchronousRead(&SD2, buffer, sizeof(buffer));
 
-        if (len != 5) { continue; }
+        if (len < 3) {
+            cube_color_from_string((char*)buffer, 3, colors);
+            messagebus_topic_publish(&colors_topic, &colors[0], sizeof(colors));
 
-        cube_color_from_string((char*)buffer, 3, colors);
-        messagebus_topic_publish(&colors_topic, &colors[0], sizeof(colors));
+            DEBUG("Received color: %s %s %s %s %s",
+                  cube_color_name(colors[0]),
+                  cube_color_name(colors[1]),
+                  cube_color_name(colors[2]),
+                  cube_color_name(colors[3]),
+                  cube_color_name(colors[4]));
+        }
+
+        chThdSleepMilliseconds(1000 / COLOR_SEQUENCE_SERVER_FREQUENCY);
     }
 }
 

--- a/master-firmware/src/strategy/color_sequence_server.c
+++ b/master-firmware/src/strategy/color_sequence_server.c
@@ -5,6 +5,7 @@
 
 #include "main.h"
 #include "priorities.h"
+#include "control_panel.h"
 
 #include "robot_helpers/eurobot2018.h"
 #include "color_sequence_server.h"
@@ -51,6 +52,7 @@ static THD_FUNCTION(color_sequence_server_thd, arg) {
             cube_color_from_string((char*)buffer, 3, colors);
             messagebus_topic_publish(&colors_topic, &colors[0], sizeof(colors));
 
+            control_panel_toggle(LED_POWER);
             DEBUG("Received color: %s %s %s %s %s",
                   cube_color_name(colors[0]),
                   cube_color_name(colors[1]),

--- a/master-firmware/src/strategy/color_sequence_server.c
+++ b/master-firmware/src/strategy/color_sequence_server.c
@@ -1,0 +1,53 @@
+#include <ch.h>
+#include <hal.h>
+
+#include <error/error.h>
+
+#include "robot_helpers/eurobot2018.h"
+
+#include "priorities.h"
+#include "color_sequence_server.h"
+
+#define COLOR_SEQUENCE_SERVER_STACKSIZE 512
+
+// Bluetooth UART
+#define BLUETOOTH_UART_BAUDRATE 19200
+static const SerialConfig bt_uart_config = {
+    .speed = BLUETOOTH_UART_BAUDRATE,
+    .cr1 = 0,
+    .cr2 = USART_CR2_STOP1_BITS | USART_CR2_LINEN,
+    .cr3 = 0
+};
+
+static enum cube_color colors[5] = {
+    CUBE_UNKNOWN, CUBE_UNKNOWN, CUBE_UNKNOWN, CUBE_UNKNOWN, CUBE_UNKNOWN
+};
+
+static THD_FUNCTION(color_sequence_server_thd, arg) {
+    (void)arg;
+    chRegSetThreadName(__FUNCTION__);
+
+    uint8_t buffer[16];
+    sdStart(&SD2, &bt_uart_config);
+
+    NOTICE("Color sequence server up, listening over BT");
+
+    while (true) {
+        size_t len = sdAsynchronousRead(&SD2, buffer, sizeof(buffer));
+
+        if (len != 5) { continue; }
+
+        cube_color_from_string((char*)buffer, colors);
+
+        chThdSleepMilliseconds(1000 / COLOR_SEQUENCE_SERVER_FREQUENCY);
+    }
+}
+
+void color_sequence_server_start()
+{
+    static THD_WORKING_AREA(color_sequence_server_thd_wa,
+                            COLOR_SEQUENCE_SERVER_STACKSIZE);
+    chThdCreateStatic(
+        color_sequence_server_thd_wa, sizeof(color_sequence_server_thd_wa),
+        COLOR_SEQUENCE_SERVER_PRIO, color_sequence_server_thd, NULL);
+}

--- a/master-firmware/src/strategy/color_sequence_server.h
+++ b/master-firmware/src/strategy/color_sequence_server.h
@@ -1,0 +1,16 @@
+#ifndef COLOR_SEQUENCE_SERVER_H
+#define COLOR_SEQUENCE_SERVER_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define COLOR_SEQUENCE_SERVER_FREQUENCY 1
+
+void color_sequence_server_start(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* COLOR_SEQUENCE_SERVER_H */

--- a/master-firmware/src/strategy/score.cpp
+++ b/master-firmware/src/strategy/score.cpp
@@ -33,6 +33,10 @@ int score_count_tower(const RobotState& state)
 
 int score_count_tower_bonus(const RobotState& state)
 {
+    if (!state.tower_sequence_known) {
+        return 0;
+    }
+
     int score = 0;
     for (const auto& construction_zone : state.construction_zone) {
         if (construction_zone.tower_level >= 3) {

--- a/master-firmware/src/strategy/score.cpp
+++ b/master-firmware/src/strategy/score.cpp
@@ -30,3 +30,14 @@ int score_count_tower(const RobotState& state)
     }
     return score;
 }
+
+int score_count_tower_bonus(const RobotState& state)
+{
+    int score = 0;
+    for (const auto& construction_zone : state.construction_zone) {
+        if (construction_zone.tower_level >= 3) {
+            score += 30;
+        }
+    }
+    return score;
+}

--- a/master-firmware/src/strategy/score.h
+++ b/master-firmware/src/strategy/score.h
@@ -14,6 +14,7 @@ int score_count_bee(const RobotState& state);
 int score_count_switch(const RobotState& state);
 
 int score_count_tower(const RobotState& state);
+int score_count_tower_bonus(const RobotState& state);
 
 #ifdef __cplusplus
 }

--- a/master-firmware/src/strategy/score_counter.cpp
+++ b/master-firmware/src/strategy/score_counter.cpp
@@ -37,6 +37,7 @@ static THD_FUNCTION(score_counter_thd, arg)
         score += score_count_bee(state);
         score += score_count_switch(state);
         score += score_count_tower(state);
+        score += score_count_tower_bonus(state);
 
         messagebus_topic_publish(&score_topic, &score, sizeof(score));
     }

--- a/master-firmware/src/strategy/state.h
+++ b/master-firmware/src/strategy/state.h
@@ -22,6 +22,7 @@ struct RobotState {
         {850, 540}, {300, 1190}, {1100, 1500}, {1900, 1500}, {2700, 1190}, {2150, 540},
     };
 
+    bool tower_sequence_known = {false};
     enum cube_color tower_sequence[5] = {CUBE_YELLOW, CUBE_BLACK, CUBE_BLUE, CUBE_GREEN, CUBE_ORANGE};
     struct {
         bool cubes_ready[5] = {false, false, false, false, false}; // YELLOW, GREEN, BLUE, ORANGE, BLACK

--- a/master-firmware/src/strategy/state.h
+++ b/master-firmware/src/strategy/state.h
@@ -22,9 +22,9 @@ struct RobotState {
         {850, 540}, {300, 1190}, {1100, 1500}, {1900, 1500}, {2700, 1190}, {2150, 540},
     };
 
-    enum cube_color tower_sequence[5] = {CUBE_YELLOW, CUBE_BLACK, CUBE_BLUE, CUBE_GREEN, CUBE_RED};
+    enum cube_color tower_sequence[5] = {CUBE_YELLOW, CUBE_BLACK, CUBE_BLUE, CUBE_GREEN, CUBE_ORANGE};
     struct {
-        bool cubes_ready[5] = {false, false, false, false, false}; // YELLOW, GREEN, BLUE, RED, BLACK
+        bool cubes_ready[5] = {false, false, false, false, false}; // YELLOW, GREEN, BLUE, ORANGE, BLACK
         uint16_t cubes_pos[5][2] = {{0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}};
         uint8_t tower_level{0};
         uint16_t tower_pos[2] = {0, 0};

--- a/master-firmware/tests/strategy/test_score.cpp
+++ b/master-firmware/tests/strategy/test_score.cpp
@@ -112,3 +112,25 @@ TEST(AScore, countsTwosTowerOfDifferentLevels)
 
     CHECK_EQUAL(16, score_count_tower(state));
 };
+
+TEST(AScore, doesNotCountTowerBonusForSmallTower)
+{
+    state.construction_zone[0].tower_level = 1;
+
+    CHECK_EQUAL(0, score_count_tower_bonus(state));
+};
+
+TEST(AScore, countsTowerBonusForSingleTower)
+{
+    state.construction_zone[0].tower_level = 3;
+
+    CHECK_EQUAL(30, score_count_tower_bonus(state));
+};
+
+TEST(AScore, countsTowerBonusForTwoTowers)
+{
+    state.construction_zone[0].tower_level = 3;
+    state.construction_zone[1].tower_level = 4;
+
+    CHECK_EQUAL(60, score_count_tower_bonus(state));
+};

--- a/master-firmware/tests/strategy/test_score.cpp
+++ b/master-firmware/tests/strategy/test_score.cpp
@@ -113,8 +113,16 @@ TEST(AScore, countsTwosTowerOfDifferentLevels)
     CHECK_EQUAL(16, score_count_tower(state));
 };
 
+TEST(AScore, doesNotCountTowerBonusWhenSequenceIsNotKnown)
+{
+    state.construction_zone[0].tower_level = 3;
+
+    CHECK_EQUAL(0, score_count_tower_bonus(state));
+};
+
 TEST(AScore, doesNotCountTowerBonusForSmallTower)
 {
+    state.tower_sequence_known = true;
     state.construction_zone[0].tower_level = 1;
 
     CHECK_EQUAL(0, score_count_tower_bonus(state));
@@ -122,6 +130,7 @@ TEST(AScore, doesNotCountTowerBonusForSmallTower)
 
 TEST(AScore, countsTowerBonusForSingleTower)
 {
+    state.tower_sequence_known = true;
     state.construction_zone[0].tower_level = 3;
 
     CHECK_EQUAL(30, score_count_tower_bonus(state));
@@ -129,6 +138,7 @@ TEST(AScore, countsTowerBonusForSingleTower)
 
 TEST(AScore, countsTowerBonusForTwoTowers)
 {
+    state.tower_sequence_known = true;
     state.construction_zone[0].tower_level = 3;
     state.construction_zone[1].tower_level = 4;
 

--- a/master-firmware/tests/test_eurobot2018.cpp
+++ b/master-firmware/tests/test_eurobot2018.cpp
@@ -11,7 +11,7 @@ TEST(ACubeColorParser, FindsColorsFromValidCharacters)
     CHECK_EQUAL(CUBE_YELLOW, cube_color_from_character('Y'));
     CHECK_EQUAL( CUBE_GREEN, cube_color_from_character('G'));
     CHECK_EQUAL(  CUBE_BLUE, cube_color_from_character('B'));
-    CHECK_EQUAL(   CUBE_RED, cube_color_from_character('R'));
+    CHECK_EQUAL(CUBE_ORANGE, cube_color_from_character('O'));
     CHECK_EQUAL( CUBE_BLACK, cube_color_from_character('K'));
 }
 
@@ -28,7 +28,7 @@ TEST(ACubeColorParser, FindsColorSequence)
     enum cube_color colors[5];
     char string[] = {'Y', 'B', 'G'};
 
-    cube_color_from_string(&string[0], &colors[0]);
+    cube_color_from_string(&string[0], sizeof(string), &colors[0]);
 
     CHECK_EQUAL(CUBE_YELLOW, colors[0]);
     CHECK_EQUAL(CUBE_BLUE, colors[1]);

--- a/master-firmware/tests/test_eurobot2018.cpp
+++ b/master-firmware/tests/test_eurobot2018.cpp
@@ -1,0 +1,36 @@
+#include <CppUTest/TestHarness.h>
+
+#include "robot_helpers/eurobot2018.h"
+
+TEST_GROUP(ACubeColorParser)
+{
+};
+
+TEST(ACubeColorParser, FindsColorsFromValidCharacters)
+{
+    CHECK_EQUAL(CUBE_YELLOW, cube_color_from_character('Y'));
+    CHECK_EQUAL( CUBE_GREEN, cube_color_from_character('G'));
+    CHECK_EQUAL(  CUBE_BLUE, cube_color_from_character('B'));
+    CHECK_EQUAL(   CUBE_RED, cube_color_from_character('R'));
+    CHECK_EQUAL( CUBE_BLACK, cube_color_from_character('K'));
+}
+
+TEST(ACubeColorParser, DoesNotKnowColorGivenInvalidCharacters)
+{
+    CHECK_EQUAL(CUBE_UNKNOWN, cube_color_from_character('C'));
+    CHECK_EQUAL(CUBE_UNKNOWN, cube_color_from_character('W'));
+    CHECK_EQUAL(CUBE_UNKNOWN, cube_color_from_character('A'));
+    CHECK_EQUAL(CUBE_UNKNOWN, cube_color_from_character('P'));
+}
+
+TEST(ACubeColorParser, FindsColorSequence)
+{
+    enum cube_color colors[5];
+    char string[] = {'Y', 'B', 'G'};
+
+    cube_color_from_string(&string[0], &colors[0]);
+
+    CHECK_EQUAL(CUBE_YELLOW, colors[0]);
+    CHECK_EQUAL(CUBE_BLUE, colors[1]);
+    CHECK_EQUAL(CUBE_GREEN, colors[2]);
+}

--- a/master-firmware/tests/test_eurobot2018.cpp
+++ b/master-firmware/tests/test_eurobot2018.cpp
@@ -1,4 +1,5 @@
 #include <CppUTest/TestHarness.h>
+#include <array>
 
 #include "robot_helpers/eurobot2018.h"
 
@@ -33,4 +34,30 @@ TEST(ACubeColorParser, FindsColorSequence)
     CHECK_EQUAL(CUBE_YELLOW, colors[0]);
     CHECK_EQUAL(CUBE_BLUE, colors[1]);
     CHECK_EQUAL(CUBE_GREEN, colors[2]);
+}
+
+TEST(ACubeColorParser, FillsUnknownWithValidColors)
+{
+    std::array<enum cube_color, 5> colors = {CUBE_UNKNOWN, CUBE_UNKNOWN, CUBE_UNKNOWN, CUBE_UNKNOWN, CUBE_UNKNOWN};
+
+    cube_color_fill_unknown(colors.data(), colors.size());
+
+    CHECK_EQUAL(CUBE_YELLOW, colors[0]);
+    CHECK_EQUAL(CUBE_GREEN, colors[1]);
+    CHECK_EQUAL(CUBE_BLUE, colors[2]);
+    CHECK_EQUAL(CUBE_ORANGE, colors[3]);
+    CHECK_EQUAL(CUBE_BLACK, colors[4]);
+}
+
+TEST(ACubeColorParser, FillsOnlyUnknownWithValidColors)
+{
+    std::array<enum cube_color, 5> colors = {CUBE_BLACK, CUBE_BLUE, CUBE_GREEN, CUBE_UNKNOWN, CUBE_UNKNOWN};
+
+    cube_color_fill_unknown(colors.data(), colors.size());
+
+    CHECK_EQUAL(CUBE_BLACK, colors[0]);
+    CHECK_EQUAL(CUBE_BLUE, colors[1]);
+    CHECK_EQUAL(CUBE_GREEN, colors[2]);
+    CHECK_EQUAL(CUBE_YELLOW, colors[3]);
+    CHECK_EQUAL(CUBE_ORANGE, colors[4]);
 }

--- a/master-firmware/tests/test_strategy_helpers.cpp
+++ b/master-firmware/tests/test_strategy_helpers.cpp
@@ -25,7 +25,7 @@ TEST(ACubePositionComputer, FindsPositionOfTrivialBlocksPose)
     POINT_EQUAL({  0,   0}, strategy_cube_pos(cubes_pose, CUBE_YELLOW));
     POINT_EQUAL({ 60,   0}, strategy_cube_pos(cubes_pose, CUBE_GREEN));
     POINT_EQUAL({  0,  60}, strategy_cube_pos(cubes_pose, CUBE_BLUE));
-    POINT_EQUAL({-60,   0}, strategy_cube_pos(cubes_pose, CUBE_RED));
+    POINT_EQUAL({-60,   0}, strategy_cube_pos(cubes_pose, CUBE_ORANGE));
     POINT_EQUAL({  0, -60}, strategy_cube_pos(cubes_pose, CUBE_BLACK));
 }
 
@@ -37,7 +37,7 @@ TEST(ACubePositionComputer, FindsPositionOfNonTrivialBlocksPose)
     POINT_EQUAL({100,          200         }, strategy_cube_pos(cubes_pose, CUBE_YELLOW));
     POINT_EQUAL({100 + offset, 200 + offset}, strategy_cube_pos(cubes_pose, CUBE_GREEN));
     POINT_EQUAL({100 - offset, 200 + offset}, strategy_cube_pos(cubes_pose, CUBE_BLUE));
-    POINT_EQUAL({100 - offset, 200 - offset}, strategy_cube_pos(cubes_pose, CUBE_RED));
+    POINT_EQUAL({100 - offset, 200 - offset}, strategy_cube_pos(cubes_pose, CUBE_ORANGE));
     POINT_EQUAL({100 + offset, 200 - offset}, strategy_cube_pos(cubes_pose, CUBE_BLACK));
 }
 


### PR DESCRIPTION
This PR integrates the work from https://github.com/cvra/computer-vision that detects the color sequence using a RPi with camera and streams the results over bluetooth. A Bluetooth module is wired on UART2 on the master board, and the result is parsed, published over msgbus, then the last value is read by the strategy just after the starter is triggered.
The score counting is also updated.