### PR TITLE
Use ball gun on both robots

### DIFF
--- a/config_chaos.yaml
+++ b/config_chaos.yaml
@@ -274,3 +274,7 @@ actuator:
         control:
             mode: 0 # openloop
             low_batt_th: 12.
+    ball-accelerator:
+        control:
+            mode: 0 # openloop
+            low_batt_th: 12.

--- a/config_chaos.yaml
+++ b/config_chaos.yaml
@@ -68,7 +68,7 @@ master:
     ballgun:
         servo:
             deployed: 0.0015
-            retracted: 0.0020
+            retracted: 0.00192
         turbine:
             arm: 0.00153
             charge: 0.0018

--- a/config_chaos.yaml
+++ b/config_chaos.yaml
@@ -70,11 +70,13 @@ master:
             deployed_fully: 0.00095
             deployed: 0.0015
             retracted: 0.00192
+            channel: 1
         turbine:
             arm: 0.00153
             charge: 0.00193
             fire: 0.0012
             slowfire: 0.00133
+            channel: 0
         accelerator:
             charge: -3.0
             fire: 5.0

--- a/config_chaos.yaml
+++ b/config_chaos.yaml
@@ -65,6 +65,10 @@ master:
             servo:
                 deployed: 0.0022
                 retracted: 0.00088
+    ballgun:
+        servo:
+            deployed: 0.0017
+            retracted: 0.0021
     main_arm:
         control:
             x:

--- a/config_chaos.yaml
+++ b/config_chaos.yaml
@@ -73,6 +73,9 @@ master:
             arm: 0.00153
             charge: 0.0018
             fire: 0.0012
+        accelerator:
+            charge: 2.0
+            fire: -2.0
     main_arm:
         control:
             x:

--- a/config_chaos.yaml
+++ b/config_chaos.yaml
@@ -72,9 +72,9 @@ master:
             retracted: 0.00192
             channel: 1
         turbine:
-            arm: 0.00153
+            arm: 0.00154
             charge: 0.00193
-            fire: 0.0012
+            fire: 0.00125
             slowfire: 0.00133
             channel: 0
         accelerator:

--- a/config_chaos.yaml
+++ b/config_chaos.yaml
@@ -67,6 +67,7 @@ master:
                 retracted: 0.00088
     ballgun:
         servo:
+            deployed_fully: 0.00095
             deployed: 0.0015
             retracted: 0.00192
         turbine:

--- a/config_chaos.yaml
+++ b/config_chaos.yaml
@@ -69,6 +69,10 @@ master:
         servo:
             deployed: 0.0017
             retracted: 0.0021
+        turbine:
+            arm: 0.00153
+            charge: 0.0018
+            fire: 0.0012
     main_arm:
         control:
             x:

--- a/config_chaos.yaml
+++ b/config_chaos.yaml
@@ -67,15 +67,15 @@ master:
                 retracted: 0.00088
     ballgun:
         servo:
-            deployed: 0.0017
-            retracted: 0.0021
+            deployed: 0.0015
+            retracted: 0.0020
         turbine:
             arm: 0.00153
             charge: 0.0018
             fire: 0.0012
         accelerator:
-            charge: 2.0
-            fire: -2.0
+            charge: -3.0
+            fire: 5.0
     main_arm:
         control:
             x:

--- a/config_chaos.yaml
+++ b/config_chaos.yaml
@@ -73,9 +73,11 @@ master:
             arm: 0.00153
             charge: 0.0018
             fire: 0.0012
+            slowfire: 0.00145
         accelerator:
             charge: -3.0
             fire: 5.0
+            slowfire: 2.0
     main_arm:
         control:
             x:

--- a/config_chaos.yaml
+++ b/config_chaos.yaml
@@ -72,13 +72,13 @@ master:
             retracted: 0.00192
         turbine:
             arm: 0.00153
-            charge: 0.0018
+            charge: 0.00193
             fire: 0.0012
-            slowfire: 0.00145
+            slowfire: 0.00133
         accelerator:
             charge: -3.0
             fire: 5.0
-            slowfire: 2.0
+            slowfire: 1.5
     main_arm:
         control:
             x:

--- a/config_order.yaml
+++ b/config_order.yaml
@@ -274,3 +274,7 @@ actuator:
         control:
             mode: 0 # openloop
             low_batt_th: 12.
+    ball-accelerator:
+        control:
+            mode: 0 # openloop
+            low_batt_th: 12.

--- a/config_order.yaml
+++ b/config_order.yaml
@@ -65,6 +65,10 @@ master:
             servo:
                 deployed: 0.00215
                 retracted: 0.0008
+    ballgun:
+        servo:
+            deployed: 0.0017
+            retracted: 0.0021
     main_arm:
         control:
             x:

--- a/config_order.yaml
+++ b/config_order.yaml
@@ -67,6 +67,7 @@ master:
                 retracted: 0.0008
     ballgun:
         servo:
+            deployed_fully: 0.00095
             deployed: 0.0017
             retracted: 0.0021
         turbine:

--- a/config_order.yaml
+++ b/config_order.yaml
@@ -73,6 +73,9 @@ master:
             arm: 0.00153
             charge: 0.0018
             fire: 0.0012
+        accelerator:
+            charge: 2.0
+            fire: -2.0
     main_arm:
         control:
             x:

--- a/config_order.yaml
+++ b/config_order.yaml
@@ -69,6 +69,10 @@ master:
         servo:
             deployed: 0.0017
             retracted: 0.0021
+        turbine:
+            arm: 0.00153
+            charge: 0.0018
+            fire: 0.0012
     main_arm:
         control:
             x:

--- a/config_order.yaml
+++ b/config_order.yaml
@@ -74,8 +74,8 @@ master:
             charge: 0.0018
             fire: 0.0012
         accelerator:
-            charge: 2.0
-            fire: -2.0
+            charge: -3.0
+            fire: 5.0
     main_arm:
         control:
             x:

--- a/config_order.yaml
+++ b/config_order.yaml
@@ -73,9 +73,11 @@ master:
             arm: 0.00153
             charge: 0.0018
             fire: 0.0012
+            slowfire: 0.00145
         accelerator:
             charge: -3.0
             fire: 5.0
+            slowfire: 2.0
     main_arm:
         control:
             x:

--- a/config_order.yaml
+++ b/config_order.yaml
@@ -70,11 +70,13 @@ master:
             deployed_fully: 0.00095
             deployed: 0.0017
             retracted: 0.0021
+            channel: 1
         turbine:
             arm: 0.00153
             charge: 0.0018
             fire: 0.0012
             slowfire: 0.00145
+            channel: 0
         accelerator:
             charge: -3.0
             fire: 5.0

--- a/master-firmware/package.yml
+++ b/master-firmware/package.yml
@@ -65,6 +65,7 @@ target.arm:
     - src/parameter_port.c
     - src/strategy/score_counter.cpp
     - src/strategy/color_sequence_server.c
+    - src/ballgun/ballgun_module.c
 
 source:
     - src/unix_timestamp.c

--- a/master-firmware/package.yml
+++ b/master-firmware/package.yml
@@ -107,6 +107,7 @@ source:
     - src/base/base_helpers.c
     - src/strategy/state.cpp
     - src/strategy/score.cpp
+    - src/ballgun/ballgun.c
 
 include_directories:
     - src/
@@ -152,6 +153,7 @@ tests:
     - tests/aversive/test_geometry_polygon_intersection.cpp
     - tests/strategy/test_score.cpp
     - tests/test_eurobot2018.cpp
+    - tests/test_ballgun.cpp
 
 templates:
     app_src.mk.jinja: app_src.mk

--- a/master-firmware/src/ballgun/ballgun.c
+++ b/master-firmware/src/ballgun/ballgun.c
@@ -125,3 +125,9 @@ void ballgun_fire(ballgun_t* ballgun)
 
     ballgun_unlock(&ballgun->lock);
 }
+
+void ballgun_tidy(ballgun_t* ballgun)
+{
+    ballgun_arm(ballgun);
+    ballgun_retract(ballgun);
+}

--- a/master-firmware/src/ballgun/ballgun.c
+++ b/master-firmware/src/ballgun/ballgun.c
@@ -22,12 +22,13 @@ void ballgun_init(ballgun_t* ballgun)
     chMtxObjectInit(&ballgun->lock);
 }
 
-void ballgun_set_servo_range(ballgun_t* ballgun, float retracted, float deployed)
+void ballgun_set_servo_range(ballgun_t* ballgun, float retracted, float deployed, float deployed_fully)
 {
     ballgun_lock(&ballgun->lock);
 
     ballgun->servo_retracted_pwm = retracted;
     ballgun->servo_deployed_pwm = deployed;
+    ballgun->servo_deployed_fully_pwm = deployed_fully;
 
     ballgun_unlock(&ballgun->lock);
 }
@@ -80,6 +81,16 @@ void ballgun_deploy(ballgun_t* ballgun)
 
     ballgun->state = BALLGUN_DEPLOYED;
     ballgun->set_ballgun(ballgun->ballgun_args, ballgun->servo_deployed_pwm);
+
+    ballgun_unlock(&ballgun->lock);
+}
+
+void ballgun_deploy_fully(ballgun_t* ballgun)
+{
+    ballgun_lock(&ballgun->lock);
+
+    ballgun->state = BALLGUN_DEPLOYED_FULLY;
+    ballgun->set_ballgun(ballgun->ballgun_args, ballgun->servo_deployed_fully_pwm);
 
     ballgun_unlock(&ballgun->lock);
 }

--- a/master-firmware/src/ballgun/ballgun.c
+++ b/master-firmware/src/ballgun/ballgun.c
@@ -1,0 +1,58 @@
+#include "ballgun.h"
+
+#include <string.h>
+
+static void ballgun_lock(mutex_t* mutex)
+{
+    chMtxLock(mutex);
+}
+
+static void ballgun_unlock(mutex_t* mutex)
+{
+    chMtxUnlock(mutex);
+}
+
+void ballgun_init(ballgun_t* ballgun)
+{
+    memset(ballgun, 0, sizeof(ballgun_t));
+
+    ballgun->state = BALLGUN_DISABLED;
+
+    chMtxObjectInit(&ballgun->lock);
+}
+
+void ballgun_set_servo_range(ballgun_t* ballgun, float servo_retracted_pwm, float servo_deployed_pwm)
+{
+    ballgun_lock(&ballgun->lock);
+
+    ballgun->servo_retracted_pwm = servo_retracted_pwm;
+    ballgun->servo_deployed_pwm = servo_deployed_pwm;
+
+    ballgun_unlock(&ballgun->lock);
+}
+
+void ballgun_set_callbacks(ballgun_t* ballgun, void (*set_ballgun)(void*, float), void* ballgun_args)
+{
+    ballgun->set_ballgun = set_ballgun;
+    ballgun->ballgun_args = ballgun_args;
+}
+
+void ballgun_deploy(ballgun_t* ballgun)
+{
+    ballgun_lock(&ballgun->lock);
+
+    ballgun->state = BALLGUN_DEPLOYED;
+    ballgun->set_ballgun(ballgun->ballgun_args, ballgun->servo_deployed_pwm);
+
+    ballgun_unlock(&ballgun->lock);
+}
+
+void ballgun_retract(ballgun_t* ballgun)
+{
+    ballgun_lock(&ballgun->lock);
+
+    ballgun->state = BALLGUN_RETRACTED;
+    ballgun->set_ballgun(ballgun->ballgun_args, ballgun->servo_retracted_pwm);
+
+    ballgun_unlock(&ballgun->lock);
+}

--- a/master-firmware/src/ballgun/ballgun.c
+++ b/master-firmware/src/ballgun/ballgun.c
@@ -22,34 +22,35 @@ void ballgun_init(ballgun_t* ballgun)
     chMtxObjectInit(&ballgun->lock);
 }
 
-void ballgun_set_servo_range(ballgun_t* ballgun, float servo_retracted_pwm, float servo_deployed_pwm)
+void ballgun_set_servo_range(ballgun_t* ballgun, float retracted, float deployed)
 {
     ballgun_lock(&ballgun->lock);
 
-    ballgun->servo_retracted_pwm = servo_retracted_pwm;
-    ballgun->servo_deployed_pwm = servo_deployed_pwm;
+    ballgun->servo_retracted_pwm = retracted;
+    ballgun->servo_deployed_pwm = deployed;
 
     ballgun_unlock(&ballgun->lock);
 }
 
-void ballgun_set_turbine_range(ballgun_t *ballgun, float turbine_armed_pwm, float turbine_charge_pwm,
-                               float turbine_fire_pwm)
+void ballgun_set_turbine_range(ballgun_t *ballgun, float armed, float charge, float fire, float slowfire)
 {
     ballgun_lock(&ballgun->lock);
 
-    ballgun->turbine_armed_pwm = turbine_armed_pwm;
-    ballgun->turbine_charge_pwm = turbine_charge_pwm;
-    ballgun->turbine_fire_pwm = turbine_fire_pwm;
+    ballgun->turbine_armed_pwm = armed;
+    ballgun->turbine_charge_pwm = charge;
+    ballgun->turbine_fire_pwm = fire;
+    ballgun->turbine_slowfire_pwm = slowfire;
 
     ballgun_unlock(&ballgun->lock);
 }
 
-void ballgun_set_accelerator_range(ballgun_t *ballgun, float accelerator_charge, float accelerator_fire)
+void ballgun_set_accelerator_range(ballgun_t *ballgun, float charge, float fire, float slowfire)
 {
     ballgun_lock(&ballgun->lock);
 
-    ballgun->accelerator_charge = accelerator_charge;
-    ballgun->accelerator_fire = accelerator_fire;
+    ballgun->accelerator_charge = charge;
+    ballgun->accelerator_fire = fire;
+    ballgun->accelerator_slowfire = slowfire;
 
     ballgun_unlock(&ballgun->lock);
 }
@@ -122,6 +123,17 @@ void ballgun_fire(ballgun_t* ballgun)
     ballgun->turbine_state = BALLGUN_FIRING;
     ballgun->set_turbine(ballgun->turbine_args, ballgun->turbine_fire_pwm);
     ballgun->set_accelerator(ballgun->accelerator_args, ballgun->accelerator_fire);
+
+    ballgun_unlock(&ballgun->lock);
+}
+
+void ballgun_slowfire(ballgun_t* ballgun)
+{
+    ballgun_lock(&ballgun->lock);
+
+    ballgun->turbine_state = BALLGUN_SLOWFIRING;
+    ballgun->set_turbine(ballgun->turbine_args, ballgun->turbine_slowfire_pwm);
+    ballgun->set_accelerator(ballgun->accelerator_args, ballgun->accelerator_slowfire);
 
     ballgun_unlock(&ballgun->lock);
 }

--- a/master-firmware/src/ballgun/ballgun.c
+++ b/master-firmware/src/ballgun/ballgun.c
@@ -44,6 +44,16 @@ void ballgun_set_turbine_range(ballgun_t *ballgun, float turbine_armed_pwm, floa
     ballgun_unlock(&ballgun->lock);
 }
 
+void ballgun_set_accelerator_range(ballgun_t *ballgun, float accelerator_charge, float accelerator_fire)
+{
+    ballgun_lock(&ballgun->lock);
+
+    ballgun->accelerator_charge = accelerator_charge;
+    ballgun->accelerator_fire = accelerator_fire;
+
+    ballgun_unlock(&ballgun->lock);
+}
+
 void ballgun_set_callbacks(ballgun_t* ballgun, void (*set_ballgun)(void*, float), void* ballgun_args)
 {
     ballgun->set_ballgun = set_ballgun;
@@ -54,6 +64,13 @@ void ballgun_set_turbine_callbacks(ballgun_t* ballgun, void (*set_turbine)(void*
 {
     ballgun->set_turbine = set_turbine;
     ballgun->turbine_args = turbine_args;
+}
+
+void ballgun_set_accelerator_callbacks(ballgun_t* ballgun, void (*set_accelerator)(void*, float),
+                                       void* accelerator_args)
+{
+    ballgun->set_accelerator = set_accelerator;
+    ballgun->accelerator_args = accelerator_args;
 }
 
 void ballgun_deploy(ballgun_t* ballgun)
@@ -82,6 +99,7 @@ void ballgun_arm(ballgun_t* ballgun)
 
     ballgun->turbine_state = BALLGUN_ARMED;
     ballgun->set_turbine(ballgun->turbine_args, ballgun->turbine_armed_pwm);
+    ballgun->set_accelerator(ballgun->accelerator_args, 0);
 
     ballgun_unlock(&ballgun->lock);
 }
@@ -92,6 +110,7 @@ void ballgun_charge(ballgun_t* ballgun)
 
     ballgun->turbine_state = BALLGUN_CHARGING;
     ballgun->set_turbine(ballgun->turbine_args, ballgun->turbine_charge_pwm);
+    ballgun->set_accelerator(ballgun->accelerator_args, ballgun->accelerator_charge);
 
     ballgun_unlock(&ballgun->lock);
 }
@@ -102,6 +121,7 @@ void ballgun_fire(ballgun_t* ballgun)
 
     ballgun->turbine_state = BALLGUN_FIRING;
     ballgun->set_turbine(ballgun->turbine_args, ballgun->turbine_fire_pwm);
+    ballgun->set_accelerator(ballgun->accelerator_args, ballgun->accelerator_fire);
 
     ballgun_unlock(&ballgun->lock);
 }

--- a/master-firmware/src/ballgun/ballgun.h
+++ b/master-firmware/src/ballgun/ballgun.h
@@ -69,6 +69,9 @@ void ballgun_arm(ballgun_t* ballgun);
 void ballgun_charge(ballgun_t* ballgun);
 void ballgun_fire(ballgun_t* ballgun);
 
+/* Ballgun tidy : arm and retract */
+void ballgun_tidy(ballgun_t* ballgun);
+
 #ifdef __cplusplus
 }
 #endif

--- a/master-firmware/src/ballgun/ballgun.h
+++ b/master-firmware/src/ballgun/ballgun.h
@@ -26,6 +26,9 @@ typedef struct {
     void (*set_turbine)(void*, float);
     void* turbine_args;
 
+    void (*set_accelerator)(void*, float);
+    void* accelerator_args;
+
     ballgun_state_t state;
     ballgun_turbine_state_t turbine_state;
 
@@ -34,7 +37,10 @@ typedef struct {
 
     float turbine_armed_pwm;    // pwm duty cycle in seconds to arm the turbine ESC
     float turbine_charge_pwm;   // pwm duty cycle in seconds to charge by sucking up
-    float turbine_fire_pwm;     // pwm duty cycle in seconds to charge by sucking up
+    float turbine_fire_pwm;     // pwm duty cycle in seconds to fire by sucking up
+
+    float accelerator_charge;   // accelerator voltage to get balls in
+    float accelerator_fire;     // accelerator voltage to get balls out
 
     mutex_t lock;
 } ballgun_t;
@@ -44,10 +50,13 @@ void ballgun_init(ballgun_t* ballgun);
 void ballgun_set_servo_range(ballgun_t* ballgun, float servo_retracted_pwm, float servo_deployed_pwm);
 void ballgun_set_turbine_range(ballgun_t *ballgun, float turbine_armed_pwm, float turbine_charge_pwm,
                                float turbine_fire_pwm);
+void ballgun_set_accelerator_range(ballgun_t *ballgun, float accelerator_charge, float accelerator_fire);
 
 /* Actuator callbacks */
 void ballgun_set_callbacks(ballgun_t* ballgun, void (*set_ballgun)(void*, float), void* ballgun_args);
 void ballgun_set_turbine_callbacks(ballgun_t* ballgun, void (*set_turbine)(void*, float), void* turbine_args);
+void ballgun_set_accelerator_callbacks(ballgun_t* ballgun, void (*set_accelerator)(void*, float),
+                                       void* accelerator_args);
 
 /* Deploy ballgun */
 void ballgun_deploy(ballgun_t* ballgun);

--- a/master-firmware/src/ballgun/ballgun.h
+++ b/master-firmware/src/ballgun/ballgun.h
@@ -17,6 +17,7 @@ typedef enum {
     BALLGUN_ARMED = 0,
     BALLGUN_CHARGING,
     BALLGUN_FIRING,
+    BALLGUN_SLOWFIRING,
 } ballgun_turbine_state_t;
 
 typedef struct {
@@ -38,19 +39,20 @@ typedef struct {
     float turbine_armed_pwm;    // pwm duty cycle in seconds to arm the turbine ESC
     float turbine_charge_pwm;   // pwm duty cycle in seconds to charge by sucking up
     float turbine_fire_pwm;     // pwm duty cycle in seconds to fire by sucking up
+    float turbine_slowfire_pwm; // pwm duty cycle in seconds to slowfire by sucking up
 
     float accelerator_charge;   // accelerator voltage to get balls in
     float accelerator_fire;     // accelerator voltage to get balls out
+    float accelerator_slowfire; // accelerator voltage to get balls out slowly
 
     mutex_t lock;
 } ballgun_t;
 
 /* Initialize ballgun */
 void ballgun_init(ballgun_t* ballgun);
-void ballgun_set_servo_range(ballgun_t* ballgun, float servo_retracted_pwm, float servo_deployed_pwm);
-void ballgun_set_turbine_range(ballgun_t *ballgun, float turbine_armed_pwm, float turbine_charge_pwm,
-                               float turbine_fire_pwm);
-void ballgun_set_accelerator_range(ballgun_t *ballgun, float accelerator_charge, float accelerator_fire);
+void ballgun_set_servo_range(ballgun_t* ballgun, float retracted, float deployed);
+void ballgun_set_turbine_range(ballgun_t *ballgun, float armed, float charge, float fire, float slowfire);
+void ballgun_set_accelerator_range(ballgun_t *ballgun, float charge, float fire, float slowfire);
 
 /* Actuator callbacks */
 void ballgun_set_callbacks(ballgun_t* ballgun, void (*set_ballgun)(void*, float), void* ballgun_args);
@@ -64,10 +66,11 @@ void ballgun_deploy(ballgun_t* ballgun);
 /* Retract ballgun */
 void ballgun_retract(ballgun_t* ballgun);
 
-/* Turbine control: Arm, Charge, Fire */
+/* Turbine control: Arm, Charge, Fire, Slow fire */
 void ballgun_arm(ballgun_t* ballgun);
 void ballgun_charge(ballgun_t* ballgun);
 void ballgun_fire(ballgun_t* ballgun);
+void ballgun_slowfire(ballgun_t* ballgun);
 
 /* Ballgun tidy : arm and retract */
 void ballgun_tidy(ballgun_t* ballgun);

--- a/master-firmware/src/ballgun/ballgun.h
+++ b/master-firmware/src/ballgun/ballgun.h
@@ -8,34 +8,57 @@ extern "C" {
 #include <ch.h>
 
 typedef enum {
-    BALLGUN_DISABLED,
+    BALLGUN_DISABLED = 0,
     BALLGUN_RETRACTED,
     BALLGUN_DEPLOYED,
 } ballgun_state_t;
+
+typedef enum {
+    BALLGUN_ARMED = 0,
+    BALLGUN_CHARGING,
+    BALLGUN_FIRING,
+} ballgun_turbine_state_t;
 
 typedef struct {
     void (*set_ballgun)(void*, float);
     void* ballgun_args;
 
+    void (*set_turbine)(void*, float);
+    void* turbine_args;
+
     ballgun_state_t state;
+    ballgun_turbine_state_t turbine_state;
 
     float servo_retracted_pwm;  // pwm duty cycle in seconds to retract servo
     float servo_deployed_pwm;   // pwm duty cycle in seconds to deploy servo
+
+    float turbine_armed_pwm;    // pwm duty cycle in seconds to arm the turbine ESC
+    float turbine_charge_pwm;   // pwm duty cycle in seconds to charge by sucking up
+    float turbine_fire_pwm;     // pwm duty cycle in seconds to charge by sucking up
+
     mutex_t lock;
 } ballgun_t;
 
 /* Initialize ballgun */
 void ballgun_init(ballgun_t* ballgun);
 void ballgun_set_servo_range(ballgun_t* ballgun, float servo_retracted_pwm, float servo_deployed_pwm);
+void ballgun_set_turbine_range(ballgun_t *ballgun, float turbine_armed_pwm, float turbine_charge_pwm,
+                               float turbine_fire_pwm);
 
 /* Actuator callbacks */
 void ballgun_set_callbacks(ballgun_t* ballgun, void (*set_ballgun)(void*, float), void* ballgun_args);
+void ballgun_set_turbine_callbacks(ballgun_t* ballgun, void (*set_turbine)(void*, float), void* turbine_args);
 
 /* Deploy ballgun */
 void ballgun_deploy(ballgun_t* ballgun);
 
 /* Retract ballgun */
 void ballgun_retract(ballgun_t* ballgun);
+
+/* Turbine control: Arm, Charge, Fire */
+void ballgun_arm(ballgun_t* ballgun);
+void ballgun_charge(ballgun_t* ballgun);
+void ballgun_fire(ballgun_t* ballgun);
 
 #ifdef __cplusplus
 }

--- a/master-firmware/src/ballgun/ballgun.h
+++ b/master-firmware/src/ballgun/ballgun.h
@@ -11,6 +11,7 @@ typedef enum {
     BALLGUN_DISABLED = 0,
     BALLGUN_RETRACTED,
     BALLGUN_DEPLOYED,
+    BALLGUN_DEPLOYED_FULLY,
 } ballgun_state_t;
 
 typedef enum {
@@ -35,6 +36,7 @@ typedef struct {
 
     float servo_retracted_pwm;  // pwm duty cycle in seconds to retract servo
     float servo_deployed_pwm;   // pwm duty cycle in seconds to deploy servo
+    float servo_deployed_fully_pwm; // pwm duty cycle in seconds to deploy servo fully
 
     float turbine_armed_pwm;    // pwm duty cycle in seconds to arm the turbine ESC
     float turbine_charge_pwm;   // pwm duty cycle in seconds to charge by sucking up
@@ -50,7 +52,7 @@ typedef struct {
 
 /* Initialize ballgun */
 void ballgun_init(ballgun_t* ballgun);
-void ballgun_set_servo_range(ballgun_t* ballgun, float retracted, float deployed);
+void ballgun_set_servo_range(ballgun_t* ballgun, float retracted, float deployed, float deployed_fully);
 void ballgun_set_turbine_range(ballgun_t *ballgun, float armed, float charge, float fire, float slowfire);
 void ballgun_set_accelerator_range(ballgun_t *ballgun, float charge, float fire, float slowfire);
 
@@ -62,6 +64,7 @@ void ballgun_set_accelerator_callbacks(ballgun_t* ballgun, void (*set_accelerato
 
 /* Deploy ballgun */
 void ballgun_deploy(ballgun_t* ballgun);
+void ballgun_deploy_fully(ballgun_t* ballgun);
 
 /* Retract ballgun */
 void ballgun_retract(ballgun_t* ballgun);

--- a/master-firmware/src/ballgun/ballgun.h
+++ b/master-firmware/src/ballgun/ballgun.h
@@ -1,0 +1,44 @@
+#ifndef BALLGUN_H
+#define BALLGUN_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <ch.h>
+
+typedef enum {
+    BALLGUN_DISABLED,
+    BALLGUN_RETRACTED,
+    BALLGUN_DEPLOYED,
+} ballgun_state_t;
+
+typedef struct {
+    void (*set_ballgun)(void*, float);
+    void* ballgun_args;
+
+    ballgun_state_t state;
+
+    float servo_retracted_pwm;  // pwm duty cycle in seconds to retract servo
+    float servo_deployed_pwm;   // pwm duty cycle in seconds to deploy servo
+    mutex_t lock;
+} ballgun_t;
+
+/* Initialize ballgun */
+void ballgun_init(ballgun_t* ballgun);
+void ballgun_set_servo_range(ballgun_t* ballgun, float servo_retracted_pwm, float servo_deployed_pwm);
+
+/* Actuator callbacks */
+void ballgun_set_callbacks(ballgun_t* ballgun, void (*set_ballgun)(void*, float), void* ballgun_args);
+
+/* Deploy ballgun */
+void ballgun_deploy(ballgun_t* ballgun);
+
+/* Retract ballgun */
+void ballgun_retract(ballgun_t* ballgun);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BALLGUN_H */

--- a/master-firmware/src/ballgun/ballgun_module.c
+++ b/master-firmware/src/ballgun/ballgun_module.c
@@ -1,0 +1,57 @@
+#include <ch.h>
+
+#include <error/error.h>
+
+#include "config.h"
+#include "main.h"
+#include "pca9685_pwm.h"
+#include "priorities.h"
+
+#include "ballgun_module.h"
+
+#define BALLGUN_MODULE_STACKSIZE 512
+
+ballgun_t main_ballgun;
+
+static void set_servo(void* ballgun, float pos)
+{
+    (void)ballgun;
+    pca9685_pwm_set_pulse_width(0, pos);
+}
+
+static void ballgun_update_settings(ballgun_t* ballgun, parameter_namespace_t* ns)
+{
+    float deployed = parameter_scalar_get(parameter_find(ns, "servo/deployed"));
+    float retracted = parameter_scalar_get(parameter_find(ns, "servo/retracted"));
+
+    ballgun_set_servo_range(ballgun, retracted, deployed);
+}
+
+static THD_FUNCTION(ballgun_module_thd, arg)
+{
+    (void) arg;
+    chRegSetThreadName(__FUNCTION__);
+
+    parameter_namespace_t* main_ballgun_params = parameter_namespace_find(&master_config, "ballgun");
+
+    ballgun_init(&main_ballgun);
+    ballgun_update_settings(&main_ballgun, main_ballgun_params);
+    ballgun_set_callbacks(&main_ballgun, set_servo, NULL);
+
+    NOTICE("Ball gun ready to shoot");
+
+    while (true) {
+        if (parameter_namespace_contains_changed(main_ballgun_params)) {
+            ballgun_update_settings(&main_ballgun, main_ballgun_params);
+        }
+
+        chThdSleepMilliseconds(1000 / BALLGUN_FREQUENCY);
+    }
+}
+
+void ballgun_module_start(void)
+{
+    static THD_WORKING_AREA(ballgun_module_thd_wa, BALLGUN_MODULE_STACKSIZE);
+    chThdCreateStatic(ballgun_module_thd_wa, sizeof(ballgun_module_thd_wa),
+                      BALLGUN_MODULE_PRIO, ballgun_module_thd, NULL);
+}

--- a/master-firmware/src/ballgun/ballgun_module.c
+++ b/master-firmware/src/ballgun/ballgun_module.c
@@ -17,13 +17,15 @@ ballgun_t main_ballgun;
 static void set_servo(void* ballgun, float pos)
 {
     (void)ballgun;
-    pca9685_pwm_set_pulse_width(0, pos);
+    int channel = config_get_integer("master/ballgun/servo/channel");
+    pca9685_pwm_set_pulse_width(channel, pos);
 }
 
 static void set_turbine(void* ballgun, float speed)
 {
     (void)ballgun;
-    pca9685_pwm_set_pulse_width(1, speed);
+    int channel = config_get_integer("master/ballgun/turbine/channel");
+    pca9685_pwm_set_pulse_width(channel, speed);
 }
 
 static void ballgun_update_settings(ballgun_t* ballgun, parameter_namespace_t* ns)

--- a/master-firmware/src/ballgun/ballgun_module.c
+++ b/master-firmware/src/ballgun/ballgun_module.c
@@ -2,6 +2,7 @@
 
 #include <error/error.h>
 
+#include <arms/cvra_arm_motors.h>
 #include "config.h"
 #include "main.h"
 #include "pca9685_pwm.h"
@@ -37,6 +38,11 @@ static void ballgun_update_settings(ballgun_t* ballgun, parameter_namespace_t* n
     float fire = parameter_scalar_get(parameter_find(ns, "turbine/fire"));
 
     ballgun_set_turbine_range(ballgun, arm, charge, fire);
+
+    float acc_charge = parameter_scalar_get(parameter_find(ns, "accelerator/charge"));
+    float acc_fire = parameter_scalar_get(parameter_find(ns, "accelerator/fire"));
+
+    ballgun_set_accelerator_range(ballgun, acc_charge, acc_fire);
 }
 
 static THD_FUNCTION(ballgun_module_thd, arg)
@@ -50,6 +56,9 @@ static THD_FUNCTION(ballgun_module_thd, arg)
     ballgun_update_settings(&main_ballgun, main_ballgun_params);
     ballgun_set_callbacks(&main_ballgun, set_servo, NULL);
     ballgun_set_turbine_callbacks(&main_ballgun, set_turbine, NULL);
+
+    static cvra_arm_motor_t ball_accelerator = {.id = "ball-accelerator", .direction = 0, .index = 0};
+    ballgun_set_accelerator_callbacks(&main_ballgun, set_motor_voltage, &ball_accelerator);
 
     NOTICE("Ball gun ready to shoot");
 

--- a/master-firmware/src/ballgun/ballgun_module.c
+++ b/master-firmware/src/ballgun/ballgun_module.c
@@ -36,13 +36,15 @@ static void ballgun_update_settings(ballgun_t* ballgun, parameter_namespace_t* n
     float arm = parameter_scalar_get(parameter_find(ns, "turbine/arm"));
     float charge = parameter_scalar_get(parameter_find(ns, "turbine/charge"));
     float fire = parameter_scalar_get(parameter_find(ns, "turbine/fire"));
+    float slowfire = parameter_scalar_get(parameter_find(ns, "turbine/slowfire"));
 
-    ballgun_set_turbine_range(ballgun, arm, charge, fire);
+    ballgun_set_turbine_range(ballgun, arm, charge, fire, slowfire);
 
     float acc_charge = parameter_scalar_get(parameter_find(ns, "accelerator/charge"));
     float acc_fire = parameter_scalar_get(parameter_find(ns, "accelerator/fire"));
+    float acc_slowfire = parameter_scalar_get(parameter_find(ns, "accelerator/slowfire"));
 
-    ballgun_set_accelerator_range(ballgun, acc_charge, acc_fire);
+    ballgun_set_accelerator_range(ballgun, acc_charge, acc_fire, acc_slowfire);
 }
 
 static THD_FUNCTION(ballgun_module_thd, arg)

--- a/master-firmware/src/ballgun/ballgun_module.c
+++ b/master-firmware/src/ballgun/ballgun_module.c
@@ -30,8 +30,9 @@ static void ballgun_update_settings(ballgun_t* ballgun, parameter_namespace_t* n
 {
     float deployed = parameter_scalar_get(parameter_find(ns, "servo/deployed"));
     float retracted = parameter_scalar_get(parameter_find(ns, "servo/retracted"));
+    float deployed_fully = parameter_scalar_get(parameter_find(ns, "servo/deployed_fully"));
 
-    ballgun_set_servo_range(ballgun, retracted, deployed);
+    ballgun_set_servo_range(ballgun, retracted, deployed, deployed_fully);
 
     float arm = parameter_scalar_get(parameter_find(ns, "turbine/arm"));
     float charge = parameter_scalar_get(parameter_find(ns, "turbine/charge"));

--- a/master-firmware/src/ballgun/ballgun_module.c
+++ b/master-firmware/src/ballgun/ballgun_module.c
@@ -19,12 +19,24 @@ static void set_servo(void* ballgun, float pos)
     pca9685_pwm_set_pulse_width(0, pos);
 }
 
+static void set_turbine(void* ballgun, float speed)
+{
+    (void)ballgun;
+    pca9685_pwm_set_pulse_width(1, speed);
+}
+
 static void ballgun_update_settings(ballgun_t* ballgun, parameter_namespace_t* ns)
 {
     float deployed = parameter_scalar_get(parameter_find(ns, "servo/deployed"));
     float retracted = parameter_scalar_get(parameter_find(ns, "servo/retracted"));
 
     ballgun_set_servo_range(ballgun, retracted, deployed);
+
+    float arm = parameter_scalar_get(parameter_find(ns, "turbine/arm"));
+    float charge = parameter_scalar_get(parameter_find(ns, "turbine/charge"));
+    float fire = parameter_scalar_get(parameter_find(ns, "turbine/fire"));
+
+    ballgun_set_turbine_range(ballgun, arm, charge, fire);
 }
 
 static THD_FUNCTION(ballgun_module_thd, arg)
@@ -37,6 +49,7 @@ static THD_FUNCTION(ballgun_module_thd, arg)
     ballgun_init(&main_ballgun);
     ballgun_update_settings(&main_ballgun, main_ballgun_params);
     ballgun_set_callbacks(&main_ballgun, set_servo, NULL);
+    ballgun_set_turbine_callbacks(&main_ballgun, set_turbine, NULL);
 
     NOTICE("Ball gun ready to shoot");
 

--- a/master-firmware/src/ballgun/ballgun_module.h
+++ b/master-firmware/src/ballgun/ballgun_module.h
@@ -1,0 +1,20 @@
+#ifndef BALLGUN_MODULE_H
+#define BALLGUN_MODULE_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "ballgun.h"
+
+#define BALLGUN_FREQUENCY 10
+
+extern ballgun_t main_ballgun;
+
+void ballgun_module_start(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BALLGUN_MODULE_H */

--- a/master-firmware/src/base/map_server.cpp
+++ b/master-firmware/src/base/map_server.cpp
@@ -53,8 +53,8 @@ static THD_FUNCTION(map_server_thd, arg)
         messagebus_topic_read(strategy_state_topic, &state, sizeof(state));
         for (int i = 0; i < MAP_NUM_BLOCKS_CUBE; i++) {
             if (state.blocks_on_map[i]) {
-                const int x = state.blocks_pos[i][0];
-                const int y = state.blocks_pos[i][1];
+                const int x = BLOCK_OF_CUBES_POS[i][0];
+                const int y = BLOCK_OF_CUBES_POS[i][1];
                 map_set_cubes_obstacle(&map, i, MIRROR_X(color, x), y, robot_size);
             } else {
                 map_set_cubes_obstacle(&map, i, 0, 0, 0);

--- a/master-firmware/src/commands.c
+++ b/master-firmware/src/commands.c
@@ -1416,20 +1416,21 @@ static void cmd_check_dist(BaseSequentialStream *chp, int argc, char *argv[])
 static void cmd_ballgun(BaseSequentialStream *chp, int argc, char *argv[])
 {
     if (argc != 1) {
-        chprintf(chp, "Usage: ballgun deploy|retract|arm|charge|fire|slowfire|tidy\r\n");
+        chprintf(chp, "Usage: ballgun deploy|deploy_fully|retract|arm|charge|fire|slowfire|tidy\r\n");
         return;
     }
 
     ballgun_t* ballgun = &main_ballgun;
 
-    if      (strcmp("deploy", argv[0]) == 0)   { ballgun_deploy(ballgun); }
-    else if (strcmp("retract", argv[0]) == 0)  { ballgun_retract(ballgun); }
-    else if (strcmp("arm", argv[0]) == 0)      { ballgun_arm(ballgun); }
-    else if (strcmp("charge", argv[0]) == 0)   { ballgun_charge(ballgun); }
-    else if (strcmp("fire", argv[0]) == 0)     { ballgun_fire(ballgun); }
-    else if (strcmp("slowfire", argv[0]) == 0) { ballgun_slowfire(ballgun); }
-    else if (strcmp("tidy", argv[0]) == 0)     { ballgun_tidy(ballgun); }
-    else                                       { chprintf(chp, "Invalid command: %s", argv[0]); }
+    if      (strcmp("deploy", argv[0]) == 0)       { ballgun_deploy(ballgun); }
+    else if (strcmp("deploy_fully", argv[0]) == 0) { ballgun_deploy_fully(ballgun); }
+    else if (strcmp("retract", argv[0]) == 0)      { ballgun_retract(ballgun); }
+    else if (strcmp("arm", argv[0]) == 0)          { ballgun_arm(ballgun); }
+    else if (strcmp("charge", argv[0]) == 0)       { ballgun_charge(ballgun); }
+    else if (strcmp("fire", argv[0]) == 0)         { ballgun_fire(ballgun); }
+    else if (strcmp("slowfire", argv[0]) == 0)     { ballgun_slowfire(ballgun); }
+    else if (strcmp("tidy", argv[0]) == 0)         { ballgun_tidy(ballgun); }
+    else                                           { chprintf(chp, "Invalid command: %s", argv[0]); }
 }
 
 static void cmd_wastewater(BaseSequentialStream *chp, int argc, char *argv[])

--- a/master-firmware/src/commands.c
+++ b/master-firmware/src/commands.c
@@ -1443,6 +1443,14 @@ static void cmd_wastewater(BaseSequentialStream *chp, int argc, char *argv[])
     else                                     { chprintf(chp, "Invalid color: %s", argv[0]); }
 }
 
+static void cmd_watertower(BaseSequentialStream *chp, int argc, char *argv[])
+{
+    (void)chp;
+    (void)argc;
+    (void)argv;
+    strat_fill_watertower();
+}
+
 const ShellCommand commands[] = {
     {"crashme", cmd_crashme},
     {"config_tree", cmd_config_tree},
@@ -1503,5 +1511,6 @@ const ShellCommand commands[] = {
     {"check_dist", cmd_check_dist},
     {"ballgun", cmd_ballgun},
     {"wastewater", cmd_wastewater},
+    {"watertower", cmd_watertower},
     {NULL, NULL}
 };

--- a/master-firmware/src/commands.c
+++ b/master-firmware/src/commands.c
@@ -1416,7 +1416,7 @@ static void cmd_check_dist(BaseSequentialStream *chp, int argc, char *argv[])
 static void cmd_ballgun(BaseSequentialStream *chp, int argc, char *argv[])
 {
     if (argc != 1) {
-        chprintf(chp, "Usage: ballgun deploy|retract\r\n");
+        chprintf(chp, "Usage: ballgun deploy|retract|arm|charge|fire\r\n");
         return;
     }
 
@@ -1424,6 +1424,9 @@ static void cmd_ballgun(BaseSequentialStream *chp, int argc, char *argv[])
 
     if      (strcmp("deploy", argv[0]) == 0)  { ballgun_deploy(ballgun); }
     else if (strcmp("retract", argv[0]) == 0) { ballgun_retract(ballgun); }
+    else if (strcmp("arm", argv[0]) == 0)     { ballgun_arm(ballgun); }
+    else if (strcmp("charge", argv[0]) == 0)  { ballgun_charge(ballgun); }
+    else if (strcmp("fire", argv[0]) == 0)    { ballgun_fire(ballgun); }
     else                                      { chprintf(chp, "Invalid command: %s", argv[1]); }
 }
 

--- a/master-firmware/src/commands.c
+++ b/master-firmware/src/commands.c
@@ -1416,7 +1416,7 @@ static void cmd_check_dist(BaseSequentialStream *chp, int argc, char *argv[])
 static void cmd_ballgun(BaseSequentialStream *chp, int argc, char *argv[])
 {
     if (argc != 1) {
-        chprintf(chp, "Usage: ballgun deploy|retract|arm|charge|fire\r\n");
+        chprintf(chp, "Usage: ballgun deploy|retract|arm|charge|fire|tidy\r\n");
         return;
     }
 
@@ -1427,7 +1427,8 @@ static void cmd_ballgun(BaseSequentialStream *chp, int argc, char *argv[])
     else if (strcmp("arm", argv[0]) == 0)     { ballgun_arm(ballgun); }
     else if (strcmp("charge", argv[0]) == 0)  { ballgun_charge(ballgun); }
     else if (strcmp("fire", argv[0]) == 0)    { ballgun_fire(ballgun); }
-    else                                      { chprintf(chp, "Invalid command: %s", argv[1]); }
+    else if (strcmp("tidy", argv[0]) == 0)    { ballgun_tidy(ballgun); }
+    else                                      { chprintf(chp, "Invalid command: %s", argv[0]); }
 }
 
 const ShellCommand commands[] = {

--- a/master-firmware/src/commands.c
+++ b/master-firmware/src/commands.c
@@ -1431,6 +1431,18 @@ static void cmd_ballgun(BaseSequentialStream *chp, int argc, char *argv[])
     else                                      { chprintf(chp, "Invalid command: %s", argv[0]); }
 }
 
+static void cmd_wastewater(BaseSequentialStream *chp, int argc, char *argv[])
+{
+    if (argc != 1) {
+        chprintf(chp, "Usage: wastewater yellow|green\r\n");
+        return;
+    }
+
+    if      (strcmp("yellow", argv[0]) == 0) { strat_collect_wastewater(YELLOW); }
+    else if (strcmp("green", argv[0]) == 0)  { strat_collect_wastewater(BLUE); }
+    else                                     { chprintf(chp, "Invalid color: %s", argv[0]); }
+}
+
 const ShellCommand commands[] = {
     {"crashme", cmd_crashme},
     {"config_tree", cmd_config_tree},
@@ -1490,5 +1502,6 @@ const ShellCommand commands[] = {
     {"bee", cmd_push_the_bee},
     {"check_dist", cmd_check_dist},
     {"ballgun", cmd_ballgun},
+    {"wastewater", cmd_wastewater},
     {NULL, NULL}
 };

--- a/master-firmware/src/commands.c
+++ b/master-firmware/src/commands.c
@@ -37,6 +37,7 @@
 #include <trace/trace.h>
 #include "pca9685_pwm.h"
 #include "lever/lever_module.h"
+#include "ballgun/ballgun_module.h"
 
 const ShellCommand commands[];
 
@@ -1412,6 +1413,19 @@ static void cmd_check_dist(BaseSequentialStream *chp, int argc, char *argv[])
     }
 }
 
+static void cmd_ballgun(BaseSequentialStream *chp, int argc, char *argv[])
+{
+    if (argc != 1) {
+        chprintf(chp, "Usage: ballgun deploy|retract\r\n");
+        return;
+    }
+
+    ballgun_t* ballgun = &main_ballgun;
+
+    if      (strcmp("deploy", argv[0]) == 0)  { ballgun_deploy(ballgun); }
+    else if (strcmp("retract", argv[0]) == 0) { ballgun_retract(ballgun); }
+    else                                      { chprintf(chp, "Invalid command: %s", argv[1]); }
+}
 
 const ShellCommand commands[] = {
     {"crashme", cmd_crashme},
@@ -1471,5 +1485,6 @@ const ShellCommand commands[] = {
     {"motor_sin", cmd_motor_sin},
     {"bee", cmd_push_the_bee},
     {"check_dist", cmd_check_dist},
+    {"ballgun", cmd_ballgun},
     {NULL, NULL}
 };

--- a/master-firmware/src/commands.c
+++ b/master-firmware/src/commands.c
@@ -1416,19 +1416,20 @@ static void cmd_check_dist(BaseSequentialStream *chp, int argc, char *argv[])
 static void cmd_ballgun(BaseSequentialStream *chp, int argc, char *argv[])
 {
     if (argc != 1) {
-        chprintf(chp, "Usage: ballgun deploy|retract|arm|charge|fire|tidy\r\n");
+        chprintf(chp, "Usage: ballgun deploy|retract|arm|charge|fire|slowfire|tidy\r\n");
         return;
     }
 
     ballgun_t* ballgun = &main_ballgun;
 
-    if      (strcmp("deploy", argv[0]) == 0)  { ballgun_deploy(ballgun); }
-    else if (strcmp("retract", argv[0]) == 0) { ballgun_retract(ballgun); }
-    else if (strcmp("arm", argv[0]) == 0)     { ballgun_arm(ballgun); }
-    else if (strcmp("charge", argv[0]) == 0)  { ballgun_charge(ballgun); }
-    else if (strcmp("fire", argv[0]) == 0)    { ballgun_fire(ballgun); }
-    else if (strcmp("tidy", argv[0]) == 0)    { ballgun_tidy(ballgun); }
-    else                                      { chprintf(chp, "Invalid command: %s", argv[0]); }
+    if      (strcmp("deploy", argv[0]) == 0)   { ballgun_deploy(ballgun); }
+    else if (strcmp("retract", argv[0]) == 0)  { ballgun_retract(ballgun); }
+    else if (strcmp("arm", argv[0]) == 0)      { ballgun_arm(ballgun); }
+    else if (strcmp("charge", argv[0]) == 0)   { ballgun_charge(ballgun); }
+    else if (strcmp("fire", argv[0]) == 0)     { ballgun_fire(ballgun); }
+    else if (strcmp("slowfire", argv[0]) == 0) { ballgun_slowfire(ballgun); }
+    else if (strcmp("tidy", argv[0]) == 0)     { ballgun_tidy(ballgun); }
+    else                                       { chprintf(chp, "Invalid command: %s", argv[0]); }
 }
 
 static void cmd_wastewater(BaseSequentialStream *chp, int argc, char *argv[])

--- a/master-firmware/src/commands.c
+++ b/master-firmware/src/commands.c
@@ -1453,6 +1453,14 @@ static void cmd_watertower(BaseSequentialStream *chp, int argc, char *argv[])
     strat_fill_watertower();
 }
 
+static void cmd_watertower_plant(BaseSequentialStream *chp, int argc, char *argv[])
+{
+    (void)chp;
+    (void)argc;
+    (void)argv;
+    strat_fill_wastewater_treatment_plant();
+}
+
 const ShellCommand commands[] = {
     {"crashme", cmd_crashme},
     {"config_tree", cmd_config_tree},
@@ -1514,5 +1522,6 @@ const ShellCommand commands[] = {
     {"ballgun", cmd_ballgun},
     {"wastewater", cmd_wastewater},
     {"watertower", cmd_watertower},
+    {"watertower_plant", cmd_watertower_plant},
     {NULL, NULL}
 };

--- a/master-firmware/src/config.c
+++ b/master-firmware/src/config.c
@@ -67,6 +67,12 @@ static struct {
         parameter_t retracted;
         parameter_t deployed;
     } servo;
+    struct {
+        parameter_namespace_t ns;
+        parameter_t arm;
+        parameter_t charge;
+        parameter_t fire;
+    } turbine;
 } ballgun;
 
 static parameter_namespace_t arms_config, arms_main_config, motor_offsets_config;
@@ -198,9 +204,15 @@ void config_init(void)
     parameter_scalar_declare_with_default(&lever.left.servo.retracted, &lever.left.servo.ns, "retracted", 0);
 
     parameter_namespace_declare(&ballgun.ns, &master_config, "ballgun");
+
     parameter_namespace_declare(&ballgun.servo.ns, &ballgun.ns, "servo");
     parameter_scalar_declare_with_default(&ballgun.servo.deployed, &ballgun.servo.ns, "deployed", 0);
     parameter_scalar_declare_with_default(&ballgun.servo.retracted, &ballgun.servo.ns, "retracted", 0);
+
+    parameter_namespace_declare(&ballgun.turbine.ns, &ballgun.ns, "turbine");
+    parameter_scalar_declare_with_default(&ballgun.turbine.arm, &ballgun.turbine.ns, "arm", 0);
+    parameter_scalar_declare_with_default(&ballgun.turbine.charge, &ballgun.turbine.ns, "charge", 0);
+    parameter_scalar_declare_with_default(&ballgun.turbine.fire, &ballgun.turbine.ns, "fire", 0);
 
     parameter_namespace_declare(&arms_config, &master_config, "arms");
 

--- a/master-firmware/src/config.c
+++ b/master-firmware/src/config.c
@@ -73,6 +73,11 @@ static struct {
         parameter_t charge;
         parameter_t fire;
     } turbine;
+    struct {
+        parameter_namespace_t ns;
+        parameter_t charge;
+        parameter_t fire;
+    } accelerator;
 } ballgun;
 
 static parameter_namespace_t arms_config, arms_main_config, motor_offsets_config;
@@ -213,6 +218,10 @@ void config_init(void)
     parameter_scalar_declare_with_default(&ballgun.turbine.arm, &ballgun.turbine.ns, "arm", 0);
     parameter_scalar_declare_with_default(&ballgun.turbine.charge, &ballgun.turbine.ns, "charge", 0);
     parameter_scalar_declare_with_default(&ballgun.turbine.fire, &ballgun.turbine.ns, "fire", 0);
+
+    parameter_namespace_declare(&ballgun.accelerator.ns, &ballgun.ns, "accelerator");
+    parameter_scalar_declare_with_default(&ballgun.accelerator.charge, &ballgun.accelerator.ns, "charge", 0);
+    parameter_scalar_declare_with_default(&ballgun.accelerator.fire, &ballgun.accelerator.ns, "fire", 0);
 
     parameter_namespace_declare(&arms_config, &master_config, "arms");
 

--- a/master-firmware/src/config.c
+++ b/master-firmware/src/config.c
@@ -72,11 +72,13 @@ static struct {
         parameter_t arm;
         parameter_t charge;
         parameter_t fire;
+        parameter_t slowfire;
     } turbine;
     struct {
         parameter_namespace_t ns;
         parameter_t charge;
         parameter_t fire;
+        parameter_t slowfire;
     } accelerator;
 } ballgun;
 
@@ -218,10 +220,12 @@ void config_init(void)
     parameter_scalar_declare_with_default(&ballgun.turbine.arm, &ballgun.turbine.ns, "arm", 0);
     parameter_scalar_declare_with_default(&ballgun.turbine.charge, &ballgun.turbine.ns, "charge", 0);
     parameter_scalar_declare_with_default(&ballgun.turbine.fire, &ballgun.turbine.ns, "fire", 0);
+    parameter_scalar_declare_with_default(&ballgun.turbine.slowfire, &ballgun.turbine.ns, "slowfire", 0);
 
     parameter_namespace_declare(&ballgun.accelerator.ns, &ballgun.ns, "accelerator");
     parameter_scalar_declare_with_default(&ballgun.accelerator.charge, &ballgun.accelerator.ns, "charge", 0);
     parameter_scalar_declare_with_default(&ballgun.accelerator.fire, &ballgun.accelerator.ns, "fire", 0);
+    parameter_scalar_declare_with_default(&ballgun.accelerator.slowfire, &ballgun.accelerator.ns, "slowfire", 0);
 
     parameter_namespace_declare(&arms_config, &master_config, "arms");
 

--- a/master-firmware/src/config.c
+++ b/master-firmware/src/config.c
@@ -60,6 +60,15 @@ static struct {
     } right, left;
 } lever;
 
+static struct {
+    parameter_namespace_t ns;
+    struct {
+        parameter_namespace_t ns;
+        parameter_t retracted;
+        parameter_t deployed;
+    } servo;
+} ballgun;
+
 static parameter_namespace_t arms_config, arms_main_config, motor_offsets_config;
 static parameter_t upperarm_length, forearm_length;
 static parameter_t main_offset_x, main_offset_y, main_offset_a;
@@ -187,6 +196,11 @@ void config_init(void)
     parameter_namespace_declare(&lever.left.servo.ns, &lever.left.ns, "servo");
     parameter_scalar_declare_with_default(&lever.left.servo.deployed, &lever.left.servo.ns, "deployed", 0);
     parameter_scalar_declare_with_default(&lever.left.servo.retracted, &lever.left.servo.ns, "retracted", 0);
+
+    parameter_namespace_declare(&ballgun.ns, &master_config, "ballgun");
+    parameter_namespace_declare(&ballgun.servo.ns, &ballgun.ns, "servo");
+    parameter_scalar_declare_with_default(&ballgun.servo.deployed, &ballgun.servo.ns, "deployed", 0);
+    parameter_scalar_declare_with_default(&ballgun.servo.retracted, &ballgun.servo.ns, "retracted", 0);
 
     parameter_namespace_declare(&arms_config, &master_config, "arms");
 

--- a/master-firmware/src/config.c
+++ b/master-firmware/src/config.c
@@ -67,6 +67,7 @@ static struct {
         parameter_t retracted;
         parameter_t deployed;
         parameter_t deployed_fully;
+        parameter_t channel;
     } servo;
     struct {
         parameter_namespace_t ns;
@@ -74,6 +75,7 @@ static struct {
         parameter_t charge;
         parameter_t fire;
         parameter_t slowfire;
+        parameter_t channel;
     } turbine;
     struct {
         parameter_namespace_t ns;
@@ -217,12 +219,14 @@ void config_init(void)
     parameter_scalar_declare_with_default(&ballgun.servo.deployed_fully, &ballgun.servo.ns, "deployed_fully", 0);
     parameter_scalar_declare_with_default(&ballgun.servo.deployed, &ballgun.servo.ns, "deployed", 0);
     parameter_scalar_declare_with_default(&ballgun.servo.retracted, &ballgun.servo.ns, "retracted", 0);
+    parameter_integer_declare_with_default(&ballgun.servo.channel, &ballgun.servo.ns, "channel", 0);
 
     parameter_namespace_declare(&ballgun.turbine.ns, &ballgun.ns, "turbine");
     parameter_scalar_declare_with_default(&ballgun.turbine.arm, &ballgun.turbine.ns, "arm", 0);
     parameter_scalar_declare_with_default(&ballgun.turbine.charge, &ballgun.turbine.ns, "charge", 0);
     parameter_scalar_declare_with_default(&ballgun.turbine.fire, &ballgun.turbine.ns, "fire", 0);
     parameter_scalar_declare_with_default(&ballgun.turbine.slowfire, &ballgun.turbine.ns, "slowfire", 0);
+    parameter_integer_declare_with_default(&ballgun.turbine.channel, &ballgun.turbine.ns, "channel", 0);
 
     parameter_namespace_declare(&ballgun.accelerator.ns, &ballgun.ns, "accelerator");
     parameter_scalar_declare_with_default(&ballgun.accelerator.charge, &ballgun.accelerator.ns, "charge", 0);

--- a/master-firmware/src/config.c
+++ b/master-firmware/src/config.c
@@ -66,6 +66,7 @@ static struct {
         parameter_namespace_t ns;
         parameter_t retracted;
         parameter_t deployed;
+        parameter_t deployed_fully;
     } servo;
     struct {
         parameter_namespace_t ns;
@@ -213,6 +214,7 @@ void config_init(void)
     parameter_namespace_declare(&ballgun.ns, &master_config, "ballgun");
 
     parameter_namespace_declare(&ballgun.servo.ns, &ballgun.ns, "servo");
+    parameter_scalar_declare_with_default(&ballgun.servo.deployed_fully, &ballgun.servo.ns, "deployed_fully", 0);
     parameter_scalar_declare_with_default(&ballgun.servo.deployed, &ballgun.servo.ns, "deployed", 0);
     parameter_scalar_declare_with_default(&ballgun.servo.retracted, &ballgun.servo.ns, "retracted", 0);
 

--- a/master-firmware/src/main.c
+++ b/master-firmware/src/main.c
@@ -208,7 +208,7 @@ int main(void)
     /* Initialise timestamp module */
     timestamp_stm32_init();
 
-    pca9685_pwm_init(0.020);
+    pca9685_pwm_init(0.0212);
 
     /* bus enumerator init */
     static __attribute__((section(".ccm"))) struct bus_enumerator_entry_allocator

--- a/master-firmware/src/main.c
+++ b/master-firmware/src/main.c
@@ -40,6 +40,7 @@
 #include "http/server.h"
 #include "pca9685_pwm.h"
 #include "gui.h"
+#include "ballgun/ballgun_module.h"
 
 
 void init_base_motors(void);
@@ -265,6 +266,9 @@ int main(void)
 
     /* Lever arms init */
     lever_module_start();
+
+    /* Ball gun module start */
+    ballgun_module_start();
 
     /* Initialize strategy thread, will wait for signal to begin game */
     strategy_start();

--- a/master-firmware/src/main.c
+++ b/master-firmware/src/main.c
@@ -46,6 +46,7 @@
 void init_base_motors(void);
 void init_arm_motors(void);
 void init_lever_motors(void);
+void init_ballgun_motors(void);
 
 motor_manager_t motor_manager;
 
@@ -227,10 +228,9 @@ int main(void)
 
     /* Initialize motors */
     init_base_motors();
-    chThdSleepMilliseconds(100);
     init_arm_motors();
-    chThdSleepMilliseconds(100);
     init_lever_motors();
+    init_ballgun_motors();
 
     /* Load stored robot config */
     config_load_from_flash();
@@ -325,6 +325,11 @@ void init_lever_motors(void)
     bus_enumerator_add_node(&bus_enumerator, "left-lever", NULL);
     motor_manager_create_driver(&motor_manager, "left-pump-1");
     motor_manager_create_driver(&motor_manager, "left-pump-2");
+}
+
+void init_ballgun_motors(void)
+{
+    motor_manager_create_driver(&motor_manager, "ball-accelerator");
 }
 
 void __stack_chk_fail(void)

--- a/master-firmware/src/priorities.h
+++ b/master-firmware/src/priorities.h
@@ -19,6 +19,7 @@
 #define ARMS_CONTROLLER_PRIO                    (NORMALPRIO)
 #define ARM_TRAJ_MANAGER_PRIO                   (NORMALPRIO)
 #define LEVER_MODULE_PRIO                       (NORMALPRIO)
+#define BALLGUN_MODULE_PRIO                     (NORMALPRIO)
 #define STRATEGY_PRIO                           (NORMALPRIO)
 #define SCORE_COUNTER_PRIO                      (NORMALPRIO)
 #define ENCODER_PRIO                            (NORMALPRIO)

--- a/master-firmware/src/robot_helpers/trajectory_helpers.h
+++ b/master-firmware/src/robot_helpers/trajectory_helpers.h
@@ -28,6 +28,7 @@ extern "C" {
                         TRAJ_END_TIMER)
 
 #define TRAJ_FLAGS_SHORT_DISTANCE (TRAJ_END_GOAL_REACHED | TRAJ_END_TIMER)
+#define TRAJ_FLAGS_ROTATION (TRAJ_END_GOAL_REACHED | TRAJ_END_COLLISION | TRAJ_END_TIMER)
 
 /** Returns when ongoing trajectory is finished for the reasons specified
  *  For example when goal is reached

--- a/master-firmware/src/strategy.cpp
+++ b/master-firmware/src/strategy.cpp
@@ -21,6 +21,7 @@
 #include "arms/arm_trajectory_manager.h"
 #include "arms/arm.h"
 #include "lever/lever_module.h"
+#include "ballgun/ballgun_module.h"
 #include "config.h"
 #include "control_panel.h"
 #include "main.h"
@@ -633,6 +634,7 @@ void strategy_order_play_game(enum strat_color_t color, RobotState& state)
 
     lever_retract(&right_lever);
     lever_retract(&left_lever);
+    ballgun_tidy(&main_ballgun);
 
     NOTICE("Getting arms ready...");
     int len = planner.plan(state, init_goal, path, max_path_len);
@@ -733,6 +735,7 @@ void strategy_chaos_play_game(enum strat_color_t color, RobotState& state)
 
     lever_retract(&right_lever);
     lever_retract(&left_lever);
+    ballgun_tidy(&main_ballgun);
 
     NOTICE("Getting arms ready...");
     int len = planner.plan(state, init_goal, path, max_path_len);

--- a/master-firmware/src/strategy.cpp
+++ b/master-firmware/src/strategy.cpp
@@ -584,7 +584,7 @@ struct EmptyMonocolorWasteWaterCollector : actions::EmptyMonocolorWasteWaterColl
 
         strat_collect_wastewater(m_color);
 
-        state.ballgun_full = true;
+        state.ballgun_state = BallgunState::CHARGED_MONOCOLOR;
 
         return true;
     }
@@ -619,7 +619,7 @@ struct FireBallGunIntoWaterTower : actions::FireBallGunIntoWaterTower {
 
         strat_fill_watertower();
 
-        state.ballgun_full = false;
+        state.ballgun_state = BallgunState::IS_EMPTY;
         state.balls_in_watertower += 8;
 
         return true;

--- a/master-firmware/src/strategy.cpp
+++ b/master-firmware/src/strategy.cpp
@@ -462,8 +462,8 @@ struct DepositCubes : actions::DepositCubes {
         : actions::DepositCubes(zone_id), m_color(color) {}
 
     bool execute(RobotState &state) {
-        const int x_mm = state.construction_zone_pos[construction_zone_id][0];
-        const int y_mm = state.construction_zone_pos[construction_zone_id][1];
+        const int x_mm = CONSTRUCTION_ZONE_POS[construction_zone_id][0];
+        const int y_mm = CONSTRUCTION_ZONE_POS[construction_zone_id][1];
         NOTICE("Depositing cubes at %d %d", x_mm, y_mm);
 
         enum lever_side_t lever_side = LEVER_SIDE_LEFT;
@@ -512,8 +512,8 @@ struct BuildTowerLevel : actions::BuildTowerLevel {
         : actions::BuildTowerLevel(zone_id, level), m_color(color) {}
 
     bool execute(RobotState &state) {
-        const int x_mm = state.construction_zone_pos[construction_zone_id][0];
-        const int y_mm = state.construction_zone_pos[construction_zone_id][1];
+        const int x_mm = CONSTRUCTION_ZONE_POS[construction_zone_id][0];
+        const int y_mm = CONSTRUCTION_ZONE_POS[construction_zone_id][1];
         NOTICE("Building a tower level %d at %d %d", level, x_mm, y_mm);
 
         if (level == 0) {

--- a/master-firmware/src/strategy.cpp
+++ b/master-firmware/src/strategy.cpp
@@ -344,8 +344,8 @@ struct PickupCubes : actions::PickupCubes {
 
     bool execute(RobotState &state)
     {
-        const int x_mm = state.blocks_pos[blocks_id][0];
-        const int y_mm = state.blocks_pos[blocks_id][1];
+        const int x_mm = BLOCK_OF_CUBES_POS[blocks_id][0];
+        const int y_mm = BLOCK_OF_CUBES_POS[blocks_id][1];
         NOTICE("Picking up some blocks at %d %d", MIRROR_X(m_color, x_mm), y_mm);
 
         enum lever_side_t lever_side = LEVER_SIDE_LEFT;

--- a/master-firmware/src/strategy.cpp
+++ b/master-firmware/src/strategy.cpp
@@ -555,12 +555,13 @@ void strat_collect_wastewater(enum strat_color_t color)
     ballgun_deploy(&main_ballgun);
     strategy_wait_ms(1000);
 
-    trajectory_a_rel(&robot.traj, MIRROR(color, -95));
-    trajectory_wait_for_end(TRAJ_FLAGS_ROTATION);
-    trajectory_a_rel(&robot.traj, MIRROR(color, 5));
-    trajectory_wait_for_end(TRAJ_FLAGS_ROTATION);
-
     ballgun_charge(&main_ballgun);
+
+    trajectory_a_rel(&robot.traj, MIRROR(color, -95));
+    trajectory_wait_for_end(TRAJ_FLAGS_SHORT_DISTANCE /*TRAJ_FLAGS_ROTATION*/);
+    trajectory_a_rel(&robot.traj, MIRROR(color, 5));
+    trajectory_wait_for_end(TRAJ_FLAGS_SHORT_DISTANCE /*TRAJ_FLAGS_ROTATION*/);
+
     strategy_wait_ms(2000);
 
     ballgun_tidy(&main_ballgun);

--- a/master-firmware/src/strategy.cpp
+++ b/master-firmware/src/strategy.cpp
@@ -850,9 +850,11 @@ void strategy_chaos_play_game(enum strat_color_t color, RobotState& state)
 
     SwitchGoal switch_goal;
     PickupCubesGoal pickup_cubes_goal;
+    WasteWaterGoal wastewater_plant_goal;
     goap::Goal<RobotState>* goals[] = {
         &pickup_cubes_goal,
         &switch_goal,
+        &wastewater_plant_goal,
     };
 
     IndexArms index_arms;
@@ -861,6 +863,8 @@ void strategy_chaos_play_game(enum strat_color_t color, RobotState& state)
         PickupCubes(color, 2), PickupCubes(color, 3),
     };
     TurnSwitchOn turn_switch_on(color);
+    EmptyMulticolorWasteWaterCollector empty_wastewater_multicolor(color);
+    FireBallGunIntoWasteWaterTreatmentPlant fill_wasterwater_plant(color);
 
     const int max_path_len = 10;
     goap::Action<RobotState> *path[max_path_len] = {nullptr};
@@ -871,6 +875,8 @@ void strategy_chaos_play_game(enum strat_color_t color, RobotState& state)
         &pickup_cubes[0],
         &pickup_cubes[1],
         &turn_switch_on,
+        &empty_wastewater_multicolor,
+        &fill_wasterwater_plant,
     };
 
     static goap::Planner<RobotState> planner(actions, sizeof(actions) / sizeof(actions[0]));

--- a/master-firmware/src/strategy.cpp
+++ b/master-firmware/src/strategy.cpp
@@ -657,10 +657,12 @@ void strategy_order_play_game(enum strat_color_t color, RobotState& state)
 
     BeeGoal bee_goal;
     PickupCubesGoal pickup_cubes_goal;
+    WaterTowerGoal watertower_goal;
     BuildTowerGoal build_tower_goal[2] = {BuildTowerGoal(0), BuildTowerGoal(1)};
     goap::Goal<RobotState>* goals[] = {
         &pickup_cubes_goal,
         &bee_goal,
+        &watertower_goal,
         &build_tower_goal[0],
         &build_tower_goal[1],
     };
@@ -684,6 +686,8 @@ void strategy_order_play_game(enum strat_color_t color, RobotState& state)
             BuildTowerLevel(color, 1, 2), BuildTowerLevel(color, 1, 3),
         },
     };
+    EmptyMonocolorWasteWaterCollector empty_wastewater(color);
+    FireBallGunIntoWaterTower fill_watertower(color);
 
     const int max_path_len = 10;
     goap::Action<RobotState> *path[max_path_len] = {nullptr};
@@ -704,6 +708,8 @@ void strategy_order_play_game(enum strat_color_t color, RobotState& state)
         &build_tower_lvl[1][1],
         &build_tower_lvl[1][2],
         &build_tower_lvl[1][3],
+        &empty_wastewater,
+        &fill_watertower,
     };
 
     static goap::Planner<RobotState> planner(actions, sizeof(actions) / sizeof(actions[0]));

--- a/master-firmware/src/strategy.cpp
+++ b/master-firmware/src/strategy.cpp
@@ -574,17 +574,40 @@ struct EmptyMonocolorWasteWaterCollector : actions::EmptyMonocolorWasteWaterColl
         : m_color(color) {}
 
     bool execute(RobotState &state) {
-        const int x_mm = 0;
+        const int x_mm = 0 + 240;
         const int y_mm = 840;
-        NOTICE("Emptying waste water collector at %d %d", x_mm, y_mm);
+        NOTICE("Emptying monocolor waste water collector at %d %d", x_mm, y_mm);
 
-        if (!strategy_goto_avoid(MIRROR_X(m_color, x_mm + 240), y_mm, MIRROR_A(m_color, -90), TRAJ_FLAGS_ALL)) {
+        if (!strategy_goto_avoid(MIRROR_X(m_color, x_mm), y_mm, MIRROR_A(m_color, -90), TRAJ_FLAGS_ALL)) {
             return false;
         }
 
         strat_collect_wastewater(m_color);
 
         state.ballgun_state = BallgunState::CHARGED_MONOCOLOR;
+
+        return true;
+    }
+};
+
+struct EmptyMulticolorWasteWaterCollector : actions::EmptyMulticolorWasteWaterCollector {
+    enum strat_color_t m_color;
+
+    EmptyMulticolorWasteWaterCollector(enum strat_color_t color)
+        : m_color(color) {}
+
+    bool execute(RobotState &state) {
+        const int x_mm = 2390;
+        const int y_mm = 2000 - 240;
+        NOTICE("Emptying multicolor waste water collector at %d %d", x_mm, y_mm);
+
+        if (!strategy_goto_avoid(MIRROR_X(m_color, x_mm), y_mm, MIRROR_A(m_color, -180), TRAJ_FLAGS_ALL)) {
+            return false;
+        }
+
+        strat_collect_wastewater(m_color);
+
+        state.ballgun_state = BallgunState::CHARGED_MULTICOLOR;
 
         return true;
     }
@@ -621,6 +644,42 @@ struct FireBallGunIntoWaterTower : actions::FireBallGunIntoWaterTower {
 
         state.ballgun_state = BallgunState::IS_EMPTY;
         state.balls_in_watertower += 8;
+
+        return true;
+    }
+};
+
+void strat_fill_wastewater_treatment_plant(void)
+{
+    ballgun_tidy(&main_ballgun);
+    ballgun_deploy_fully(&main_ballgun);
+    strategy_wait_ms(1000);
+
+    ballgun_slowfire(&main_ballgun);
+    strategy_wait_ms(2000);
+
+    ballgun_tidy(&main_ballgun);
+}
+
+struct FireBallGunIntoWasteWaterTreatmentPlant : actions::FireBallGunIntoWasteWaterTreatmentPlant {
+    enum strat_color_t m_color;
+
+    FireBallGunIntoWasteWaterTreatmentPlant(enum strat_color_t color)
+        : m_color(color) {}
+
+    bool execute(RobotState &state) {
+        const int x_mm = 2390;
+        const int y_mm = 1600;
+        NOTICE("Filling waste water treatment plant from %d %d", x_mm, y_mm);
+
+        if (!strategy_goto_avoid(MIRROR_X(m_color, x_mm), y_mm, MIRROR_A(m_color, 150), TRAJ_FLAGS_ALL)) {
+            return false;
+        }
+
+        strat_fill_wastewater_treatment_plant();
+
+        state.ballgun_state = BallgunState::IS_EMPTY;
+        state.balls_in_wastewater_treatment_plant += 8;
 
         return true;
     }

--- a/master-firmware/src/strategy.cpp
+++ b/master-firmware/src/strategy.cpp
@@ -589,6 +589,42 @@ struct EmptyMonocolorWasteWaterCollector : actions::EmptyMonocolorWasteWaterColl
     }
 };
 
+void strat_fill_watertower(void)
+{
+    ballgun_tidy(&main_ballgun);
+    ballgun_deploy(&main_ballgun);
+    strategy_wait_ms(1000);
+
+    ballgun_fire(&main_ballgun);
+    strategy_wait_ms(2000);
+
+    ballgun_tidy(&main_ballgun);
+}
+
+struct FireBallGunIntoWaterTower : actions::FireBallGunIntoWaterTower {
+    enum strat_color_t m_color;
+
+    FireBallGunIntoWaterTower(enum strat_color_t color)
+        : m_color(color) {}
+
+    bool execute(RobotState &state) {
+        const int x_mm = 240;
+        const int y_mm = 740;
+        NOTICE("Filling water tower from %d %d", x_mm, y_mm);
+
+        if (!strategy_goto_avoid(MIRROR_X(m_color, x_mm), y_mm, MIRROR_A(m_color, -90), TRAJ_FLAGS_ALL)) {
+            return false;
+        }
+
+        strat_fill_watertower();
+
+        state.ballgun_full = false;
+        state.balls_in_watertower += 8;
+
+        return true;
+    }
+};
+
 void strategy_read_color_sequence(RobotState& state)
 {
     int tower_sequence_len = sizeof(state.tower_sequence) / sizeof(enum cube_color);

--- a/master-firmware/src/strategy.h
+++ b/master-firmware/src/strategy.h
@@ -18,6 +18,7 @@ void strat_push_the_bee(point_t start, point_t end, float bee_height);
 
 void strat_collect_wastewater(enum strat_color_t color);
 void strat_fill_watertower(void);
+void strat_fill_wastewater_treatment_plant(void);
 
 #ifdef __cplusplus
 }

--- a/master-firmware/src/strategy.h
+++ b/master-firmware/src/strategy.h
@@ -17,6 +17,7 @@ void strat_push_switch_on(float x, float y, float z, float y_push);
 void strat_push_the_bee(point_t start, point_t end, float bee_height);
 
 void strat_collect_wastewater(enum strat_color_t color);
+void strat_fill_watertower(void);
 
 #ifdef __cplusplus
 }

--- a/master-firmware/src/strategy.h
+++ b/master-firmware/src/strategy.h
@@ -16,6 +16,8 @@ bool strat_deposit_cube(float x, float y, int num_cubes_in_tower);
 void strat_push_switch_on(float x, float y, float z, float y_push);
 void strat_push_the_bee(point_t start, point_t end, float bee_height);
 
+void strat_collect_wastewater(enum strat_color_t color);
+
 #ifdef __cplusplus
 }
 #endif

--- a/master-firmware/src/strategy/actions.h
+++ b/master-firmware/src/strategy/actions.h
@@ -138,6 +138,19 @@ struct BuildTowerLevel : public goap::Action<RobotState> {
     }
 };
 
+struct FireBallGunIntoWaterTower : public goap::Action<RobotState> {
+    bool can_run(RobotState state)
+    {
+        return state.arms_are_deployed == false;
+    }
+
+    RobotState plan_effects(RobotState state)
+    {
+        state.balls_in_watertower += 8;
+        return state;
+    }
+};
+
 } // namespace actions
 
 #endif /* STRATEGY_ACTIONS_H */

--- a/master-firmware/src/strategy/actions.h
+++ b/master-firmware/src/strategy/actions.h
@@ -141,12 +141,26 @@ struct BuildTowerLevel : public goap::Action<RobotState> {
 struct FireBallGunIntoWaterTower : public goap::Action<RobotState> {
     bool can_run(RobotState state)
     {
-        return state.arms_are_deployed == false;
+        return state.arms_are_deployed == false && state.ballgun_full;
     }
 
     RobotState plan_effects(RobotState state)
     {
+        state.ballgun_full = false;
         state.balls_in_watertower += 8;
+        return state;
+    }
+};
+
+struct EmptyMonocolorWasteWaterCollector : public goap::Action<RobotState> {
+    bool can_run(RobotState state)
+    {
+        return state.arms_are_deployed == false && state.ballgun_full == false;
+    }
+
+    RobotState plan_effects(RobotState state)
+    {
+        state.ballgun_full = true;
         return state;
     }
 };

--- a/master-firmware/src/strategy/actions.h
+++ b/master-firmware/src/strategy/actions.h
@@ -141,13 +141,27 @@ struct BuildTowerLevel : public goap::Action<RobotState> {
 struct FireBallGunIntoWaterTower : public goap::Action<RobotState> {
     bool can_run(RobotState state)
     {
-        return state.arms_are_deployed == false && state.ballgun_full;
+        return state.arms_are_deployed == false && state.ballgun_state == BallgunState::CHARGED_MONOCOLOR;
     }
 
     RobotState plan_effects(RobotState state)
     {
-        state.ballgun_full = false;
+        state.ballgun_state = BallgunState::IS_EMPTY;
         state.balls_in_watertower += 8;
+        return state;
+    }
+};
+
+struct FireBallGunIntoWasteWaterTreatmentPlant : public goap::Action<RobotState> {
+    bool can_run(RobotState state)
+    {
+        return state.arms_are_deployed == false && state.ballgun_state == BallgunState::CHARGED_MULTICOLOR;
+    }
+
+    RobotState plan_effects(RobotState state)
+    {
+        state.ballgun_state = BallgunState::IS_EMPTY;
+        state.balls_in_wastewater_treatment_plant += 8;
         return state;
     }
 };
@@ -155,12 +169,25 @@ struct FireBallGunIntoWaterTower : public goap::Action<RobotState> {
 struct EmptyMonocolorWasteWaterCollector : public goap::Action<RobotState> {
     bool can_run(RobotState state)
     {
-        return state.arms_are_deployed == false && state.ballgun_full == false;
+        return state.arms_are_deployed == false && state.ballgun_state == BallgunState::IS_EMPTY;
     }
 
     RobotState plan_effects(RobotState state)
     {
-        state.ballgun_full = true;
+        state.ballgun_state = BallgunState::CHARGED_MONOCOLOR;
+        return state;
+    }
+};
+
+struct EmptyMulticolorWasteWaterCollector : public goap::Action<RobotState> {
+    bool can_run(RobotState state)
+    {
+        return state.arms_are_deployed == false && state.ballgun_state == BallgunState::IS_EMPTY;
+    }
+
+    RobotState plan_effects(RobotState state)
+    {
+        state.ballgun_state = BallgunState::CHARGED_MULTICOLOR;
         return state;
     }
 };

--- a/master-firmware/src/strategy/goals.h
+++ b/master-firmware/src/strategy/goals.h
@@ -43,4 +43,11 @@ struct BuildTowerGoal : goap::Goal<RobotState> {
     }
 };
 
+struct WaterTowerGoal : goap::Goal<RobotState> {
+    virtual int distance_to(const RobotState &state) const
+    {
+        return goap::Distance().shouldBeTrue(state.balls_in_watertower > 0);
+    }
+};
+
 #endif /* STRATEGY_GOALS_H */

--- a/master-firmware/src/strategy/goals.h
+++ b/master-firmware/src/strategy/goals.h
@@ -50,4 +50,11 @@ struct WaterTowerGoal : goap::Goal<RobotState> {
     }
 };
 
+struct WasteWaterGoal : goap::Goal<RobotState> {
+    virtual int distance_to(const RobotState &state) const
+    {
+        return goap::Distance().shouldBeTrue(state.balls_in_wastewater_treatment_plant > 0);
+    }
+};
+
 #endif /* STRATEGY_GOALS_H */

--- a/master-firmware/src/strategy/score.cpp
+++ b/master-firmware/src/strategy/score.cpp
@@ -45,3 +45,9 @@ int score_count_tower_bonus(const RobotState& state)
     }
     return score;
 }
+
+int score_count_balls(const RobotState& state)
+{
+    return state.balls_in_watertower * 5 +
+           state.balls_in_wastewater_treatment_plant * 10;
+}

--- a/master-firmware/src/strategy/score.h
+++ b/master-firmware/src/strategy/score.h
@@ -16,6 +16,8 @@ int score_count_switch(const RobotState& state);
 int score_count_tower(const RobotState& state);
 int score_count_tower_bonus(const RobotState& state);
 
+int score_count_balls(const RobotState& state);
+
 #ifdef __cplusplus
 }
 #endif

--- a/master-firmware/src/strategy/score_counter.cpp
+++ b/master-firmware/src/strategy/score_counter.cpp
@@ -41,6 +41,7 @@ static THD_FUNCTION(score_counter_thd, arg)
         score += score_count_switch(state);
         score += score_count_tower(state);
         score += score_count_tower_bonus(state);
+        score += score_count_balls(state);
 
         messagebus_topic_publish(&score_topic, &score, sizeof(score));
     }

--- a/master-firmware/src/strategy/state.h
+++ b/master-firmware/src/strategy/state.h
@@ -32,6 +32,7 @@ struct RobotState {
     } construction_zone[2];
     uint16_t construction_zone_pos[2][2] = {{500, 300}, {900, 300}};
 
+    bool ballgun_full{false};
     int balls_in_watertower{0};
 };
 

--- a/master-firmware/src/strategy/state.h
+++ b/master-firmware/src/strategy/state.h
@@ -10,7 +10,6 @@ struct RobotState {
 
     bool arms_are_indexed{false};
     bool arms_are_deployed{true};
-    bool has_blocks{false};
     bool switch_on{false};
     bool bee_deployed{false};
 
@@ -33,7 +32,7 @@ struct RobotState {
     uint16_t construction_zone_pos[2][2] = {{500, 300}, {900, 300}};
 
     bool ballgun_full{false};
-    int balls_in_watertower{0};
+    uint8_t balls_in_watertower{0};
 };
 
 bool operator==(const RobotState& lhs, const RobotState& rhs);

--- a/master-firmware/src/strategy/state.h
+++ b/master-firmware/src/strategy/state.h
@@ -4,6 +4,11 @@
 #include <stdint.h>
 #include "robot_helpers/eurobot2018.h"
 
+const int NUM_BLOCK_OF_CUBES = 6;
+const uint16_t BLOCK_OF_CUBES_POS[NUM_BLOCK_OF_CUBES][2] = {
+    {850, 540}, {300, 1190}, {1100, 1500}, {1900, 1500}, {2700, 1190}, {2150, 540},
+};
+
 const int NUM_CONSTRUCTION_ZONES = 2;
 const uint16_t CONSTRUCTION_ZONE_POS[NUM_CONSTRUCTION_ZONES][2] = {
     {500, 300}, {900, 300},
@@ -21,10 +26,7 @@ struct RobotState {
     bool lever_full_left{false};
     bool lever_full_right{false};
 
-    bool blocks_on_map[6] = {true, true, true, true, true, true};
-    uint16_t blocks_pos[6][2] = {
-        {850, 540}, {300, 1190}, {1100, 1500}, {1900, 1500}, {2700, 1190}, {2150, 540},
-    };
+    bool blocks_on_map[NUM_BLOCK_OF_CUBES] = {true, true, true, true, true, true};
 
     bool tower_sequence_known{false};
     enum cube_color tower_sequence[5] = {CUBE_YELLOW, CUBE_BLACK, CUBE_BLUE, CUBE_GREEN, CUBE_ORANGE};

--- a/master-firmware/src/strategy/state.h
+++ b/master-firmware/src/strategy/state.h
@@ -4,6 +4,11 @@
 #include <stdint.h>
 #include "robot_helpers/eurobot2018.h"
 
+const int NUM_CONSTRUCTION_ZONES = 2;
+const uint16_t CONSTRUCTION_ZONE_POS[NUM_CONSTRUCTION_ZONES][2] = {
+    {500, 300}, {900, 300},
+};
+
 struct RobotState {
     bool bee_on_map{true};
     bool panel_on_map{true};
@@ -28,8 +33,7 @@ struct RobotState {
         uint16_t cubes_pos[5][2] = {{0, 0}, {0, 0}, {0, 0}, {0, 0}, {0, 0}};
         uint8_t tower_level{0};
         uint16_t tower_pos[2] = {0, 0};
-    } construction_zone[2];
-    uint16_t construction_zone_pos[2][2] = {{500, 300}, {900, 300}};
+    } construction_zone[NUM_CONSTRUCTION_ZONES];
 
     bool ballgun_full{false};
     uint8_t balls_in_watertower{0};

--- a/master-firmware/src/strategy/state.h
+++ b/master-firmware/src/strategy/state.h
@@ -22,7 +22,7 @@ struct RobotState {
         {850, 540}, {300, 1190}, {1100, 1500}, {1900, 1500}, {2700, 1190}, {2150, 540},
     };
 
-    bool tower_sequence_known = {false};
+    bool tower_sequence_known{false};
     enum cube_color tower_sequence[5] = {CUBE_YELLOW, CUBE_BLACK, CUBE_BLUE, CUBE_GREEN, CUBE_ORANGE};
     struct {
         bool cubes_ready[5] = {false, false, false, false, false}; // YELLOW, GREEN, BLUE, ORANGE, BLACK
@@ -31,6 +31,8 @@ struct RobotState {
         uint16_t tower_pos[2] = {0, 0};
     } construction_zone[2];
     uint16_t construction_zone_pos[2][2] = {{500, 300}, {900, 300}};
+
+    int balls_in_watertower{0};
 };
 
 bool operator==(const RobotState& lhs, const RobotState& rhs);

--- a/master-firmware/src/strategy/state.h
+++ b/master-firmware/src/strategy/state.h
@@ -14,6 +14,13 @@ const uint16_t CONSTRUCTION_ZONE_POS[NUM_CONSTRUCTION_ZONES][2] = {
     {500, 300}, {900, 300},
 };
 
+
+enum BallgunState {
+    IS_EMPTY = 0,
+    CHARGED_MONOCOLOR,
+    CHARGED_MULTICOLOR,
+};
+
 struct RobotState {
     bool bee_on_map{true};
     bool panel_on_map{true};
@@ -37,8 +44,9 @@ struct RobotState {
         uint16_t tower_pos[2] = {0, 0};
     } construction_zone[NUM_CONSTRUCTION_ZONES];
 
-    bool ballgun_full{false};
+    BallgunState ballgun_state{BallgunState::IS_EMPTY};
     uint8_t balls_in_watertower{0};
+    uint8_t balls_in_wastewater_treatment_plant{0};
 };
 
 bool operator==(const RobotState& lhs, const RobotState& rhs);

--- a/master-firmware/tests/strategy/test_score.cpp
+++ b/master-firmware/tests/strategy/test_score.cpp
@@ -144,3 +144,17 @@ TEST(AScore, countsTowerBonusForTwoTowers)
 
     CHECK_EQUAL(60, score_count_tower_bonus(state));
 };
+
+TEST(AScore, countsBallsInWaterTower)
+{
+    state.balls_in_watertower = 4;
+
+    CHECK_EQUAL(4 * 5, score_count_balls(state));
+};
+
+TEST(AScore, countsBallsInWasteWaterTreatmentPlant)
+{
+    state.balls_in_wastewater_treatment_plant = 3;
+
+    CHECK_EQUAL(3 * 10, score_count_balls(state));
+};

--- a/master-firmware/tests/test_ballgun.cpp
+++ b/master-firmware/tests/test_ballgun.cpp
@@ -1,0 +1,47 @@
+#include <CppUTest/TestHarness.h>
+#include <CppUTestExt/MockSupport.h>
+
+#include <ballgun/ballgun.h>
+
+namespace {
+void set_servo_pos(void *s, float value) { *(float *)s = value; }
+}
+
+TEST_GROUP(ABallGun)
+{
+    ballgun_t ballgun;
+    float ballgun_servo_pos;
+
+    void setup()
+    {
+        ballgun_init(&ballgun);
+        ballgun_set_callbacks(&ballgun, &set_servo_pos, &ballgun_servo_pos);
+        ballgun_set_servo_range(&ballgun, 0.001, 0.002);
+    }
+
+    void teardown()
+    {
+        lock_mocks_enable(false);
+    }
+};
+
+TEST(ABallGun, initializesInDisabledState)
+{
+    CHECK_EQUAL(BALLGUN_DISABLED, ballgun.state);
+}
+
+TEST(ABallGun, deploys)
+{
+    ballgun_deploy(&ballgun);
+
+    CHECK_EQUAL(BALLGUN_DEPLOYED, ballgun.state);
+    CHECK(ballgun_servo_pos != 0.0f);
+}
+
+TEST(ABallGun, retracts)
+{
+    ballgun_retract(&ballgun);
+
+    CHECK_EQUAL(BALLGUN_RETRACTED, ballgun.state);
+    CHECK(ballgun_servo_pos != 0.0f);
+}

--- a/master-firmware/tests/test_ballgun.cpp
+++ b/master-firmware/tests/test_ballgun.cpp
@@ -23,7 +23,7 @@ TEST_GROUP(ABallGun)
         ballgun_set_turbine_callbacks(&ballgun, &set_turbine_speed, &ballgun_tubine_speed);
         ballgun_set_accelerator_callbacks(&ballgun, &set_accelerator_speed, &ballgun_accelerator_speed);
 
-        ballgun_set_servo_range(&ballgun, 0.001, 0.002);
+        ballgun_set_servo_range(&ballgun, 0.001, 0.002, 0.003);
         ballgun_set_turbine_range(&ballgun, 0.0, -0.001, 0.001, 0.0005);
         ballgun_set_accelerator_range(&ballgun, -2, 2, 1);
     }
@@ -45,6 +45,14 @@ TEST(ABallGun, deploys)
     ballgun_deploy(&ballgun);
 
     CHECK_EQUAL(BALLGUN_DEPLOYED, ballgun.state);
+    CHECK(ballgun_servo_pos != 0.0f);
+}
+
+TEST(ABallGun, fullyDeploys)
+{
+    ballgun_deploy_fully(&ballgun);
+
+    CHECK_EQUAL(BALLGUN_DEPLOYED_FULLY, ballgun.state);
     CHECK(ballgun_servo_pos != 0.0f);
 }
 

--- a/master-firmware/tests/test_ballgun.cpp
+++ b/master-firmware/tests/test_ballgun.cpp
@@ -6,6 +6,7 @@
 namespace {
 void set_servo_pos(void *s, float value) { *(float *)s = value; }
 void set_turbine_speed(void *s, float value) { *(float *)s = value; }
+void set_accelerator_speed(void *s, float value) { *(float *)s = value; }
 }
 
 TEST_GROUP(ABallGun)
@@ -13,15 +14,18 @@ TEST_GROUP(ABallGun)
     ballgun_t ballgun;
     float ballgun_servo_pos;
     float ballgun_tubine_speed;
+    float ballgun_accelerator_speed;
 
     void setup()
     {
         ballgun_init(&ballgun);
         ballgun_set_callbacks(&ballgun, &set_servo_pos, &ballgun_servo_pos);
         ballgun_set_turbine_callbacks(&ballgun, &set_turbine_speed, &ballgun_tubine_speed);
+        ballgun_set_accelerator_callbacks(&ballgun, &set_accelerator_speed, &ballgun_accelerator_speed);
 
         ballgun_set_servo_range(&ballgun, 0.001, 0.002);
         ballgun_set_turbine_range(&ballgun, 0.0, -0.001, 0.001);
+        ballgun_set_accelerator_range(&ballgun, -2, 2);
     }
 
     void teardown()
@@ -58,6 +62,7 @@ TEST(ABallGun, charges)
 
     CHECK_EQUAL(BALLGUN_CHARGING, ballgun.turbine_state);
     CHECK(ballgun_tubine_speed < 0.0f);
+    CHECK(ballgun_accelerator_speed < 0.0f);
 }
 
 TEST(ABallGun, fires)
@@ -65,7 +70,7 @@ TEST(ABallGun, fires)
     ballgun_fire(&ballgun);
 
     CHECK_EQUAL(BALLGUN_FIRING, ballgun.turbine_state);
-    CHECK(ballgun_tubine_speed > 0.0f);
+    CHECK(ballgun_accelerator_speed > 0.0f);
 }
 
 TEST(ABallGun, armsAfterFiring)
@@ -75,4 +80,5 @@ TEST(ABallGun, armsAfterFiring)
 
     CHECK_EQUAL(BALLGUN_ARMED, ballgun.turbine_state);
     CHECK(ballgun_tubine_speed == 0.0f);
+    CHECK(ballgun_accelerator_speed == 0.0f);
 }

--- a/master-firmware/tests/test_ballgun.cpp
+++ b/master-firmware/tests/test_ballgun.cpp
@@ -24,8 +24,8 @@ TEST_GROUP(ABallGun)
         ballgun_set_accelerator_callbacks(&ballgun, &set_accelerator_speed, &ballgun_accelerator_speed);
 
         ballgun_set_servo_range(&ballgun, 0.001, 0.002);
-        ballgun_set_turbine_range(&ballgun, 0.0, -0.001, 0.001);
-        ballgun_set_accelerator_range(&ballgun, -2, 2);
+        ballgun_set_turbine_range(&ballgun, 0.0, -0.001, 0.001, 0.0005);
+        ballgun_set_accelerator_range(&ballgun, -2, 2, 1);
     }
 
     void teardown()
@@ -70,6 +70,14 @@ TEST(ABallGun, fires)
     ballgun_fire(&ballgun);
 
     CHECK_EQUAL(BALLGUN_FIRING, ballgun.turbine_state);
+    CHECK(ballgun_accelerator_speed > 0.0f);
+}
+
+TEST(ABallGun, slowfires)
+{
+    ballgun_slowfire(&ballgun);
+
+    CHECK_EQUAL(BALLGUN_SLOWFIRING, ballgun.turbine_state);
     CHECK(ballgun_accelerator_speed > 0.0f);
 }
 

--- a/master-firmware/tests/test_ballgun.cpp
+++ b/master-firmware/tests/test_ballgun.cpp
@@ -5,18 +5,23 @@
 
 namespace {
 void set_servo_pos(void *s, float value) { *(float *)s = value; }
+void set_turbine_speed(void *s, float value) { *(float *)s = value; }
 }
 
 TEST_GROUP(ABallGun)
 {
     ballgun_t ballgun;
     float ballgun_servo_pos;
+    float ballgun_tubine_speed;
 
     void setup()
     {
         ballgun_init(&ballgun);
         ballgun_set_callbacks(&ballgun, &set_servo_pos, &ballgun_servo_pos);
+        ballgun_set_turbine_callbacks(&ballgun, &set_turbine_speed, &ballgun_tubine_speed);
+
         ballgun_set_servo_range(&ballgun, 0.001, 0.002);
+        ballgun_set_turbine_range(&ballgun, 0.0, -0.001, 0.001);
     }
 
     void teardown()
@@ -28,6 +33,7 @@ TEST_GROUP(ABallGun)
 TEST(ABallGun, initializesInDisabledState)
 {
     CHECK_EQUAL(BALLGUN_DISABLED, ballgun.state);
+    CHECK_EQUAL(BALLGUN_ARMED, ballgun.turbine_state);
 }
 
 TEST(ABallGun, deploys)
@@ -44,4 +50,29 @@ TEST(ABallGun, retracts)
 
     CHECK_EQUAL(BALLGUN_RETRACTED, ballgun.state);
     CHECK(ballgun_servo_pos != 0.0f);
+}
+
+TEST(ABallGun, charges)
+{
+    ballgun_charge(&ballgun);
+
+    CHECK_EQUAL(BALLGUN_CHARGING, ballgun.turbine_state);
+    CHECK(ballgun_tubine_speed < 0.0f);
+}
+
+TEST(ABallGun, fires)
+{
+    ballgun_fire(&ballgun);
+
+    CHECK_EQUAL(BALLGUN_FIRING, ballgun.turbine_state);
+    CHECK(ballgun_tubine_speed > 0.0f);
+}
+
+TEST(ABallGun, armsAfterFiring)
+{
+    ballgun_fire(&ballgun);
+    ballgun_arm(&ballgun);
+
+    CHECK_EQUAL(BALLGUN_ARMED, ballgun.turbine_state);
+    CHECK(ballgun_tubine_speed == 0.0f);
 }

--- a/master-firmware/tests/test_strategy.cpp
+++ b/master-firmware/tests/test_strategy.cpp
@@ -37,7 +37,13 @@ struct BuildTowerLevel : actions::BuildTowerLevel {
 struct FireBallGunIntoWaterTower : actions::FireBallGunIntoWaterTower {
     bool execute(RobotState &state) { return dummy_execute(this, state); }
 };
+struct FireBallGunIntoWasteWaterTreatmentPlant : actions::FireBallGunIntoWasteWaterTreatmentPlant {
+    bool execute(RobotState &state) { return dummy_execute(this, state); }
+};
 struct EmptyMonocolorWasteWaterCollector : actions::EmptyMonocolorWasteWaterCollector {
+    bool execute(RobotState &state) { return dummy_execute(this, state); }
+};
+struct EmptyMulticolorWasteWaterCollector : actions::EmptyMulticolorWasteWaterCollector {
     bool execute(RobotState &state) { return dummy_execute(this, state); }
 };
 
@@ -55,7 +61,9 @@ TEST_GROUP(Strategy) {
         {{1, 0}, {1, 1}, {1, 2}, {1, 3}},
     };
     FireBallGunIntoWaterTower fire_ballgun_into_watertower;
-    EmptyMonocolorWasteWaterCollector empty_wasterwater_collector;
+    FireBallGunIntoWasteWaterTreatmentPlant fire_ballgun_into_wastewater_treatment_plant;
+    EmptyMonocolorWasteWaterCollector empty_wasterwater_collector_monocolor;
+    EmptyMulticolorWasteWaterCollector empty_wasterwater_collector_multicolor;
 
     std::vector<goap::Action<RobotState>*> availableActions()
     {
@@ -78,7 +86,9 @@ TEST_GROUP(Strategy) {
             &build_tower_lvl[1][2],
             &build_tower_lvl[1][3],
             &fire_ballgun_into_watertower,
-            &empty_wasterwater_collector,
+            &fire_ballgun_into_wastewater_treatment_plant,
+            &empty_wasterwater_collector_monocolor,
+            &empty_wasterwater_collector_multicolor,
         };
     }
 
@@ -193,6 +203,16 @@ TEST(Strategy, CanBuildTwoTowers)
 TEST(Strategy, CanFillWaterTower)
 {
     WaterTowerGoal goal;
+
+    int len = compute_and_execute_plan(goal, state);
+
+    CHECK_TRUE(len > 0);
+    CHECK_TRUE(goal.is_reached(state));
+}
+
+TEST(Strategy, CanFillWasteWaterTreatment)
+{
+    WasteWaterGoal goal;
 
     int len = compute_and_execute_plan(goal, state);
 

--- a/master-firmware/tests/test_strategy.cpp
+++ b/master-firmware/tests/test_strategy.cpp
@@ -34,6 +34,9 @@ struct BuildTowerLevel : actions::BuildTowerLevel {
     BuildTowerLevel(int id, int level) : actions::BuildTowerLevel(id, level) {}
     bool execute(RobotState &state) { return dummy_execute(this, state); }
 };
+struct FireBallGunIntoWaterTower : actions::FireBallGunIntoWaterTower {
+    bool execute(RobotState &state) { return dummy_execute(this, state); }
+};
 
 TEST_GROUP(Strategy) {
     RobotState state;
@@ -48,6 +51,7 @@ TEST_GROUP(Strategy) {
         {{0, 0}, {0, 1}, {0, 2}, {0, 3}},
         {{1, 0}, {1, 1}, {1, 2}, {1, 3}},
     };
+    FireBallGunIntoWaterTower fire_ballgun_into_watertower;
 
     std::vector<goap::Action<RobotState>*> availableActions()
     {
@@ -69,6 +73,7 @@ TEST_GROUP(Strategy) {
             &build_tower_lvl[1][1],
             &build_tower_lvl[1][2],
             &build_tower_lvl[1][3],
+            &fire_ballgun_into_watertower,
         };
     }
 
@@ -178,4 +183,14 @@ TEST(Strategy, CanBuildTwoTowers)
         CHECK_TRUE(len > 0);
         CHECK_TRUE(goal.is_reached(state));
     }
+}
+
+TEST(Strategy, CanFillWaterTower)
+{
+    WaterTowerGoal goal;
+
+    int len = compute_and_execute_plan(goal, state);
+
+    CHECK_TRUE(len > 0);
+    CHECK_TRUE(goal.is_reached(state));
 }

--- a/master-firmware/tests/test_strategy.cpp
+++ b/master-firmware/tests/test_strategy.cpp
@@ -37,6 +37,9 @@ struct BuildTowerLevel : actions::BuildTowerLevel {
 struct FireBallGunIntoWaterTower : actions::FireBallGunIntoWaterTower {
     bool execute(RobotState &state) { return dummy_execute(this, state); }
 };
+struct EmptyMonocolorWasteWaterCollector : actions::EmptyMonocolorWasteWaterCollector {
+    bool execute(RobotState &state) { return dummy_execute(this, state); }
+};
 
 TEST_GROUP(Strategy) {
     RobotState state;
@@ -52,6 +55,7 @@ TEST_GROUP(Strategy) {
         {{1, 0}, {1, 1}, {1, 2}, {1, 3}},
     };
     FireBallGunIntoWaterTower fire_ballgun_into_watertower;
+    EmptyMonocolorWasteWaterCollector empty_wasterwater_collector;
 
     std::vector<goap::Action<RobotState>*> availableActions()
     {
@@ -74,6 +78,7 @@ TEST_GROUP(Strategy) {
             &build_tower_lvl[1][2],
             &build_tower_lvl[1][3],
             &fire_ballgun_into_watertower,
+            &empty_wasterwater_collector,
         };
     }
 


### PR DESCRIPTION
This PR implements support for the ball gun module, and integrates it in the strategy of both robots. The ball gun sequences need more tuning, but the groundwork is done.