### PR TITLE
Separate MessagePack config for Order and Chaos

### DIFF
--- a/master-firmware/Makefile
+++ b/master-firmware/Makefile
@@ -55,8 +55,10 @@ endif
 
 ifeq ($(ROBOT), order)
   CONFIG_YAML = ../config_order.yaml
+  CONFIG_MSGPACK_C = src/config_msgpack_order.c
 else
   CONFIG_YAML = ../config_chaos.yaml
+  CONFIG_MSGPACK_C = src/config_msgpack_chaos.c
 endif
 
 #
@@ -133,7 +135,8 @@ CSRC = $(PORTSRC) \
 	   $(CHIBIOS)/os/various/syscalls.c \
 	   $(CHIBIOS)/os/various/fatfs_bindings/fatfs_diskio.c \
 	   $(BOARDSRC) \
-	   $(GFXSRC)
+	   $(GFXSRC) \
+	   $(CONFIG_MSGPACK_C)
 
 include app_src.mk
 
@@ -261,7 +264,8 @@ RULESPATH = ./linker/
 include $(CHIBIOS)/os/common/startup/ARMCMx/compilers/GCC/rules.mk
 
 # Empty libraries, required by stack smashing protection
-PRE_MAKE_ALL_RULE_HOOK: app_src.mk libssp.a libssp_nonshared.a src/config_msgpack.c
+PRE_MAKE_ALL_RULE_HOOK: app_src.mk $(CONFIG_MSGPACK_C) libssp.a libssp_nonshared.a
+
 libssp.a:
 	arm-none-eabi-ar rcs $@
 
@@ -288,9 +292,9 @@ dsdlc:
 	@$(COLOR_PRINTF) "Running uavcan dsdl compiler"
 	$(LIBUAVCAN_DSDLC) ../uavcan_data_types/cvra $(UAVCAN_DSDL_DIR)
 
-src/config_msgpack.c: ${CONFIG_YAML}
+$(CONFIG_MSGPACK_C): $(CONFIG_YAML)
 	@$(COLOR_PRINTF) "Generating MessagePack config..."
-	@../tools/config/config_to_msgpack.py ${CONFIG_YAML} src/config_msgpack.c
+	@../tools/config/config_to_msgpack.py $< $@
 
 .PHONY: heap_size
 heap_size: $(BUILDDIR)/$(PROJECT).elf
@@ -300,6 +304,6 @@ all: heap_size mem_info
 
 CLEAN_RULE_HOOK:
 	@$(COLOR_PRINTF) "Remove MessagePack config"
-	-rm -f src/config_msgpack.c
+	-rm -f $(CONFIG_MSGPACK_C)
 
 include ../tools/generate_ctags.mk

--- a/master-firmware/Makefile
+++ b/master-firmware/Makefile
@@ -281,7 +281,6 @@ endif
 .PHONY: flash
 flash: $(BUILDDIR)/$(PROJECT).elf
 	openocd -f $(OPENOCD_CFG) -c "program $(BUILDDIR)/$(PROJECT).elf verify reset" -c "shutdown"
-	say -v "Daniel" "Robot flashed master!"
 
 # run uavcan dsdl compiler
 .PHONY: dsdlc

--- a/master-firmware/Makefile
+++ b/master-firmware/Makefile
@@ -231,10 +231,6 @@ DLIBS =
 UDEFS = -DON_ROBOT
 UDEFS += $(addprefix -D, $(GFXDEFS))
 
-ifeq ($(ROBOT), order)
-  UDEFS += -DDEBRA=1
-endif
-
 # Define ASM defines here
 UADEFS =
 

--- a/master-firmware/Makefile
+++ b/master-firmware/Makefile
@@ -47,19 +47,8 @@ ifeq ($(USE_VERBOSE_COMPILE),)
   USE_VERBOSE_COMPILE = no
 endif
 
-
-# Config file depending on robot
-ifeq ($(ROBOT), )
-  $(error Please define ROBOT to either 'order' or 'chaos')
-endif
-
-ifeq ($(ROBOT), order)
-  CONFIG_YAML = ../config_order.yaml
-  CONFIG_MSGPACK_C = src/config_msgpack_order.c
-else
-  CONFIG_YAML = ../config_chaos.yaml
-  CONFIG_MSGPACK_C = src/config_msgpack_chaos.c
-endif
+CONFIG_YAML = ../config_order.yaml ../config_chaos.yaml
+CONFIG_MSGPACK_C = $(addprefix src/, $(notdir $(CONFIG_YAML:.yaml=.c)))
 
 #
 # Build global options
@@ -292,9 +281,9 @@ dsdlc:
 	@$(COLOR_PRINTF) "Running uavcan dsdl compiler"
 	$(LIBUAVCAN_DSDLC) ../uavcan_data_types/cvra $(UAVCAN_DSDL_DIR)
 
-$(CONFIG_MSGPACK_C): $(CONFIG_YAML)
-	@$(COLOR_PRINTF) "Generating MessagePack config..."
-	@../tools/config/config_to_msgpack.py $< $@
+$(CONFIG_MSGPACK_C): src/%.c : ../%.yaml
+	@$(COLOR_PRINTF) "Generating $@"
+	@../tools/config/config_to_msgpack.py $< $@ --name msgpack_$(notdir $(<:.yaml=))
 
 .PHONY: heap_size
 heap_size: $(BUILDDIR)/$(PROJECT).elf

--- a/master-firmware/Makefile
+++ b/master-firmware/Makefile
@@ -303,11 +303,8 @@ heap_size: $(BUILDDIR)/$(PROJECT).elf
 
 all: heap_size mem_info
 
-clean:
-	@echo Cleaning
-	-rm src/config_msgpack.c
-	-rm -fR .dep $(BUILDDIR)
-	@echo
-	@echo Done
+CLEAN_RULE_HOOK:
+	@$(COLOR_PRINTF) "Remove MessagePack config"
+	-rm -f src/config_msgpack.c
 
 include ../tools/generate_ctags.mk

--- a/master-firmware/README.md
+++ b/master-firmware/README.md
@@ -28,3 +28,10 @@ When using `make` to build the firmware, you can specify the following options:
 - `ROBOT=debra` or `ROBOT=sandoi` will tell the makefile to use the correct config file (Debra: `../config_debra.yaml`, Sandoi: `../config.yaml`.
 
 When switching from one configuration to another, do not forget to run `make clean` to prevent weird errors.
+
+## Hardware configuration
+
+The firmware for the two robots is the same.
+The hardware jumper `ROBOT_SELECT` on the Nucleo shield tells the software on which robot it runs.
+Jumper position 1 selects *Order*, jumper position 2 selects *Chaos*.
+The default configuration (i.e. no jumper present) selects *Order*.

--- a/master-firmware/package.yml
+++ b/master-firmware/package.yml
@@ -55,7 +55,6 @@ target.arm:
     - src/arms/arms_controller.c
     - src/arms/arm_trajectory_manager.c
     - src/robot_helpers/motor_helpers.c
-    - src/config_msgpack.c
     - src/trace/trace_points.c
     - src/strategy.cpp
     - src/filesystem.c

--- a/master-firmware/src/board/board.h
+++ b/master-firmware/src/board/board.h
@@ -146,7 +146,7 @@
 #define GPIOF_PIN0                  0
 #define GPIOF_PIN1                  1
 #define GPIOF_PIN2                  2
-#define GPIOF_ROBOT_SELECT          3 // ROBOT_SELECT (input up), default = debra
+#define GPIOF_ROBOT_SELECT          3 // ROBOT_SELECT (input up), default = high
 #define GPIOF_PIN4                  4
 #define GPIOF_PIN5                  5
 #define GPIOF_UART7_RX              6 // DEBUG_UART_RX (alternate 8, pullup)

--- a/master-firmware/src/main.c
+++ b/master-firmware/src/main.c
@@ -156,14 +156,23 @@ void config_load_err_cb(void *arg, const char *id, const char *err)
     WARNING("parameter %s: %s", id == NULL ? "(...)" : id, err);
 }
 
-extern unsigned char config_msgpack[];
-extern const size_t config_msgpack_size;
+extern unsigned char msgpack_config_order[];
+extern const size_t msgpack_config_order_size;
+extern unsigned char msgpack_config_chaos[];
+extern const size_t msgpack_config_chaos_size;
 
 void config_load_from_flash(void)
 {
     cmp_ctx_t cmp;
     cmp_mem_access_t mem;
-    cmp_mem_access_ro_init(&cmp, &mem, config_msgpack, config_msgpack_size);
+
+    bool robot_is_order = palReadPad(GPIOF, GPIOF_ROBOT_SELECT);
+
+    if (robot_is_order) {
+        cmp_mem_access_ro_init(&cmp, &mem, msgpack_config_order, msgpack_config_order_size);
+    } else {
+        cmp_mem_access_ro_init(&cmp, &mem, msgpack_config_chaos, msgpack_config_chaos_size);
+    }
     parameter_msgpack_read_cmp(&global_config, &cmp, config_load_err_cb, NULL);
 }
 

--- a/tools/config/config_to_msgpack.py
+++ b/tools/config/config_to_msgpack.py
@@ -17,6 +17,9 @@ def keys_to_str(to_convert):
 
 def main():
     parser = argparse.ArgumentParser()
+    parser.add_argument('--name',
+                        required=True,
+                        help='symbol name of the MessagePack buffer')
     parser.add_argument('config_file', type=argparse.FileType(),
                         help='YAML file containing the config')
     parser.add_argument('output',
@@ -30,12 +33,12 @@ def main():
 
     args.output.write('/* generated file */\n')
     args.output.write('#include <stddef.h>\n')
-    args.output.write('unsigned char config_msgpack[] = {')
+    args.output.write('unsigned char {:s}[] = {{'.format(args.name))
     args.output.write('0x{:02x}'.format(binary[0]))
     for b in binary[1:]:
         args.output.write(',0x{:02x}'.format(b))
     args.output.write('};\n')
-    args.output.write('const size_t config_msgpack_size = {};\n'.format(len(binary)))
+    args.output.write('const size_t {:s}_size = sizeof({});\n'.format(args.name, args.name))
     args.output.flush()
     args.output.close()
 


### PR DESCRIPTION
With this PR I propose to generate two different `config_msgpack.c` from the yaml configs of the two robots. This avoids having to `rm src/config_msgpack.c` when changing the build target.

It also fixes some annoying make warnings.
