### PR TITLE
Enable obstacle avoidance in polar mode

### DIFF
--- a/master-firmware/src/commands.c
+++ b/master-firmware/src/commands.c
@@ -417,6 +417,11 @@ static void cmd_traj_forward(BaseSequentialStream *chp, int argc, char *argv[])
         int32_t distance;
         distance = atoi(argv[0]);
         trajectory_d_rel(&robot.traj, distance);
+        int end_reason = trajectory_wait_for_end(
+            TRAJ_END_GOAL_REACHED | TRAJ_END_COLLISION |
+            TRAJ_END_OPPONENT_NEAR | TRAJ_END_ALLY_NEAR);
+        trajectory_hardstop(&robot.traj);
+        chprintf(chp, "End reason %d\r\n", end_reason);
 
         robot.mode = BOARD_MODE_ANGLE_DISTANCE;
     } else {

--- a/master-firmware/src/robot_helpers/trajectory_helpers.c
+++ b/master-firmware/src/robot_helpers/trajectory_helpers.c
@@ -64,7 +64,7 @@ int trajectory_has_ended(int watched_end_reasons)
                                          &x_opp,
                                          &y_opp);
 
-                if (trajectory_is_on_collision_path(x_opp, y_opp)) {
+                if (trajectory_is_on_collision_path(&robot, x_opp, y_opp)) {
                     return TRAJ_END_OPPONENT_NEAR;
                 }
             }
@@ -79,7 +79,7 @@ int trajectory_has_ended(int watched_end_reasons)
             uint32_t age = timestamp_duration_s(pos.timestamp, timestamp_get());
 
             if (age < TRAJ_MAX_TIME_DELAY_OPPONENT_DETECTION) {
-                if (trajectory_is_on_collision_path(pos.point.x, pos.point.y)) {
+                if (trajectory_is_on_collision_path(&robot, pos.point.x, pos.point.y)) {
                     return TRAJ_END_ALLY_NEAR;
                 }
             }
@@ -121,37 +121,37 @@ void trajectory_move_to(int32_t x_mm, int32_t y_mm, int32_t a_deg)
     trajectory_wait_for_end(TRAJ_END_GOAL_REACHED);
 }
 
-bool trajectory_crosses_obstacle(poly_t* opponent, point_t* intersection)
+bool trajectory_crosses_obstacle(struct _robot* robot, poly_t* opponent, point_t* intersection)
 {
     point_t current_position = {
-            position_get_x_float(&robot.pos),
-            position_get_y_float(&robot.pos)
+            position_get_x_float(&robot->pos),
+            position_get_y_float(&robot->pos)
         };
     point_t target_position = {
-            robot.traj.target.cart.x,
-            robot.traj.target.cart.y
+            robot->traj.target.cart.x;
+            robot->traj.target.cart.y;
         };
 
     uint8_t path_crosses_obstacle = is_crossing_poly(current_position, target_position, intersection, opponent);
     bool current_pos_inside_obstacle =
-        math_point_is_in_square(opponent, position_get_x_s16(&robot.pos), position_get_y_s16(&robot.pos));
+        math_point_is_in_square(opponent, position_get_x_s16(&robot->pos), position_get_y_s16(&robot->pos));
 
     return path_crosses_obstacle == 1 || current_pos_inside_obstacle;
 }
 
-bool trajectory_is_on_collision_path(int x, int y)
+bool trajectory_is_on_collision_path(struct _robot* robot, int x, int y)
 {
     point_t points[4];
     poly_t opponent = {.pts = points, .l = 4};
     map_set_rectangular_obstacle(&opponent,
                                  x,
                                  y,
-                                 robot.opponent_size,
-                                 robot.opponent_size,
-                                 robot.robot_size);
+                                 robot->opponent_size,
+                                 robot->opponent_size,
+                                 robot->robot_size);
 
     point_t intersection;
-    return trajectory_crosses_obstacle(&opponent, &intersection);
+    return trajectory_crosses_obstacle(robot, &opponent, &intersection);
 }
 
 void trajectory_set_mode_aligning(

--- a/master-firmware/src/robot_helpers/trajectory_helpers.h
+++ b/master-firmware/src/robot_helpers/trajectory_helpers.h
@@ -61,12 +61,12 @@ void trajectory_move_to(int32_t x_mm, int32_t y_mm, int32_t a_deg);
 
 /** Check if current trajectory segment crosses the passed obstacle
  */
-bool trajectory_crosses_obstacle(poly_t* opponent, point_t* intersection);
+bool trajectory_crosses_obstacle(struct _robot* robot, poly_t* opponent, point_t* intersection);
 
 /** Check if the current trajectory will collide with the obstacle
     seen at position (x,y)
  */
-bool trajectory_is_on_collision_path(int x, int y);
+bool trajectory_is_on_collision_path(struct _robot* robot, int x, int y);
 
 /** Prepare robot for aligning by settings its dynamics accordingly
  * ie. slower and less sensitive to collisions

--- a/master-firmware/tests/test_trajectory_helpers.cpp
+++ b/master-firmware/tests/test_trajectory_helpers.cpp
@@ -238,6 +238,30 @@ TEST(CurrentTrajectoryCheck, DetectsPathCrossingIfPathInsideObstacle)
     CHECK_TRUE(trajectory_crosses_obstacle(&robot, opponent, &intersection));
 }
 
+TEST(CurrentTrajectoryCheck, DetectsPathNotCrossingInPolarMode)
+{
+    point_t intersection;
+    robot.opponent_size = 100;
+
+    set_opponent_position(250, 250);
+    trajectory_d_rel(&robot.traj, 100);
+    robot_manage();
+
+    CHECK_FALSE(trajectory_crosses_obstacle(&robot, opponent, &intersection));
+}
+
+TEST(CurrentTrajectoryCheck, DetectsPathCrossingInPolarMode)
+{
+    point_t intersection;
+    robot.opponent_size = 100;
+
+    set_opponent_position(250, 250);
+    trajectory_d_rel(&robot.traj, 400);
+    robot_manage();
+
+    CHECK_TRUE(trajectory_crosses_obstacle(&robot, opponent, &intersection));
+}
+
 TEST(CurrentTrajectoryCheck, IsNotOnCollisionPathWithObstacle)
 {
     robot.opponent_size = 100;

--- a/master-firmware/tests/test_trajectory_helpers.cpp
+++ b/master-firmware/tests/test_trajectory_helpers.cpp
@@ -138,8 +138,6 @@ TEST_GROUP(CurrentTrajectoryCheck)
 
     const int arbitrary_max_speed = 10;
     const int arbitrary_max_acc = 10;
-    const int arbitrary_goal_x = 200;
-    const int arbitrary_goal_y = 200;
     const int arbitrary_end_angle = 45;
 
     const int arbitrary_robot_size = 100;
@@ -185,9 +183,11 @@ TEST_GROUP(CurrentTrajectoryCheck)
         // Opponent obstacle
         oa_init();
         opponent = oa_new_poly(4);
+    }
 
-        // Finally go to a point
-        trajectory_goto_forward_xy_abs(&robot.traj, arbitrary_goal_x, arbitrary_goal_y);
+    void goto_xy(int x_mm, int y_mm)
+    {
+        trajectory_goto_forward_xy_abs(&robot.traj, x_mm, y_mm);
         robot_manage();
         robot_manage();
     }
@@ -205,61 +205,67 @@ TEST_GROUP(CurrentTrajectoryCheck)
     }
 };
 
-TEST(CurrentTrajectoryCheck, CurrentPathCrossesWithObstacle)
-{
-    robot.opponent_size = 100;
-    set_opponent_position(400, 400);
-
-    point_t intersection;
-    bool res = trajectory_crosses_obstacle(opponent, &intersection);
-
-    CHECK_FALSE(res);
-}
-
 TEST(CurrentTrajectoryCheck, CurrentPathDoesntCrossWithObstacle)
 {
-    robot.opponent_size = 100;
-    set_opponent_position(240, 250);
-
     point_t intersection;
-    bool res = trajectory_crosses_obstacle(opponent, &intersection);
+    robot.opponent_size = 100;
 
-    CHECK_TRUE(res);
+    set_opponent_position(400, 400);
+    goto_xy(200, 200);
+
+    CHECK_FALSE(trajectory_crosses_obstacle(opponent, &intersection));
+}
+
+TEST(CurrentTrajectoryCheck, CurrentPathCrossesWithObstacle)
+{
+    point_t intersection;
+    robot.opponent_size = 100;
+
+    set_opponent_position(240, 250);
+    goto_xy(200, 200);
+
+    CHECK_TRUE(trajectory_crosses_obstacle(opponent, &intersection));
 }
 
 TEST(CurrentTrajectoryCheck, DetectsPathCrossingIfPathInsideObstacle)
 {
-    robot.opponent_size = 400;
-    set_opponent_position(250, 250);
-
     point_t intersection;
-    bool res = trajectory_crosses_obstacle(opponent, &intersection);
+    robot.opponent_size = 400;
 
-    CHECK_TRUE(res);
+    set_opponent_position(250, 250);
+    goto_xy(200, 200);
+
+    CHECK_TRUE(trajectory_crosses_obstacle(opponent, &intersection));
 }
 
 TEST(CurrentTrajectoryCheck, IsNotOnCollisionPathWithObstacle)
 {
     robot.opponent_size = 100;
-    bool res = trajectory_is_on_collision_path(400, 400);
 
-    CHECK_FALSE(res);
+    set_opponent_position(250, 250);
+    goto_xy(200, 200);
+
+    CHECK_FALSE(trajectory_is_on_collision_path(400, 400));
 }
 
 TEST(CurrentTrajectoryCheck, IsOnCollisionPathWithObstacle)
 {
     robot.opponent_size = 100;
-    bool res = trajectory_is_on_collision_path(240, 250);
 
-    CHECK_TRUE(res);
+    set_opponent_position(250, 250);
+    goto_xy(200, 200);
+
+    CHECK_TRUE(trajectory_is_on_collision_path(240, 250));
 }
 
 TEST(CurrentTrajectoryCheck, DetectsCollisionIfPathIsCompletelyInsideObstacle)
 {
     robot.opponent_size = 400;
-    bool res = trajectory_is_on_collision_path(250, 250);
 
-    CHECK_TRUE(res);
+    set_opponent_position(250, 250);
+    goto_xy(200, 200);
+
+    CHECK_TRUE(trajectory_is_on_collision_path(250, 250));
 }
 
 

--- a/master-firmware/tests/test_trajectory_helpers.cpp
+++ b/master-firmware/tests/test_trajectory_helpers.cpp
@@ -213,7 +213,7 @@ TEST(CurrentTrajectoryCheck, CurrentPathDoesntCrossWithObstacle)
     set_opponent_position(400, 400);
     goto_xy(200, 200);
 
-    CHECK_FALSE(trajectory_crosses_obstacle(opponent, &intersection));
+    CHECK_FALSE(trajectory_crosses_obstacle(&robot, opponent, &intersection));
 }
 
 TEST(CurrentTrajectoryCheck, CurrentPathCrossesWithObstacle)
@@ -224,7 +224,7 @@ TEST(CurrentTrajectoryCheck, CurrentPathCrossesWithObstacle)
     set_opponent_position(240, 250);
     goto_xy(200, 200);
 
-    CHECK_TRUE(trajectory_crosses_obstacle(opponent, &intersection));
+    CHECK_TRUE(trajectory_crosses_obstacle(&robot, opponent, &intersection));
 }
 
 TEST(CurrentTrajectoryCheck, DetectsPathCrossingIfPathInsideObstacle)
@@ -235,7 +235,7 @@ TEST(CurrentTrajectoryCheck, DetectsPathCrossingIfPathInsideObstacle)
     set_opponent_position(250, 250);
     goto_xy(200, 200);
 
-    CHECK_TRUE(trajectory_crosses_obstacle(opponent, &intersection));
+    CHECK_TRUE(trajectory_crosses_obstacle(&robot, opponent, &intersection));
 }
 
 TEST(CurrentTrajectoryCheck, IsNotOnCollisionPathWithObstacle)
@@ -245,7 +245,7 @@ TEST(CurrentTrajectoryCheck, IsNotOnCollisionPathWithObstacle)
     set_opponent_position(250, 250);
     goto_xy(200, 200);
 
-    CHECK_FALSE(trajectory_is_on_collision_path(400, 400));
+    CHECK_FALSE(trajectory_is_on_collision_path(&robot, 400, 400));
 }
 
 TEST(CurrentTrajectoryCheck, IsOnCollisionPathWithObstacle)
@@ -255,7 +255,7 @@ TEST(CurrentTrajectoryCheck, IsOnCollisionPathWithObstacle)
     set_opponent_position(250, 250);
     goto_xy(200, 200);
 
-    CHECK_TRUE(trajectory_is_on_collision_path(240, 250));
+    CHECK_TRUE(trajectory_is_on_collision_path(&robot, 240, 250));
 }
 
 TEST(CurrentTrajectoryCheck, DetectsCollisionIfPathIsCompletelyInsideObstacle)
@@ -265,7 +265,7 @@ TEST(CurrentTrajectoryCheck, DetectsCollisionIfPathIsCompletelyInsideObstacle)
     set_opponent_position(250, 250);
     goto_xy(200, 200);
 
-    CHECK_TRUE(trajectory_is_on_collision_path(250, 250));
+    CHECK_TRUE(trajectory_is_on_collision_path(&robot, 250, 250));
 }
 
 

--- a/master-firmware/tests/trajectory_manager_test.cpp
+++ b/master-firmware/tests/trajectory_manager_test.cpp
@@ -101,3 +101,17 @@ TEST(TrajectoryManagerTestGroup, RemovesEventWhenInWindow)
 
     CHECK_FALSE(traj.scheduled);
 }
+
+TEST(TrajectoryManagerTestGroup, StartsTrajectoryInDistance)
+{
+    trajectory_d_rel(&traj, 100);
+
+    CHECK_EQUAL(RUNNING_D, traj.state);
+}
+
+TEST(TrajectoryManagerTestGroup, StartsTrajectoryInAngle)
+{
+    trajectory_a_rel(&traj, 10);
+
+    CHECK_EQUAL(RUNNING_A, traj.state);
+}


### PR DESCRIPTION
This PR fixes #121 partially by predicting collision with opponent when robot is moving in polar mode (distance or angle setpoints).