### PR TITLE
Fix stack usage of GOAP

### DIFF
--- a/lib/goap/goap.hpp
+++ b/lib/goap/goap.hpp
@@ -17,11 +17,10 @@ template<typename State>
 class Action {
 public:
     /** Checks if the given state allows this action to proceed. */
-    virtual bool can_run(State state) = 0;
+    virtual bool can_run(const State &state) = 0;
 
-    /** Plans the effects of this action on the state and returns the
-     * modified state. */
-    virtual State plan_effects(State state) = 0;
+    /** Plans the effects of this action on the state */
+    virtual void plan_effects(State &state) = 0;
 
     /** Tries to execute the task and returns true if it suceeded. */
     virtual bool execute(State &state) = 0;
@@ -59,7 +58,7 @@ public:
      *
      * If path is given, then the found path is stored there.
      */
-    int plan(State state, Goal<State> &goal,
+    int plan(const State &state, Goal<State> &goal,
              Action<State> **path = nullptr, int path_len = 10)
     {
         visited_states_array_to_list(nodes, N);
@@ -123,7 +122,8 @@ public:
                     }
 
                     auto neighbor = list_pop_head(free_nodes);
-                    neighbor->state = action->plan_effects(current->state);
+                    neighbor->state = current->state;
+                    action->plan_effects(neighbor->state);
                     neighbor->cost = current->cost + 1;
                     neighbor->priority = current->priority + 1 + goal.distance_to(neighbor->state);
                     neighbor->parent = current;

--- a/lib/goap/tests/goap_test.cpp
+++ b/lib/goap/tests/goap_test.cpp
@@ -17,15 +17,14 @@ bool operator==(const TestState& lhs, const TestState& rhs)
 
 class CutWood : public goap::Action<TestState> {
 public:
-    bool can_run(TestState state)
+    bool can_run(const TestState &state)
     {
         return state.has_axe;
     }
 
-    TestState plan_effects(TestState state)
+    void plan_effects(TestState &state)
     {
         state.has_wood = true;
-        return state;
     }
 
     bool execute(TestState &state)
@@ -36,16 +35,15 @@ public:
 };
 
 struct GrabAxe : public goap::Action<TestState> {
-    bool can_run(TestState state)
+    bool can_run(const TestState &state)
     {
         (void) state;
         return true;
     }
 
-    TestState plan_effects(TestState state)
+    void plan_effects(TestState &state)
     {
         state.has_axe = true;
-        return state;
     }
 
     bool execute(TestState &state)
@@ -94,7 +92,7 @@ TEST(SimpleScenarioHelpers, CanCheckGoal)
 
 TEST(SimpleScenarioHelpers, CanPredictWoodCuttingEffects)
 {
-    state = action.plan_effects(state);
+    action.plan_effects(state);
     CHECK_TRUE(state.has_wood);
 }
 
@@ -204,16 +202,15 @@ struct FarAwayGoal : goap::Goal<FarAwayState> {
 };
 
 struct FarAwayAction : goap::Action<FarAwayState> {
-    bool can_run(FarAwayState state)
+    bool can_run(const FarAwayState &state)
     {
         (void) state;
         return true;
     }
 
-    FarAwayState plan_effects(FarAwayState s)
+    void plan_effects(FarAwayState &state)
     {
-        s.farDistance--;
-        return s;
+        state.farDistance--;
     }
 
     bool execute(FarAwayState &s)

--- a/master-firmware/src/strategy.cpp
+++ b/master-firmware/src/strategy.cpp
@@ -1125,10 +1125,12 @@ void strategy_play_game(void *p)
 
     /* Prepare state publisher */
     RobotState state;
+
     static messagebus_topic_t state_topic;
     static MUTEX_DECL(state_lock);
     static CONDVAR_DECL(state_condvar);
-    messagebus_topic_init(&state_topic, &state_lock, &state_condvar, &state, sizeof(state));
+    static RobotState state_topic_content;
+    messagebus_topic_init(&state_topic, &state_lock, &state_condvar, &state_topic_content, sizeof(state));
     messagebus_advertise_topic(&bus, &state_topic, "/state");
 
     NOTICE("Waiting for color selection...");

--- a/master-firmware/src/strategy/actions.h
+++ b/master-firmware/src/strategy/actions.h
@@ -7,29 +7,27 @@
 namespace actions {
 
 struct IndexArms : public goap::Action<RobotState> {
-    bool can_run(RobotState state)
+    bool can_run(const RobotState &state)
     {
         (void) state;
         return true;
     }
 
-    RobotState plan_effects(RobotState state)
+    void plan_effects(RobotState &state)
     {
         state.arms_are_indexed = true;
-        return state;
     }
 };
 
 struct RetractArms : public goap::Action<RobotState> {
-    bool can_run(RobotState state)
+    bool can_run(const RobotState &state)
     {
         return state.arms_are_indexed;
     }
 
-    RobotState plan_effects(RobotState state)
+    void plan_effects(RobotState &state)
     {
         state.arms_are_deployed = false;
-        return state;
     }
 };
 
@@ -37,14 +35,14 @@ struct PickupCubes : public goap::Action<RobotState> {
     int blocks_id;
 
     PickupCubes(int blocks_id_) : blocks_id(blocks_id_) {}
-    bool can_run(RobotState state)
+    bool can_run(const RobotState &state)
     {
         return state.arms_are_deployed == false
             && (state.lever_full_right == false || state.lever_full_left == false)
             && state.blocks_on_map[blocks_id] == true;
     }
 
-    RobotState plan_effects(RobotState state)
+    void plan_effects(RobotState &state)
     {
         if (state.lever_full_right == false) {
             state.lever_full_right = true;
@@ -52,35 +50,32 @@ struct PickupCubes : public goap::Action<RobotState> {
             state.lever_full_left = true;
         }
         state.blocks_on_map[blocks_id] = false;
-        return state;
     }
 };
 
 struct TurnSwitchOn : public goap::Action<RobotState> {
-    bool can_run(RobotState state)
+    bool can_run(const RobotState &state)
     {
         return state.arms_are_deployed == false && state.panel_on_map;
     }
 
-    RobotState plan_effects(RobotState state)
+    void plan_effects(RobotState &state)
     {
         state.arms_are_deployed = true;
         state.switch_on = true;
-        return state;
     }
 };
 
 struct DeployTheBee : public goap::Action<RobotState> {
-    bool can_run(RobotState state)
+    bool can_run(const RobotState &state)
     {
         return state.arms_are_deployed == false && state.bee_on_map;
     }
 
-    RobotState plan_effects(RobotState state)
+    void plan_effects(RobotState &state)
     {
         state.arms_are_deployed = true;
         state.bee_deployed = true;
-        return state;
     }
 };
 
@@ -88,7 +83,7 @@ struct DepositCubes : public goap::Action<RobotState> {
     int construction_zone_id;
     DepositCubes(int id) : construction_zone_id(id) {}
 
-    bool can_run(RobotState state)
+    bool can_run(const RobotState &state)
     {
         auto no_cubes_in_construction_zone = [](const RobotState& state, int zone_id) -> bool {
             for (const auto& cube_in_construction_zone : state.construction_zone[zone_id].cubes_ready) {
@@ -103,7 +98,7 @@ struct DepositCubes : public goap::Action<RobotState> {
                no_cubes_in_construction_zone(state, construction_zone_id);
     }
 
-    RobotState plan_effects(RobotState state)
+    void plan_effects(RobotState &state)
     {
         if (state.lever_full_right == true) {
             state.lever_full_right = false;
@@ -114,8 +109,6 @@ struct DepositCubes : public goap::Action<RobotState> {
         for (auto& cube_ready : state.construction_zone[construction_zone_id].cubes_ready) {
             cube_ready = true;
         }
-
-        return state;
     }
 };
 
@@ -123,96 +116,89 @@ struct BuildTowerLevel : public goap::Action<RobotState> {
     int construction_zone_id, level;
     BuildTowerLevel(int id, int lvl) : construction_zone_id(id), level(lvl) {}
 
-    bool can_run(RobotState state)
+    bool can_run(const RobotState &state)
     {
       return state.construction_zone[construction_zone_id].tower_level == level &&
              state.construction_zone[construction_zone_id].cubes_ready[state.tower_sequence[level]];
     }
 
-    RobotState plan_effects(RobotState state)
+    void plan_effects(RobotState &state)
     {
         state.arms_are_deployed = true;
         state.construction_zone[construction_zone_id].cubes_ready[state.tower_sequence[level]] = false;
         state.construction_zone[construction_zone_id].tower_level += 1;
-        return state;
     }
 };
 
 struct FireBallGunIntoWaterTower : public goap::Action<RobotState> {
-    bool can_run(RobotState state)
+    bool can_run(const RobotState &state)
     {
         return state.arms_are_deployed == false && state.ballgun_state == BallgunState::CHARGED_MONOCOLOR;
     }
 
-    RobotState plan_effects(RobotState state)
+    void plan_effects(RobotState &state)
     {
         state.ballgun_state = BallgunState::IS_EMPTY;
         state.balls_in_watertower += 8;
-        return state;
     }
 };
 
 struct FireBallGunIntoWasteWaterTreatmentPlant : public goap::Action<RobotState> {
-    bool can_run(RobotState state)
+    bool can_run(const RobotState &state)
     {
         return state.arms_are_deployed == false && state.ballgun_state == BallgunState::CHARGED_MULTICOLOR;
     }
 
-    RobotState plan_effects(RobotState state)
+    void plan_effects(RobotState &state)
     {
         state.ballgun_state = BallgunState::IS_EMPTY;
         state.balls_in_wastewater_treatment_plant += 8;
-        return state;
     }
 };
 
 struct EmptyMonocolorWasteWaterCollector : public goap::Action<RobotState> {
-    bool can_run(RobotState state)
+    bool can_run(const RobotState &state)
     {
         return state.arms_are_deployed == false &&
                state.ballgun_state == BallgunState::IS_EMPTY &&
                state.wastewater_monocolor_full;
     }
 
-    RobotState plan_effects(RobotState state)
+    void plan_effects(RobotState &state)
     {
         state.ballgun_state = BallgunState::CHARGED_MONOCOLOR;
         state.wastewater_monocolor_full = false;
         state.lever_full_left = false;
         state.lever_full_right = false;
-        return state;
     }
 };
 
 struct EmptyMulticolorWasteWaterCollector : public goap::Action<RobotState> {
-    bool can_run(RobotState state)
+    bool can_run(const RobotState &state)
     {
         return state.arms_are_deployed == false &&
                state.ballgun_state == BallgunState::IS_EMPTY &&
                state.wastewater_multicolor_full;
     }
 
-    RobotState plan_effects(RobotState state)
+    void plan_effects(RobotState &state)
     {
         state.ballgun_state = BallgunState::CHARGED_MULTICOLOR;
         state.wastewater_multicolor_full = false;
-        return state;
     }
 };
 
 struct TurnOpponentSwitchOff : public goap::Action<RobotState> {
-    bool can_run(RobotState state)
+    bool can_run(const RobotState &state)
     {
         return state.arms_are_deployed == false && state.should_push_opponent_panel;
     }
 
-    RobotState plan_effects(RobotState state)
+    void plan_effects(RobotState &state)
     {
         state.arms_are_deployed = true;
         state.opponent_panel_on = false;
         state.should_push_opponent_panel = false;
-
-        return state;
     }
 };
 

--- a/master-firmware/tests/test_strategy.cpp
+++ b/master-firmware/tests/test_strategy.cpp
@@ -6,7 +6,7 @@
 
 bool dummy_execute(goap::Action<RobotState>* action, RobotState &state)
 {
-    state = action->plan_effects(state);
+    action->plan_effects(state);
     return true;
 }
 


### PR DESCRIPTION
Imagine everything you can do now that you can pass big structs to GOAP state :) What a lovely idea!

Very little change to API surface but basically we avoir having huge structs on the stack everywhere.

Also pulls unrelated change for the state topic.

Tested on nucleo but i had to disable a lot of stuff so it will required testing again in the full robot.