### PR TITLE
UWB online positioning of 1 tag using N anchors

### DIFF
--- a/tools/studio/cvra_studio/commands/__init__.py
+++ b/tools/studio/cvra_studio/commands/__init__.py
@@ -4,5 +4,6 @@ __all__ = [
     'param_tree',
     'pid_plot',
     'plot2d',
+    'plot_uwb',
     'publish',
 ]

--- a/tools/studio/cvra_studio/commands/plot_uwb.py
+++ b/tools/studio/cvra_studio/commands/plot_uwb.py
@@ -1,0 +1,86 @@
+import logging
+import sys
+import threading
+import time
+import uavcan
+
+import numpy as np
+import pyqtgraph as pg
+from pyqtgraph.Qt import QtCore, QtGui
+
+from ..network.UavcanNode import UavcanNode
+from ..viewers.LivePlotter2D import LivePlotter2D
+
+
+def argparser(parser=None):
+    parser = parser or argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("interface", help="Serial port or SocketCAN interface")
+    parser.add_argument("--dsdl", "-d", help="DSDL path", required=True)
+    parser.add_argument("--node_id", "-n", help="UAVCAN Node ID", default=127)
+    parser.add_argument('--plot_frequency', '-f', help="Plot update rate", default=30)
+    parser.add_argument('--width', help="Plot width in meters", default=20)
+    parser.add_argument('--height', help="Plot height in meters", default=20)
+    parser.add_argument('--verbose', '-v', action='count', default=0)
+
+    return parser
+
+
+class Model:
+    def __init__(self, node, size):
+        self.node = node
+        self.size = size
+        self.node.add_handler(uavcan.thirdparty.cvra.uwb_beacon.TagPosition, self._callback)
+        self.data = {
+            'robot': { 'x': 0, 'y': 0, 'a': 0, 'r': 300, 'n': 6, 'fill': 'cvra' },
+            'x_cursor': { 'pts': [[0, 0], [0, self.size[1]]], 'fill': 'cvra' },
+            'y_cursor': { 'pts': [[0, 0], [self.size[0], 0]], 'fill': 'cvra' },
+        }
+
+    def _callback(self, event):
+        print(event)
+        x = 1000 * event.message.x
+        y = 1000 * event.message.y
+        self.data.update({
+            'robot': { 'x': x, 'y': y, 'a': 0, 'r': 300, 'n': 6, 'fill': 'cvra' },
+            'x_cursor': { 'pts': [[x, 0], [x, self.size[1]]], 'fill': 'cvra' },
+            'y_cursor': { 'pts': [[0, y], [self.size[0], y]], 'fill': 'cvra' },
+        })
+
+    def get_data(self):
+        return self.data
+
+
+class Controller:
+    def __init__(self, node, plot_frequency, size):
+        self.viewer = LivePlotter2D(size=size)
+        self.plot_frequency = plot_frequency
+        self.curve = self.viewer.getPort()
+        self.model = Model(node, size=size)
+        threading.Thread(target=self.run).start()
+        self.viewer.widget.show()
+
+    def run(self):
+        while True:
+            self.curve.put(self.model.get_data())
+            time.sleep(1.0 / self.plot_frequency)
+
+
+def main(args):
+    logging.basicConfig(level=max(logging.CRITICAL - (10 * args.verbose), 0))
+    app = QtGui.QApplication(sys.argv)
+
+    uavcan.load_dsdl(args.dsdl)
+    node = UavcanNode(interface=args.interface, node_id=args.node_id)
+
+    meter_to_mm = lambda x : x * 1000
+    plot_controller = Controller(node, args.plot_frequency, (meter_to_mm(args.width), meter_to_mm(args.height)))
+
+    node.spin()
+
+    if (sys.flags.interactive != 1) or not hasattr(QtCore, 'PYQT_VERSION'):
+        QtGui.QApplication.instance().exec_()
+
+
+if __name__ == "__main__":
+    args = argparser().parse_args()
+    main(args)

--- a/uwb-beacon-firmware/oocd.cfg
+++ b/uwb-beacon-firmware/oocd.cfg
@@ -8,5 +8,5 @@ transport select hla_swd
 source [find target/stm32f4x.cfg]
 
 #reset_config srst_only srst_nogate
-adapter_khz 1000
+adapter_khz 950
 

--- a/uwb-beacon-firmware/src/ahrs_thread.c
+++ b/uwb-beacon-firmware/src/ahrs_thread.c
@@ -1,11 +1,11 @@
 #include <math.h>
 #include <ch.h>
-#include <hal.h>
 
 #include "main.h"
 #include "MadgwickAHRS.h"
 #include "ahrs_thread.h"
 #include "imu_thread.h"
+#include "board.h"
 
 static struct {
     parameter_t beta;
@@ -88,7 +88,7 @@ void ahrs_calibrate_gyro(void)
 
     topic = messagebus_find_topic_blocking(&bus, "/imu");
 
-    palSetPad(GPIOC, GPIOC_LED_ERROR);
+    board_led_set(BOARD_LED_ERROR);
     for (int i = 0; i < N; i++) {
         imu_msg_t msg;
         messagebus_topic_wait(topic, &msg, sizeof(msg));
@@ -99,10 +99,10 @@ void ahrs_calibrate_gyro(void)
 
         // Blink the LED during calibration
         if (i % 50 == 0) {
-            palTogglePad(GPIOC, GPIOC_LED_ERROR);
+            board_led_toggle(BOARD_LED_ERROR);
         }
     }
-    palClearPad(GPIOC, GPIOC_LED_ERROR);
+    board_led_clear(BOARD_LED_ERROR);
 
     new_beta = sqrtf(3/4.f) * (x_avg + y_avg + z_avg) / 3.f;
 

--- a/uwb-beacon-firmware/src/ahrs_thread.c
+++ b/uwb-beacon-firmware/src/ahrs_thread.c
@@ -88,7 +88,7 @@ void ahrs_calibrate_gyro(void)
 
     topic = messagebus_find_topic_blocking(&bus, "/imu");
 
-    palSetPad(GPIOB, GPIOB_LED_ERROR);
+    palSetPad(GPIOC, GPIOC_LED_ERROR);
     for (int i = 0; i < N; i++) {
         imu_msg_t msg;
         messagebus_topic_wait(topic, &msg, sizeof(msg));
@@ -99,10 +99,10 @@ void ahrs_calibrate_gyro(void)
 
         // Blink the LED during calibration
         if (i % 50 == 0) {
-            palTogglePad(GPIOB, GPIOB_LED_ERROR);
+            palTogglePad(GPIOC, GPIOC_LED_ERROR);
         }
     }
-    palClearPad(GPIOB, GPIOB_LED_ERROR);
+    palClearPad(GPIOC, GPIOC_LED_ERROR);
 
     new_beta = sqrtf(3/4.f) * (x_avg + y_avg + z_avg) / 3.f;
 

--- a/uwb-beacon-firmware/src/board.c
+++ b/uwb-beacon-firmware/src/board.c
@@ -78,3 +78,19 @@ void __early_init(void) {
  */
 void boardInit(void) {
 }
+
+static stm32_gpio_t* ports[] = { GPIOC, GPIOB, GPIOB };
+static size_t leds[] = { GPIOC_LED_ERROR, GPIOB_LED_DEBUG, GPIOB_LED_STATUS };
+
+void board_led_set(board_led_t led)
+{
+  palSetPad(ports[led], leds[led]);
+}
+void board_led_clear(board_led_t led)
+{
+  palClearPad(ports[led], leds[led]);
+}
+void board_led_toggle(board_led_t led)
+{
+  palTogglePad(ports[led], leds[led]);
+}

--- a/uwb-beacon-firmware/src/board.h
+++ b/uwb-beacon-firmware/src/board.h
@@ -43,7 +43,7 @@
 #define GPIOA_UWB_MISO              6U
 #define GPIOA_UWB_MOSI              7U
 #define GPIOA_UWB_INT               8U
-#define GPIOA_UWB_RST_N             9U
+#define GPIOA_PIN9                  9U
 #define GPIOA_PIN10                 10U
 #define GPIOA_OTG_FS_DM             11U
 #define GPIOA_OTG_FS_DP             12U
@@ -51,9 +51,9 @@
 #define GPIOA_SWCLK                 14U
 #define GPIOA_PIN15                 15U
 
-#define GPIOB_LED_ERROR             0U
-#define GPIOB_LED_DEBUG             1U
-#define GPIOB_LED_STATUS            2U
+#define GPIOB_LED_DEBUG             0U
+#define GPIOB_LED_STATUS            1U
+#define GPIOB_BOOT1                 2U
 #define GPIOB_SWO                   3U
 #define GPIOB_PIN4                  4U
 #define GPIOB_PIN5                  5U
@@ -73,11 +73,11 @@
 #define GPIOC_PIN2                  2U
 #define GPIOC_PIN3                  3U
 #define GPIOC_PIN4                  4U
-#define GPIOC_PIN5                  5U
+#define GPIOC_LED_ERROR             5U
 #define GPIOC_PIN6                  6U
 #define GPIOC_PIN7                  7U
 #define GPIOC_PIN8                  8U
-#define GPIOC_PIN9                  9U
+#define GPIOC_UWB_RST_N             9U
 #define GPIOC_PIN10                 10U
 #define GPIOC_PIN11                 11U
 #define GPIOC_PIN12                 12U
@@ -124,7 +124,7 @@
  * GPIOA_UWB_MISO                   (alternate 5).
  * GPIOA_UWB_MOSI                   (alternate 5).
  * GPIOA_UWB_INT                    (input floating).
- * GPIOA_UWB_RST_N                  (input floating).
+ * GPIOA_PIN9                       (input floating).
  * GPIOA_PIN10                      (input floating).
  * GPIOA_OTG_FS_DM                  (alternate 10).
  * GPIOA_OTG_FS_DP                  (alternate 10).
@@ -141,7 +141,7 @@
                                      PIN_MODE_ALTERNATE(GPIOA_UWB_MISO) | \
                                      PIN_MODE_ALTERNATE(GPIOA_UWB_MOSI) | \
                                      PIN_MODE_INPUT(GPIOA_UWB_INT) | \
-                                     PIN_MODE_INPUT(GPIOA_UWB_RST_N) | \
+                                     PIN_MODE_INPUT(GPIOA_PIN9) | \
                                      PIN_MODE_INPUT(GPIOA_PIN10) | \
                                      PIN_MODE_ALTERNATE(GPIOA_OTG_FS_DM) | \
                                      PIN_MODE_ALTERNATE(GPIOA_OTG_FS_DP) | \
@@ -157,7 +157,7 @@
                                      PIN_OTYPE_PUSHPULL(GPIOA_UWB_MISO) | \
                                      PIN_OTYPE_PUSHPULL(GPIOA_UWB_MOSI) | \
                                      PIN_OTYPE_PUSHPULL(GPIOA_UWB_INT) | \
-                                     PIN_OTYPE_OPENDRAIN(GPIOA_UWB_RST_N) | \
+                                     PIN_OTYPE_PUSHPULL(GPIOA_PIN9) | \
                                      PIN_OTYPE_PUSHPULL(GPIOA_PIN10) | \
                                      PIN_OTYPE_PUSHPULL(GPIOA_OTG_FS_DM) | \
                                      PIN_OTYPE_PUSHPULL(GPIOA_OTG_FS_DP) | \
@@ -173,7 +173,7 @@
                                      PIN_OSPEED_100M(GPIOA_UWB_MISO) | \
                                      PIN_OSPEED_100M(GPIOA_UWB_MOSI) | \
                                      PIN_OSPEED_100M(GPIOA_UWB_INT) | \
-                                     PIN_OSPEED_100M(GPIOA_UWB_RST_N) | \
+                                     PIN_OSPEED_100M(GPIOA_PIN9) | \
                                      PIN_OSPEED_100M(GPIOA_PIN10) | \
                                      PIN_OSPEED_100M(GPIOA_OTG_FS_DM) | \
                                      PIN_OSPEED_100M(GPIOA_OTG_FS_DP) | \
@@ -189,7 +189,7 @@
                                      PIN_PUPDR_FLOATING(GPIOA_UWB_MISO) | \
                                      PIN_PUPDR_FLOATING(GPIOA_UWB_MOSI) | \
                                      PIN_PUPDR_FLOATING(GPIOA_UWB_INT) | \
-                                     PIN_PUPDR_FLOATING(GPIOA_UWB_RST_N) | \
+                                     PIN_PUPDR_FLOATING(GPIOA_PIN9) | \
                                      PIN_PUPDR_FLOATING(GPIOA_PIN10) | \
                                      PIN_PUPDR_FLOATING(GPIOA_OTG_FS_DM) | \
                                      PIN_PUPDR_FLOATING(GPIOA_OTG_FS_DP) | \
@@ -205,7 +205,7 @@
                                      PIN_ODR_HIGH(GPIOA_UWB_MISO) | \
                                      PIN_ODR_HIGH(GPIOA_UWB_MOSI) | \
                                      PIN_ODR_HIGH(GPIOA_UWB_INT) | \
-                                     PIN_ODR_HIGH(GPIOA_UWB_RST_N) | \
+                                     PIN_ODR_HIGH(GPIOA_PIN9) | \
                                      PIN_ODR_HIGH(GPIOA_PIN10) | \
                                      PIN_ODR_HIGH(GPIOA_OTG_FS_DM) | \
                                      PIN_ODR_HIGH(GPIOA_OTG_FS_DP) | \
@@ -221,7 +221,7 @@
                                      PIN_AFIO_AF(GPIOA_UWB_MISO, 5) | \
                                      PIN_AFIO_AF(GPIOA_UWB_MOSI, 5))
 #define VAL_GPIOA_AFRH              (PIN_AFIO_AF(GPIOA_UWB_INT, 0) | \
-                                     PIN_AFIO_AF(GPIOA_UWB_RST_N, 0) | \
+                                     PIN_AFIO_AF(GPIOA_PIN9, 0) | \
                                      PIN_AFIO_AF(GPIOA_PIN10, 0) | \
                                      PIN_AFIO_AF(GPIOA_OTG_FS_DM, 10) | \
                                      PIN_AFIO_AF(GPIOA_OTG_FS_DP, 10) | \
@@ -232,9 +232,9 @@
 /*
  * GPIOB setup:
  *
- * GPIOB_LED_ERROR                  (output).
  * GPIOB_LED_DEBUG                  (output).
  * GPIOB_LED_STATUS                 (output).
+ * GPIOB_BOOT1                      (input).
  * GPIOB_SWO                        (alternate 0).
  * GPIOB_PIN4                       (input floating).
  * GPIOB_PIN5                       (input floating).
@@ -249,9 +249,9 @@
  * GPIOB_IMU_MISO                   (alternate 5).
  * GPIOB_IMU_MOSI                   (alternate 5).
  */
-#define VAL_GPIOB_MODER             (PIN_MODE_OUTPUT(GPIOB_LED_ERROR) | \
-                                     PIN_MODE_OUTPUT(GPIOB_LED_DEBUG) | \
+#define VAL_GPIOB_MODER             (PIN_MODE_OUTPUT(GPIOB_LED_DEBUG) | \
                                      PIN_MODE_OUTPUT(GPIOB_LED_STATUS) | \
+                                     PIN_MODE_INPUT(GPIOB_BOOT1) | \
                                      PIN_MODE_ALTERNATE(GPIOB_SWO) | \
                                      PIN_MODE_INPUT(GPIOB_PIN4) | \
                                      PIN_MODE_INPUT(GPIOB_PIN5) | \
@@ -265,9 +265,9 @@
                                      PIN_MODE_ALTERNATE(GPIOB_IMU_SCK) | \
                                      PIN_MODE_ALTERNATE(GPIOB_IMU_MISO) | \
                                      PIN_MODE_ALTERNATE(GPIOB_IMU_MOSI))
-#define VAL_GPIOB_OTYPER            (PIN_OTYPE_PUSHPULL(GPIOB_LED_ERROR) | \
-                                     PIN_OTYPE_PUSHPULL(GPIOB_LED_DEBUG) | \
+#define VAL_GPIOB_OTYPER            (PIN_OTYPE_PUSHPULL(GPIOB_LED_DEBUG) | \
                                      PIN_OTYPE_PUSHPULL(GPIOB_LED_STATUS) | \
+                                     PIN_OTYPE_PUSHPULL(GPIOB_BOOT1) | \
                                      PIN_OTYPE_PUSHPULL(GPIOB_SWO) | \
                                      PIN_OTYPE_PUSHPULL(GPIOB_PIN4) | \
                                      PIN_OTYPE_PUSHPULL(GPIOB_PIN5) | \
@@ -281,9 +281,9 @@
                                      PIN_OTYPE_PUSHPULL(GPIOB_IMU_SCK) | \
                                      PIN_OTYPE_PUSHPULL(GPIOB_IMU_MISO) | \
                                      PIN_OTYPE_PUSHPULL(GPIOB_IMU_MOSI))
-#define VAL_GPIOB_OSPEEDR           (PIN_OSPEED_100M(GPIOB_LED_ERROR) | \
-                                     PIN_OSPEED_100M(GPIOB_LED_DEBUG) | \
+#define VAL_GPIOB_OSPEEDR           (PIN_OSPEED_100M(GPIOB_LED_DEBUG) | \
                                      PIN_OSPEED_100M(GPIOB_LED_STATUS) | \
+                                     PIN_OSPEED_100M(GPIOB_BOOT1) | \
                                      PIN_OSPEED_100M(GPIOB_SWO) | \
                                      PIN_OSPEED_100M(GPIOB_PIN4) | \
                                      PIN_OSPEED_100M(GPIOB_PIN5) | \
@@ -297,9 +297,9 @@
                                      PIN_OSPEED_100M(GPIOB_IMU_SCK) | \
                                      PIN_OSPEED_100M(GPIOB_IMU_MISO) | \
                                      PIN_OSPEED_100M(GPIOB_IMU_MOSI))
-#define VAL_GPIOB_PUPDR             (PIN_PUPDR_FLOATING(GPIOB_LED_ERROR) | \
-                                     PIN_PUPDR_FLOATING(GPIOB_LED_DEBUG) | \
+#define VAL_GPIOB_PUPDR             (PIN_PUPDR_FLOATING(GPIOB_LED_DEBUG) | \
                                      PIN_PUPDR_FLOATING(GPIOB_LED_STATUS) | \
+                                     PIN_PUPDR_FLOATING(GPIOB_BOOT1) | \
                                      PIN_PUPDR_FLOATING(GPIOB_SWO) | \
                                      PIN_PUPDR_FLOATING(GPIOB_PIN4) | \
                                      PIN_PUPDR_FLOATING(GPIOB_PIN5) | \
@@ -313,9 +313,9 @@
                                      PIN_PUPDR_FLOATING(GPIOB_IMU_SCK) | \
                                      PIN_PUPDR_FLOATING(GPIOB_IMU_MISO) | \
                                      PIN_PUPDR_FLOATING(GPIOB_IMU_MOSI))
-#define VAL_GPIOB_ODR               (PIN_ODR_LOW(GPIOB_LED_ERROR) | \
-                                     PIN_ODR_LOW(GPIOB_LED_DEBUG) | \
+#define VAL_GPIOB_ODR               (PIN_ODR_LOW(GPIOB_LED_DEBUG) | \
                                      PIN_ODR_LOW(GPIOB_LED_STATUS) | \
+                                     PIN_ODR_HIGH(GPIOB_BOOT1) | \
                                      PIN_ODR_HIGH(GPIOB_SWO) | \
                                      PIN_ODR_HIGH(GPIOB_PIN4) | \
                                      PIN_ODR_HIGH(GPIOB_PIN5) | \
@@ -329,9 +329,9 @@
                                      PIN_ODR_HIGH(GPIOB_IMU_SCK) | \
                                      PIN_ODR_HIGH(GPIOB_IMU_MISO) | \
                                      PIN_ODR_HIGH(GPIOB_IMU_MOSI))
-#define VAL_GPIOB_AFRL              (PIN_AFIO_AF(GPIOB_LED_ERROR, 0) | \
-                                     PIN_AFIO_AF(GPIOB_LED_DEBUG, 0) | \
+#define VAL_GPIOB_AFRL              (PIN_AFIO_AF(GPIOB_LED_DEBUG, 0) | \
                                      PIN_AFIO_AF(GPIOB_LED_STATUS, 0) | \
+                                     PIN_AFIO_AF(GPIOB_BOOT1, 0) | \
                                      PIN_AFIO_AF(GPIOB_SWO, 0) | \
                                      PIN_AFIO_AF(GPIOB_PIN4, 0) | \
                                      PIN_AFIO_AF(GPIOB_PIN5, 0) | \
@@ -354,11 +354,11 @@
  * GPIOC_PIN2                       (input floating).
  * GPIOC_PIN3                       (input floating).
  * GPIOC_PIN4                       (input floating).
- * GPIOC_PIN5                       (input floating).
+ * GPIOC_LED_ERROR                  (output floating).
  * GPIOC_PIN6                       (input floating).
  * GPIOC_PIN7                       (input floating).
  * GPIOC_PIN8                       (input floating).
- * GPIOC_PIN9                       (input floating).
+ * GPIOC_UWB_RST_N                  (output floating).
  * GPIOC_PIN10                      (input floating).
  * GPIOC_PIN11                      (input floating).
  * GPIOC_PIN12                      (input floating).
@@ -371,11 +371,11 @@
                                      PIN_MODE_INPUT(GPIOC_PIN2) | \
                                      PIN_MODE_INPUT(GPIOC_PIN3) | \
                                      PIN_MODE_INPUT(GPIOC_PIN4) | \
-                                     PIN_MODE_INPUT(GPIOC_PIN5) | \
+                                     PIN_MODE_OUTPUT(GPIOC_LED_ERROR) | \
                                      PIN_MODE_INPUT(GPIOC_PIN6) | \
                                      PIN_MODE_INPUT(GPIOC_PIN7) | \
                                      PIN_MODE_INPUT(GPIOC_PIN8) | \
-                                     PIN_MODE_INPUT(GPIOC_PIN9) | \
+                                     PIN_MODE_OUTPUT(GPIOC_UWB_RST_N) | \
                                      PIN_MODE_INPUT(GPIOC_PIN10) | \
                                      PIN_MODE_INPUT(GPIOC_PIN11) | \
                                      PIN_MODE_INPUT(GPIOC_PIN12) | \
@@ -387,11 +387,11 @@
                                      PIN_OTYPE_PUSHPULL(GPIOC_PIN2) | \
                                      PIN_OTYPE_PUSHPULL(GPIOC_PIN3) | \
                                      PIN_OTYPE_PUSHPULL(GPIOC_PIN4) | \
-                                     PIN_OTYPE_PUSHPULL(GPIOC_PIN5) | \
+                                     PIN_OTYPE_PUSHPULL(GPIOC_LED_ERROR) | \
                                      PIN_OTYPE_PUSHPULL(GPIOC_PIN6) | \
                                      PIN_OTYPE_PUSHPULL(GPIOC_PIN7) | \
                                      PIN_OTYPE_PUSHPULL(GPIOC_PIN8) | \
-                                     PIN_OTYPE_PUSHPULL(GPIOC_PIN9) | \
+                                     PIN_OTYPE_PUSHPULL(GPIOC_UWB_RST_N) | \
                                      PIN_OTYPE_PUSHPULL(GPIOC_PIN10) | \
                                      PIN_OTYPE_PUSHPULL(GPIOC_PIN11) | \
                                      PIN_OTYPE_PUSHPULL(GPIOC_PIN12) | \
@@ -403,11 +403,11 @@
                                      PIN_OSPEED_100M(GPIOC_PIN2) | \
                                      PIN_OSPEED_100M(GPIOC_PIN3) | \
                                      PIN_OSPEED_100M(GPIOC_PIN4) | \
-                                     PIN_OSPEED_100M(GPIOC_PIN5) | \
+                                     PIN_OSPEED_100M(GPIOC_LED_ERROR) | \
                                      PIN_OSPEED_100M(GPIOC_PIN6) | \
                                      PIN_OSPEED_100M(GPIOC_PIN7) | \
                                      PIN_OSPEED_100M(GPIOC_PIN8) | \
-                                     PIN_OSPEED_100M(GPIOC_PIN9) | \
+                                     PIN_OSPEED_100M(GPIOC_UWB_RST_N) | \
                                      PIN_OSPEED_100M(GPIOC_PIN10) | \
                                      PIN_OSPEED_100M(GPIOC_PIN11) | \
                                      PIN_OSPEED_100M(GPIOC_PIN12) | \
@@ -419,11 +419,11 @@
                                      PIN_PUPDR_FLOATING(GPIOC_PIN2) | \
                                      PIN_PUPDR_FLOATING(GPIOC_PIN3) | \
                                      PIN_PUPDR_FLOATING(GPIOC_PIN4) | \
-                                     PIN_PUPDR_FLOATING(GPIOC_PIN5) | \
+                                     PIN_PUPDR_FLOATING(GPIOC_LED_ERROR) | \
                                      PIN_PUPDR_FLOATING(GPIOC_PIN6) | \
                                      PIN_PUPDR_FLOATING(GPIOC_PIN7) | \
                                      PIN_PUPDR_FLOATING(GPIOC_PIN8) | \
-                                     PIN_PUPDR_FLOATING(GPIOC_PIN9) | \
+                                     PIN_PUPDR_FLOATING(GPIOC_UWB_RST_N) | \
                                      PIN_PUPDR_FLOATING(GPIOC_PIN10) | \
                                      PIN_PUPDR_FLOATING(GPIOC_PIN11) | \
                                      PIN_PUPDR_FLOATING(GPIOC_PIN12) | \
@@ -435,11 +435,11 @@
                                      PIN_ODR_HIGH(GPIOC_PIN2) | \
                                      PIN_ODR_HIGH(GPIOC_PIN3) | \
                                      PIN_ODR_HIGH(GPIOC_PIN4) | \
-                                     PIN_ODR_HIGH(GPIOC_PIN5) | \
+                                     PIN_ODR_LOW(GPIOC_LED_ERROR) | \
                                      PIN_ODR_HIGH(GPIOC_PIN6) | \
                                      PIN_ODR_HIGH(GPIOC_PIN7) | \
                                      PIN_ODR_HIGH(GPIOC_PIN8) | \
-                                     PIN_ODR_HIGH(GPIOC_PIN9) | \
+                                     PIN_ODR_HIGH(GPIOC_UWB_RST_N) | \
                                      PIN_ODR_HIGH(GPIOC_PIN10) | \
                                      PIN_ODR_HIGH(GPIOC_PIN11) | \
                                      PIN_ODR_HIGH(GPIOC_PIN12) | \
@@ -451,11 +451,11 @@
                                      PIN_AFIO_AF(GPIOC_PIN2, 0) | \
                                      PIN_AFIO_AF(GPIOC_PIN3, 0) | \
                                      PIN_AFIO_AF(GPIOC_PIN4, 0) | \
-                                     PIN_AFIO_AF(GPIOC_PIN5, 0) | \
+                                     PIN_AFIO_AF(GPIOC_LED_ERROR, 0) | \
                                      PIN_AFIO_AF(GPIOC_PIN6, 0) | \
                                      PIN_AFIO_AF(GPIOC_PIN7, 0))
 #define VAL_GPIOC_AFRH              (PIN_AFIO_AF(GPIOC_PIN8, 0) | \
-                                     PIN_AFIO_AF(GPIOC_PIN9, 0) | \
+                                     PIN_AFIO_AF(GPIOC_UWB_RST_N, 0) | \
                                      PIN_AFIO_AF(GPIOC_PIN10, 0) | \
                                      PIN_AFIO_AF(GPIOC_PIN11, 0) | \
                                      PIN_AFIO_AF(GPIOC_PIN12, 0) | \

--- a/uwb-beacon-firmware/src/board.h
+++ b/uwb-beacon-firmware/src/board.h
@@ -546,6 +546,16 @@
 extern "C" {
 #endif
   void boardInit(void);
+
+  typedef enum {
+      BOARD_LED_ERROR = 0,
+      BOARD_LED_DEBUG,
+      BOARD_LED_STATUS,
+  } board_led_t;
+
+  void board_led_set(board_led_t led);
+  void board_led_clear(board_led_t led);
+  void board_led_toggle(board_led_t led);
 #ifdef __cplusplus
 }
 #endif

--- a/uwb-beacon-firmware/src/cmd.c
+++ b/uwb-beacon-firmware/src/cmd.c
@@ -233,12 +233,12 @@ static void cmd_state(BaseSequentialStream *chp, int argc, char **argv)
     if (argc > 0 && !strcmp("loop", argv[0])) {
         while (true) {
             messagebus_topic_read(topic, &msg, sizeof(msg));
-            chprintf(chp, "\rmu: (x=%.3f; y=%.3f)", msg.x, msg.y);
+            chprintf(chp, "\rmu: (x=%.3f; y=%.3f; z=%.3f)", msg.x, msg.y, msg.z);
             chThdSleepMilliseconds(500);
         }
     } else {
-        chprintf(chp, "mu: (x=%.3f; y=%.3f)\r\nSigma: (x=%f; y=%f)\r\n",
-                msg.x, msg.y, msg.variance_x, msg.variance_y);
+        chprintf(chp, "mu: (x=%.3f; y=%.3f; z=%.3f)\r\nVariance: (x=%f; y=%f; z=%f)\r\n",
+                msg.x, msg.y, msg.z, msg.variance_x, msg.variance_y, msg.variance_z);
     }
 }
 

--- a/uwb-beacon-firmware/src/cmd.c
+++ b/uwb-beacon-firmware/src/cmd.c
@@ -169,9 +169,9 @@ static void cmd_range(BaseSequentialStream *chp, int argc, char **argv)
     }
 
     messagebus_topic_read(topic, &msg, sizeof(msg));
-    chprintf(chp, "got a ToF to anchor 0x%x : %.3f\r\n", msg.anchor_addr, msg.range);
+    chprintf(chp, "got a ToF to anchor 0x%x: %.3f at timestamp %d\r\n", msg.anchor_addr, msg.range, msg.timestamp);
     messagebus_topic_wait(topic, &msg, sizeof(msg));
-    chprintf(chp, "got a ToF to anchor 0x%x : %.3f\r\n", msg.anchor_addr, msg.range);
+    chprintf(chp, "got a ToF to anchor 0x%x: %.3f at timestamp %d\r\n", msg.anchor_addr, msg.range, msg.timestamp);
 }
 
 static void cmd_anchors(BaseSequentialStream *chp, int argc, char **argv)

--- a/uwb-beacon-firmware/src/cmd.c
+++ b/uwb-beacon-firmware/src/cmd.c
@@ -170,6 +170,8 @@ static void cmd_range(BaseSequentialStream *chp, int argc, char **argv)
 
     messagebus_topic_read(topic, &msg, sizeof(msg));
     chprintf(chp, "got a ToF to anchor 0x%x : %.3f\r\n", msg.anchor_addr, msg.range);
+    messagebus_topic_wait(topic, &msg, sizeof(msg));
+    chprintf(chp, "got a ToF to anchor 0x%x : %.3f\r\n", msg.anchor_addr, msg.range);
 }
 
 static void cmd_anchors(BaseSequentialStream *chp, int argc, char **argv)

--- a/uwb-beacon-firmware/src/cmd.c
+++ b/uwb-beacon-firmware/src/cmd.c
@@ -168,7 +168,7 @@ static void cmd_range(BaseSequentialStream *chp, int argc, char **argv)
         return;
     }
 
-    messagebus_topic_wait(topic, &msg, sizeof(msg));
+    messagebus_topic_read(topic, &msg, sizeof(msg));
     chprintf(chp, "got a ToF to anchor 0x%x : %.3f\r\n", msg.anchor_addr, msg.range);
 }
 

--- a/uwb-beacon-firmware/src/cmd.c
+++ b/uwb-beacon-firmware/src/cmd.c
@@ -237,7 +237,8 @@ static void cmd_state(BaseSequentialStream *chp, int argc, char **argv)
             chThdSleepMilliseconds(500);
         }
     } else {
-        chprintf(chp, "mu: (x=%.3f; y=%.3f)\r\n", msg.x, msg.y);
+        chprintf(chp, "mu: (x=%.3f; y=%.3f)\r\nSigma: (x=%f; y=%f)\r\n",
+                msg.x, msg.y, msg.variance_x, msg.variance_y);
     }
 }
 

--- a/uwb-beacon-firmware/src/decadriver/deca_device.c
+++ b/uwb-beacon-firmware/src/decadriver/deca_device.c
@@ -2399,8 +2399,8 @@ void dwt_setleds(uint8 mode)
     {
         // Set up MFIO for LED output.
         reg = dwt_read32bitoffsetreg(GPIO_CTRL_ID, GPIO_MODE_OFFSET);
-        reg &= ~(GPIO_MSGP2_MASK | GPIO_MSGP3_MASK);
-        reg |= (GPIO_PIN2_RXLED | GPIO_PIN3_TXLED);
+        reg &= ~(GPIO_MSGP0_MASK | GPIO_MSGP1_MASK  | GPIO_MSGP2_MASK | GPIO_MSGP3_MASK);
+        reg |= (GPIO_PIN0_RXOKLED | GPIO_PIN1_SFDLED | GPIO_PIN2_RXLED | GPIO_PIN3_TXLED);
         dwt_write32bitoffsetreg(GPIO_CTRL_ID, GPIO_MODE_OFFSET, reg);
 
         // Enable LP Oscillator to run from counter and turn on de-bounce clock.

--- a/uwb-beacon-firmware/src/decadriver/deca_regs.h
+++ b/uwb-beacon-firmware/src/decadriver/deca_regs.h
@@ -682,6 +682,8 @@ extern "C" {
 #define GPIO_MSGP7_MASK         0x00300000UL    /* Mode Selection for SYNC/GPIO7 */
 #define GPIO_MSGP8_MASK         0x00C00000UL    /* Mode Selection for IRQ/GPIO8 */
 
+#define GPIO_PIN0_RXOKLED       0x00000040UL    /* The pin operates as the RXOKLED output */
+#define GPIO_PIN1_SFDLED        0x00000100UL    /* The pin operates as the SFDLED output */
 #define GPIO_PIN2_RXLED         0x00000400UL    /* The pin operates as the RXLED output */
 #define GPIO_PIN3_TXLED         0x00001000UL    /* The pin operates as the TXLED output */
 #define GPIO_PIN4_EXTPA         0x00004000UL    /* The pin operates as the EXTPA output */

--- a/uwb-beacon-firmware/src/decawave_interface.c
+++ b/uwb-beacon-firmware/src/decawave_interface.c
@@ -105,7 +105,7 @@ void decawave_start(void)
 
     /* Enable DWM1000 LEDs */
     dwt_setlnapamode(1, 1);
-    dwt_setleds(DWT_LEDS_ENABLE);
+    dwt_setleds(DWT_LEDS_ENABLE | DWT_LEDS_INIT_BLINK);
 
     /* Configuration example taken straight from decawave's example. */
     /* TODO: Make it a bit more easy to configure */
@@ -114,13 +114,21 @@ void decawave_start(void)
         DWT_PRF_64M,     /* Pulse repetition frequency. */
         DWT_PLEN_64,     /* Preamble length. Used in TX only. */
         DWT_PAC8,        /* Preamble acquisition chunk size. Used in RX only. */
-        5, 5,            /* Preamble codes (RX, TX) */
+        9, 9,            /* Preamble codes (RX, TX) */
         1,               /* Non standard Start Frame Delimiter */
         DWT_BR_6M8,      /* Data rate. */
         DWT_PHRMODE_EXT, /* PHY header mode. */
         /* SFD timeout (preamble length + 1 + SFD length - PAC size). Used in RX only. */
-        (1025 + 64 - 32) // TODO too long
+        (64 + 64 - 8)
     };
 
     dwt_configure(&config);
+
+    static dwt_txconfig_t txconfig = {
+        0xC0,       /* Pulse generator delay value */
+        0x25456585, /* TX power, Channel 5 and 64Mhz smart power enabled */
+    };
+
+    dwt_configuretxrf(&txconfig);
+    dwt_setsmarttxpower(1);
 }

--- a/uwb-beacon-firmware/src/main.c
+++ b/uwb-beacon-firmware/src/main.c
@@ -74,7 +74,7 @@ static void blink_thd(void *p)
     (void) p;
 
     while (1) {
-        palTogglePad(GPIOB, GPIOB_LED_STATUS);
+        board_led_toggle(BOARD_LED_STATUS);
         chThdSleepMilliseconds(200);
     }
 }

--- a/uwb-beacon-firmware/src/ranging_thread.c
+++ b/uwb-beacon-firmware/src/ranging_thread.c
@@ -106,7 +106,7 @@ static void ranging_thread(void *p)
     static uint8_t frame[64];
 
     int current_anchor_mac_index = 0;
-    uint16_t anchor_macs[] = {7, 11, 14};
+    uint16_t anchor_macs[] = {7, 10, 11, 14};
     int nb_anchor_macs = sizeof(anchor_macs) / sizeof(anchor_macs[0]);
 
     while (1) {

--- a/uwb-beacon-firmware/src/ranging_thread.c
+++ b/uwb-beacon-firmware/src/ranging_thread.c
@@ -79,6 +79,8 @@ static void anchor_position_timer_cb(void *t);
 static void tag_position_timer_cb(void *t);
 static void frame_tx_done_cb(const dwt_cb_data_t *data);
 static void frame_rx_cb(const dwt_cb_data_t *data);
+static void frame_rx_timeout_cb(const dwt_cb_data_t *data);
+static void frame_rx_error_cb(const dwt_cb_data_t *data);
 
 void ranging_start(void)
 {
@@ -163,6 +165,22 @@ static void frame_rx_cb(const dwt_cb_data_t *data)
     dwt_rxenable(DWT_START_RX_IMMEDIATE);
 }
 
+static void frame_rx_timeout_cb(const dwt_cb_data_t *data)
+{
+    (void) data;
+
+    palTogglePad(GPIOB, GPIOB_LED_DEBUG);
+    dwt_rxenable(DWT_START_RX_IMMEDIATE);
+}
+
+static void frame_rx_error_cb(const dwt_cb_data_t *data)
+{
+    (void) data;
+
+    palTogglePad(GPIOB, GPIOB_LED_DEBUG);
+    dwt_rxenable(DWT_START_RX_IMMEDIATE);
+}
+
 static void anchor_position_received_cb(uint16_t addr, float x, float y, float z)
 {
     anchor_position_msg_t msg;
@@ -203,8 +221,6 @@ static void ranging_found_cb(uint16_t addr, uint64_t time)
     msg.timestamp = ts;
     msg.anchor_addr = addr;
     msg.range = time * SPEED_OF_LIGHT;
-
-    palTogglePad(GPIOB, GPIOB_LED_DEBUG);
 
     messagebus_topic_publish(&ranging_topic, &msg, sizeof(msg));
 }
@@ -305,8 +321,10 @@ static void hardware_init(void)
 {
     decawave_start();
 
-    dwt_setinterrupt(DWT_INT_RFCG | DWT_INT_TFRS, true);
-    dwt_setcallbacks(frame_tx_done_cb, frame_rx_cb, NULL, NULL);
+    dwt_setinterrupt(DWT_INT_RFCG | DWT_INT_TFRS |
+                     DWT_INT_RPHE | DWT_INT_SFDT | DWT_INT_RFSL | DWT_INT_RFCE | DWT_INT_ARFE |
+                     DWT_INT_RFTO | DWT_INT_RXPTO, true);
+    dwt_setcallbacks(frame_tx_done_cb, frame_rx_cb, frame_rx_timeout_cb, frame_rx_error_cb);
 
     dwt_setrxantennadelay(parameter_integer_get(&uwb_params.antenna_delay));
 

--- a/uwb-beacon-firmware/src/ranging_thread.c
+++ b/uwb-beacon-firmware/src/ranging_thread.c
@@ -1,5 +1,4 @@
 #include <ch.h>
-#include <hal.h>
 
 #include "decadriver/deca_device_api.h"
 #include "decadriver/deca_regs.h"
@@ -124,7 +123,7 @@ static void ranging_thread(void *p)
 
         if (flags & EVENT_ADVERTISE_TIMER) {
             if (!handler.is_anchor && nb_anchor_macs > 0) {
-                palTogglePad(GPIOB, GPIOB_LED_STATUS);
+                board_led_toggle(BOARD_LED_STATUS);
                 /* First disable transceiver */
                 dwt_forcetrxoff();
 
@@ -189,7 +188,7 @@ static void frame_rx_timeout_cb(const dwt_cb_data_t *data)
 {
     (void) data;
 
-    palTogglePad(GPIOB, GPIOB_LED_DEBUG);
+    board_led_toggle(BOARD_LED_DEBUG);
     dwt_rxenable(DWT_START_RX_IMMEDIATE);
 }
 
@@ -197,7 +196,7 @@ static void frame_rx_error_cb(const dwt_cb_data_t *data)
 {
     (void) data;
 
-    palTogglePad(GPIOB, GPIOB_LED_DEBUG);
+    board_led_toggle(BOARD_LED_DEBUG);
     dwt_rxenable(DWT_START_RX_IMMEDIATE);
 }
 

--- a/uwb-beacon-firmware/src/ranging_thread.c
+++ b/uwb-beacon-firmware/src/ranging_thread.c
@@ -194,7 +194,7 @@ static void frame_rx_cb(const dwt_cb_data_t *data)
     uwb_process_incoming_frame(&handler, frame, data->datalength, rx_ts);
 
     dwt_rxenable(DWT_START_RX_IMMEDIATE);
-    palTogglePad(GPIOB, GPIOB_LED_ERROR);
+    palTogglePad(GPIOC, GPIOC_LED_ERROR);
 }
 
 static void anchor_position_received_cb(uint16_t addr, float x, float y, float z)

--- a/uwb-beacon-firmware/src/ranging_thread.c
+++ b/uwb-beacon-firmware/src/ranging_thread.c
@@ -105,7 +105,7 @@ static void ranging_thread(void *p)
 
     int current_anchor_mac_index = 0;
     uint16_t anchor_macs[] = {7, 14};
-    int nb_anchor_macs = sizeof(anchor_macs);
+    int nb_anchor_macs = sizeof(anchor_macs) / sizeof(anchor_macs[0]);
 
     while (1) {
         /* Wait for an interrupt coming from the UWB module. */
@@ -121,8 +121,8 @@ static void ranging_thread(void *p)
         }
 
         if (flags & EVENT_ADVERTISE_TIMER) {
-            palTogglePad(GPIOB, GPIOB_LED_STATUS);
             if (!handler.is_anchor && nb_anchor_macs > 0) {
+                palTogglePad(GPIOB, GPIOB_LED_STATUS);
                 /* First disable transceiver */
                 dwt_forcetrxoff();
 

--- a/uwb-beacon-firmware/src/ranging_thread.c
+++ b/uwb-beacon-firmware/src/ranging_thread.c
@@ -15,8 +15,8 @@
 /** Speed of light in Decawave units */
 #define SPEED_OF_LIGHT                   (299792458.0 / (128 * 499.2e6))
 
-/* Antenna delay for the our UWB board. */
-#define RX_ANT_DLY                       32840
+/* Antenna delay for our UWB board. */
+#define RX_ANT_DLY                       32915
 
 #define EVENT_UWB_INT                    (1 << 0)
 #define EVENT_ADVERTISE_TIMER            (1 << 1)

--- a/uwb-beacon-firmware/src/ranging_thread.c
+++ b/uwb-beacon-firmware/src/ranging_thread.c
@@ -151,7 +151,6 @@ static void frame_rx_cb(const dwt_cb_data_t *data)
     uwb_process_incoming_frame(&handler, frame, data->datalength, rx_ts);
 
     dwt_rxenable(DWT_START_RX_IMMEDIATE);
-    palTogglePad(GPIOC, GPIOC_LED_ERROR);
 }
 
 static void anchor_position_received_cb(uint16_t addr, float x, float y, float z)

--- a/uwb-beacon-firmware/src/ranging_thread.c
+++ b/uwb-beacon-firmware/src/ranging_thread.c
@@ -106,7 +106,7 @@ static void ranging_thread(void *p)
     static uint8_t frame[64];
 
     int current_anchor_mac_index = 0;
-    uint16_t anchor_macs[] = {7, 14};
+    uint16_t anchor_macs[] = {7, 11, 14};
     int nb_anchor_macs = sizeof(anchor_macs) / sizeof(anchor_macs[0]);
 
     while (1) {
@@ -137,6 +137,26 @@ static void ranging_thread(void *p)
                 }
             }
         }
+
+        if (flags & EVENT_ANCHOR_POSITION_TIMER) {
+            /* Make sure we are an anchor before we send an anchor position
+             * message. */
+            if (!handler.is_anchor) {
+                continue;
+            }
+
+            /* First disable transceiver */
+            dwt_forcetrxoff();
+
+            float x, y, z;
+            x = parameter_scalar_get(&uwb_params.anchor.position.x);
+            y = parameter_scalar_get(&uwb_params.anchor.position.y);
+            z = parameter_scalar_get(&uwb_params.anchor.position.z);
+
+            uwb_send_anchor_position(&handler, x, y, z, frame);
+
+        }
+
         if (flags & EVENT_UWB_INT) {
             /* Process the interrupt. */
             dwt_isr();

--- a/uwb-beacon-firmware/src/state_estimation.cpp
+++ b/uwb-beacon-firmware/src/state_estimation.cpp
@@ -32,7 +32,7 @@ RadioPositionEstimator::RadioPositionEstimator() : covariance(Eigen::Matrix2f::I
                                                    measurementVariance(0.03 * 0.03),
                                                    processVariance(0.025)
 {
-    setPosition(0,0);
+    setPosition(1.0, 1.0);
 }
 
 void RadioPositionEstimator::setPosition(float x, float y)

--- a/uwb-beacon-firmware/src/state_estimation.hpp
+++ b/uwb-beacon-firmware/src/state_estimation.hpp
@@ -3,15 +3,15 @@
 
 class RadioPositionEstimator {
 public:
-    typedef Eigen::Matrix<float, 2, 1> State;
-    Eigen::Vector2f state;
-    Eigen::Matrix2f covariance;
+    typedef Eigen::Matrix<float, 3, 1> State;
+    State state;
+    Eigen::Matrix3f covariance;
     float measurementVariance;
     float processVariance;
 
     RadioPositionEstimator();
-    void setPosition(float x, float y);
-    std::tuple<float, float> getPosition();
+    void setPosition(float x, float y, float z);
+    std::tuple<float, float, float> getPosition();
 
     void processDistanceMeasurement(const float anchor_position[2], float distance);
     void predict(void);

--- a/uwb-beacon-firmware/src/state_estimation_thread.cpp
+++ b/uwb-beacon-firmware/src/state_estimation_thread.cpp
@@ -83,7 +83,7 @@ static THD_FUNCTION(state_estimation_thd, arg)
             anchor_pos = anchor_position_cache_get(msg.anchor_addr);
 
             if (anchor_pos) {
-                float pos[2] = {anchor_pos->x, anchor_pos->y};
+                float pos[3] = {anchor_pos->x, anchor_pos->y, anchor_pos->z};
                 estimator.processDistanceMeasurement(pos, msg.range);
             }
 
@@ -93,13 +93,15 @@ static THD_FUNCTION(state_estimation_thd, arg)
             messagebus_topic_read(topic, &imu_msg, sizeof(imu_msg));
 
             estimator.processVariance = parameter_scalar_read(&params.process_variance);
-            //estimator.predict();
+            estimator.predict();
             position_estimation_msg_t pos_msg;
             pos_msg.timestamp = imu_msg.timestamp;
             pos_msg.x = estimator.state(0);
             pos_msg.y = estimator.state(1);
+            pos_msg.z = estimator.state(2);
             pos_msg.variance_x = estimator.covariance(0, 0);
             pos_msg.variance_y = estimator.covariance(1, 1);
+            pos_msg.variance_z = estimator.covariance(2, 2);
             messagebus_topic_publish(&state_estimation_topic, &pos_msg, sizeof(pos_msg));
         }
     }

--- a/uwb-beacon-firmware/src/state_estimation_thread.cpp
+++ b/uwb-beacon-firmware/src/state_estimation_thread.cpp
@@ -85,7 +85,6 @@ static THD_FUNCTION(state_estimation_thd, arg)
             if (anchor_pos) {
                 float pos[2] = {anchor_pos->x, anchor_pos->y};
                 estimator.processDistanceMeasurement(pos, msg.range);
-                palTogglePad(GPIOC, GPIOC_LED_ERROR);
             }
 
         } else if (topic == imu_topic) {

--- a/uwb-beacon-firmware/src/state_estimation_thread.cpp
+++ b/uwb-beacon-firmware/src/state_estimation_thread.cpp
@@ -85,7 +85,7 @@ static THD_FUNCTION(state_estimation_thd, arg)
             if (anchor_pos) {
                 float pos[2] = {anchor_pos->x, anchor_pos->y};
                 estimator.processDistanceMeasurement(pos, msg.range);
-                palTogglePad(GPIOB, GPIOB_LED_ERROR);
+                palTogglePad(GPIOC, GPIOC_LED_ERROR);
             }
 
         } else if (topic == imu_topic) {

--- a/uwb-beacon-firmware/src/state_estimation_thread.cpp
+++ b/uwb-beacon-firmware/src/state_estimation_thread.cpp
@@ -93,14 +93,14 @@ static THD_FUNCTION(state_estimation_thd, arg)
             messagebus_topic_read(topic, &imu_msg, sizeof(imu_msg));
 
             estimator.processVariance = parameter_scalar_read(&params.process_variance);
-            estimator.predict();
+            //estimator.predict();
             position_estimation_msg_t pos_msg;
             pos_msg.timestamp = imu_msg.timestamp;
             pos_msg.x = estimator.state(0);
             pos_msg.y = estimator.state(1);
             pos_msg.variance_x = estimator.covariance(0, 0);
             pos_msg.variance_y = estimator.covariance(1, 1);
-            //messagebus_topic_publish(&state_estimation_topic, &pos_msg, sizeof(pos_msg));
+            messagebus_topic_publish(&state_estimation_topic, &pos_msg, sizeof(pos_msg));
         }
     }
 }

--- a/uwb-beacon-firmware/src/state_estimation_thread.h
+++ b/uwb-beacon-firmware/src/state_estimation_thread.h
@@ -12,8 +12,10 @@ typedef struct {
     uint32_t timestamp;
     float x;
     float y;
+    float z;
     float variance_x;
     float variance_y;
+    float variance_z;
 } position_estimation_msg_t;
 
 void state_estimation_start(void);

--- a/uwb-beacon-firmware/src/uavcan/topics_publisher.cpp
+++ b/uwb-beacon-firmware/src/uavcan/topics_publisher.cpp
@@ -5,6 +5,7 @@
 #include "imu_thread.h"
 #include "ahrs_thread.h"
 #include "ranging_thread.h"
+#include "state_estimation_thread.h"
 
 #include <uavcan/equipment/ahrs/RawIMU.hpp>
 #include <uavcan/equipment/ahrs/Solution.hpp>
@@ -60,12 +61,8 @@ static void topics_watcher(void *p)
      * Maybe it would be better to check in the loop if the topic exists. */
     //imu_topic = messagebus_find_topic_blocking(&bus, "/imu");
 
-    //messagebus_watchgroup_watch(&watchers[0],
-    //                            &watchgroup.group,
-    //                            imu_topic);
-
-    tag_pos_topic = messagebus_find_topic_blocking(&bus, "/tags_pos");
-    messagebus_watchgroup_watch(&watchers[2],
+    tag_pos_topic = messagebus_find_topic_blocking(&bus, "/ekf/state");
+    messagebus_watchgroup_watch(&watchers[0],
                                 &watchgroup.group,
                                 tag_pos_topic);
 
@@ -173,9 +170,9 @@ void topics_publisher_spin(Node &node)
 
      if (chBSemWaitTimeout(&tag_pos_topic_signaled, TIME_IMMEDIATE) == MSG_OK) {
         messagebus_topic_t *topic;
-        tag_position_msg_t tag_pos_msg;
+        position_estimation_msg_t tag_pos_msg;
 
-        topic = messagebus_find_topic(&bus, "/tags_pos");
+        topic = messagebus_find_topic(&bus, "/ekf/state");
         messagebus_topic_read(topic, &tag_pos_msg, sizeof(tag_pos_msg));
 
         TagPosition msg;

--- a/uwb-beacon-firmware/src/uavcan/topics_publisher.cpp
+++ b/uwb-beacon-firmware/src/uavcan/topics_publisher.cpp
@@ -158,7 +158,6 @@ void topics_publisher_spin(Node &node)
     }
 
      if (chBSemWaitTimeout(&range_topic_signaled, TIME_IMMEDIATE) == MSG_OK) {
-        palTogglePad(GPIOC, GPIOC_LED_ERROR);
         messagebus_topic_t *topic;
         range_msg_t range_msg;
 

--- a/uwb-beacon-firmware/src/uavcan/topics_publisher.cpp
+++ b/uwb-beacon-firmware/src/uavcan/topics_publisher.cpp
@@ -158,7 +158,7 @@ void topics_publisher_spin(Node &node)
     }
 
      if (chBSemWaitTimeout(&range_topic_signaled, TIME_IMMEDIATE) == MSG_OK) {
-        palTogglePad(GPIOB, GPIOB_LED_ERROR);
+        palTogglePad(GPIOC, GPIOC_LED_ERROR);
         messagebus_topic_t *topic;
         range_msg_t range_msg;
 

--- a/uwb-beacon-firmware/src/uwb_protocol.c
+++ b/uwb-beacon-firmware/src/uwb_protocol.c
@@ -137,7 +137,6 @@ void uwb_send_measurement_advertisement(uwb_protocol_handler_t *handler, uint8_t
     uint64_t ts = uwb_timestamp_get();
     size_t frame_size;
 
-    // TODO: Is this the correct place to add some delay?
     ts += UWB_DELAY;
     ts &= MASK_40BIT;
 
@@ -334,7 +333,6 @@ void uwb_initiate_measurement(uwb_protocol_handler_t *handler, uint8_t *buffer, 
                                      buffer,
                                      0);
 
-    // TODO: Is this the correct place to add some delay?
     ts += UWB_DELAY;
     ts &= MASK_40BIT;
 

--- a/uwb-beacon-firmware/src/uwb_protocol.c
+++ b/uwb-beacon-firmware/src/uwb_protocol.c
@@ -9,11 +9,12 @@
 #define MAC_HDR_LEN                     9
 #define MAC_CRC_LEN                     2
 
-#define UWB_SEQ_NUM_ADVERTISEMENT       0
-#define UWB_SEQ_NUM_REPLY               1
-#define UWB_SEQ_NUM_FINALIZATION        2
-#define UWB_SEQ_NUM_ANCHOR_POSITION     3
-#define UWB_SEQ_NUM_TAG_POSITION        4
+#define UWB_SEQ_NUM_ADVERTISEMENT           0
+#define UWB_SEQ_NUM_REPLY                   1
+#define UWB_SEQ_NUM_FINALIZATION            2
+#define UWB_SEQ_NUM_ANCHOR_POSITION         3
+#define UWB_SEQ_NUM_TAG_POSITION            4
+#define UWB_SEQ_NUM_INITIATE_MEASUREMENT    5
 
 #define UWB_DELAY                       (1000 * 65536)
 #define MASK_40BIT                      0xfffffffe00
@@ -316,5 +317,26 @@ void uwb_process_incoming_frame(uwb_protocol_handler_t *handler,
         memcpy(&x, &frame[0], sizeof(float));
         memcpy(&y, &frame[4], sizeof(float));
         handler->tag_position_received_cb(src_addr, x, y);
+    } else if (seq_num == UWB_SEQ_NUM_INITIATE_MEASUREMENT) {
+        uwb_send_measurement_advertisement(handler, frame);
     }
+}
+
+void uwb_initiate_measurement(uwb_protocol_handler_t *handler, uint8_t *buffer, uint16_t anchor_addr)
+{
+    uint64_t ts = uwb_timestamp_get();
+
+    size_t size;
+    size = uwb_mac_encapsulate_frame(handler->pan_id,
+                                     handler->address,
+                                     anchor_addr,
+                                     UWB_SEQ_NUM_INITIATE_MEASUREMENT,
+                                     buffer,
+                                     0);
+
+    // TODO: Is this the correct place to add some delay?
+    ts += UWB_DELAY;
+    ts &= MASK_40BIT;
+
+    uwb_transmit_frame(ts, buffer, size);
 }

--- a/uwb-beacon-firmware/src/uwb_protocol.h
+++ b/uwb-beacon-firmware/src/uwb_protocol.h
@@ -110,6 +110,10 @@ size_t uwb_protocol_prepare_tag_position(uwb_protocol_handler_t *handler,
                                          uint8_t *frame);
 
 
+void uwb_initiate_measurement(uwb_protocol_handler_t *handler,
+                              uint8_t *buffer,
+                              uint16_t anchor_addr);
+
 
 /** @group UWB Board specific API
  *

--- a/uwb-beacon-firmware/tests/state_estimation.cpp
+++ b/uwb-beacon-firmware/tests/state_estimation.cpp
@@ -10,12 +10,13 @@ TEST_GROUP(StateEstimationTestGroup)
 TEST(StateEstimationTestGroup, PositionSetter)
 {
     RadioPositionEstimator est;
-    est.setPosition(10., 20.);
+    est.setPosition(10., 20., 30.);
 
-    float x, y;
-    std::tie(x, y) = est.getPosition();
+    float x, y, z;
+    std::tie(x, y, z) = est.getPosition();
     CHECK_EQUAL(10., x);
     CHECK_EQUAL(20., y);
+    CHECK_EQUAL(30., z);
 }
 
 TEST(StateEstimationTestGroup, CanInputRadio)
@@ -29,23 +30,24 @@ TEST(StateEstimationTestGroup, CanInputRadio)
 TEST(StateEstimationTestGroup, CanPredict)
 {
     RadioPositionEstimator est;
-    float x, y;
+    float x, y, z;
 
-    est.setPosition(10, 20);
+    est.setPosition(10, 20, 30);
     est.predict();
-    std::tie(x, y) = est.getPosition();
+    std::tie(x, y, z) = est.getPosition();
     CHECK_EQUAL(10, x);
     CHECK_EQUAL(20, y);
+    CHECK_EQUAL(30, z);
 }
 
 TEST(StateEstimationTestGroup, Converges)
 {
     RadioPositionEstimator est;
     const float distance = 1.;
-    const float anchor1_pos[2] = {1., 2};
-    const float anchor2_pos[2] = {3., 2};
-    const float anchor3_pos[2] = {2., 1};
-    const float anchor4_pos[2] = {2., 3};
+    const float anchor1_pos[3] = {1., 2, 1};
+    const float anchor2_pos[3] = {3., 2, 1};
+    const float anchor3_pos[3] = {2., 1, 1};
+    const float anchor4_pos[3] = {2., 3, 1};
 
     for (int i = 0; i < 100; i++) {
         est.predict();
@@ -58,10 +60,11 @@ TEST(StateEstimationTestGroup, Converges)
         est.processDistanceMeasurement(anchor4_pos, distance);
     }
 
-    float x, y;
-    std::tie(x, y) = est.getPosition();
+    float x, y, z;
+    std::tie(x, y, z) = est.getPosition();
     DOUBLES_EQUAL(2., x, 0.1);
     DOUBLES_EQUAL(2., y, 0.1);
+    DOUBLES_EQUAL(1., z, 0.1);
 }
 
 TEST(StateEstimationTestGroup, SetVariance)


### PR DESCRIPTION
Solves #145 
This is taking a shortcut to only position one moving beacon (tag) using N anchors (N >= 3 for 3D positioning). Beacons were tested on the Eurobot table and outdoor in a 20x20m field. All looks good.