### PR TITLE
Implement differential base motion control

### DIFF
--- a/drive-board-firmware/src/base/base.c
+++ b/drive-board-firmware/src/base/base.c
@@ -1,10 +1,12 @@
 #include "base.h"
+#include "pca9685_pwm.h"
 
 #include <math.h>
 
 static void base_advance(base_t* base, float speed);
 static void base_rotate(base_t* base, float speed);
 static void wheel_set_speed(wheel_t* wheel, float speed);
+static void wheel_set_angle(wheel_t* wheel, float angle);
 static float clamp(float value, float max);
 
 void base_set_speed(base_t* base, float linear_x, float angular_z)
@@ -21,10 +23,16 @@ void base_advance(base_t* base, float speed)
     float right_speed = speed;
     float left_speed = speed;
 
+    wheel_set_angle(&base->right.back_wheel, 0);
+    wheel_set_angle(&base->right.center_wheel, 0);
+    wheel_set_angle(&base->right.front_wheel, 0);
     wheel_set_speed(&base->right.back_wheel, right_speed);
     wheel_set_speed(&base->right.center_wheel, right_speed);
     wheel_set_speed(&base->right.front_wheel, right_speed);
 
+    wheel_set_angle(&base->left.back_wheel, 0);
+    wheel_set_angle(&base->left.center_wheel, 0);
+    wheel_set_angle(&base->left.front_wheel, 0);
     wheel_set_speed(&base->left.back_wheel, left_speed);
     wheel_set_speed(&base->left.center_wheel, left_speed);
     wheel_set_speed(&base->left.front_wheel, left_speed);
@@ -35,10 +43,16 @@ void base_rotate(base_t* base, float speed)
     float right_speed = - speed;
     float left_speed = speed;
 
+    wheel_set_angle(&base->right.back_wheel, -45.f);
+    wheel_set_angle(&base->right.center_wheel, 0);
+    wheel_set_angle(&base->right.front_wheel, 45.f);
     wheel_set_speed(&base->right.back_wheel, right_speed);
     wheel_set_speed(&base->right.center_wheel, right_speed);
     wheel_set_speed(&base->right.front_wheel, right_speed);
 
+    wheel_set_angle(&base->left.back_wheel, 45.f);
+    wheel_set_angle(&base->left.center_wheel, 0);
+    wheel_set_angle(&base->left.front_wheel, -45.f);
     wheel_set_speed(&base->left.back_wheel, left_speed);
     wheel_set_speed(&base->left.center_wheel, left_speed);
     wheel_set_speed(&base->left.front_wheel, left_speed);
@@ -47,6 +61,12 @@ void base_rotate(base_t* base, float speed)
 void wheel_set_speed(wheel_t* wheel, float speed)
 {
     motor_driver_set_voltage(wheel->motor, clamp(wheel->speed_factor * speed, WHEEL_MAX_SPEED));
+}
+
+void wheel_set_angle(wheel_t* wheel, float angle)
+{
+    float pulse_width = angle * WHEEL_STEERING_90_DEG / 90.f;
+    pca9685_pwm_set_pulse_width(wheel->servo, wheel->steering_center + pulse_width);
 }
 
 float clamp(float value, float max)

--- a/drive-board-firmware/src/base/base.c
+++ b/drive-board-firmware/src/base/base.c
@@ -1,12 +1,39 @@
 #include "base.h"
 
+#include <math.h>
+
+static void base_advance(base_t* base, float speed);
+static void base_rotate(base_t* base, float speed);
 static void wheel_set_speed(wheel_t* wheel, float speed);
 static float clamp(float value, float max);
 
 void base_set_speed(base_t* base, float linear_x, float angular_z)
 {
-    float right_speed = 0.5f * (linear_x - angular_z);
-    float left_speed = 0.5f * (linear_x + angular_z);
+    if (fabsf(linear_x) >= fabsf(angular_z)) {
+        base_advance(base, linear_x);
+    } else {
+        base_rotate(base, angular_z);
+    }
+}
+
+void base_advance(base_t* base, float speed)
+{
+    float right_speed = speed;
+    float left_speed = speed;
+
+    wheel_set_speed(&base->right.back_wheel, right_speed);
+    wheel_set_speed(&base->right.center_wheel, right_speed);
+    wheel_set_speed(&base->right.front_wheel, right_speed);
+
+    wheel_set_speed(&base->left.back_wheel, left_speed);
+    wheel_set_speed(&base->left.center_wheel, left_speed);
+    wheel_set_speed(&base->left.front_wheel, left_speed);
+}
+
+void base_rotate(base_t* base, float speed)
+{
+    float right_speed = - speed;
+    float left_speed = speed;
 
     wheel_set_speed(&base->right.back_wheel, right_speed);
     wheel_set_speed(&base->right.center_wheel, right_speed);

--- a/drive-board-firmware/src/base/base.c
+++ b/drive-board-firmware/src/base/base.c
@@ -1,15 +1,22 @@
 #include "base.h"
 
+static void wheel_set_speed(wheel_t* wheel, float speed);
+
 void base_set_speed(base_t* base, float linear_x, float angular_z)
 {
-    float right_voltage = 0.5f * (linear_x - angular_z);
-    float left_voltage = 0.5f * (linear_x + angular_z);
+    float right_speed = 0.5f * (linear_x - angular_z);
+    float left_speed = 0.5f * (linear_x + angular_z);
 
-    motor_driver_set_voltage(base->right.back_wheel.motor, base->right.back_wheel.speed_factor*right_voltage);
-    motor_driver_set_voltage(base->right.center_wheel.motor, base->right.center_wheel.speed_factor*right_voltage);
-    motor_driver_set_voltage(base->right.front_wheel.motor, base->right.front_wheel.speed_factor*right_voltage);
+    wheel_set_speed(&base->right.back_wheel, right_speed);
+    wheel_set_speed(&base->right.center_wheel, right_speed);
+    wheel_set_speed(&base->right.front_wheel, right_speed);
 
-    motor_driver_set_voltage(base->left.back_wheel.motor, base->left.back_wheel.speed_factor*left_voltage);
-    motor_driver_set_voltage(base->left.center_wheel.motor, base->left.center_wheel.speed_factor*left_voltage);
-    motor_driver_set_voltage(base->left.front_wheel.motor, base->left.front_wheel.speed_factor*left_voltage);
+    wheel_set_speed(&base->left.back_wheel, left_speed);
+    wheel_set_speed(&base->left.center_wheel, left_speed);
+    wheel_set_speed(&base->left.front_wheel, left_speed);
+}
+
+void wheel_set_speed(wheel_t* wheel, float speed)
+{
+    motor_driver_set_voltage(wheel->motor, wheel->speed_factor * speed);
 }

--- a/drive-board-firmware/src/base/base.c
+++ b/drive-board-firmware/src/base/base.c
@@ -1,6 +1,7 @@
 #include "base.h"
 
 static void wheel_set_speed(wheel_t* wheel, float speed);
+static float clamp(float value, float max);
 
 void base_set_speed(base_t* base, float linear_x, float angular_z)
 {
@@ -18,5 +19,12 @@ void base_set_speed(base_t* base, float linear_x, float angular_z)
 
 void wheel_set_speed(wheel_t* wheel, float speed)
 {
-    motor_driver_set_voltage(wheel->motor, wheel->speed_factor * speed);
+    motor_driver_set_voltage(wheel->motor, clamp(wheel->speed_factor * speed, WHEEL_MAX_SPEED));
+}
+
+float clamp(float value, float max)
+{
+    if (value > max) return max;
+    if (value < -max) return -max;
+    return value;
 }

--- a/drive-board-firmware/src/base/base.h
+++ b/drive-board-firmware/src/base/base.h
@@ -9,11 +9,14 @@ extern "C" {
 #include "motor_driver.h"
 
 #define MOTOR_NAME_LEN 20
-#define WHEEL_MAX_SPEED 6.0f // Maximum wheel speed achievable
+#define WHEEL_MAX_SPEED 6.0f            // Maximum wheel speed achievable
+#define WHEEL_STEERING_90_DEG 0.0005f   // Delta to span 90 degrees
 
 typedef struct {
     motor_driver_t* motor;
     float speed_factor;
+    unsigned int servo;
+    float steering_center;
 } wheel_t;
 
 typedef struct {

--- a/drive-board-firmware/src/base/base.h
+++ b/drive-board-firmware/src/base/base.h
@@ -10,7 +10,7 @@ extern "C" {
 
 #define MOTOR_NAME_LEN 20
 #define WHEEL_MAX_SPEED 6.0f            // Maximum wheel speed achievable
-#define WHEEL_STEERING_90_DEG 0.0005f   // Delta to span 90 degrees
+#define WHEEL_STEERING_90_DEG 0.0008f   // Delta to span 90 degrees
 
 typedef struct {
     motor_driver_t* motor;

--- a/drive-board-firmware/src/base/base.h
+++ b/drive-board-firmware/src/base/base.h
@@ -9,6 +9,7 @@ extern "C" {
 #include "motor_driver.h"
 
 #define MOTOR_NAME_LEN 20
+#define WHEEL_MAX_SPEED 6.0f // Maximum wheel speed achievable
 
 typedef struct {
     motor_driver_t* motor;

--- a/drive-board-firmware/src/commands.c
+++ b/drive-board-firmware/src/commands.c
@@ -7,6 +7,8 @@
 
 #include <error/error.h>
 
+#include "timestamp/timestamp.h"
+#include "pca9685_pwm.h"
 #include "main.h"
 
 const ShellCommand commands[];
@@ -266,6 +268,18 @@ static void cmd_vel(BaseSequentialStream *chp, int argc, char **argv)
              linear_x, angular_z);
 }
 
+static void cmd_servo(BaseSequentialStream *chp, int argc, char *argv[])
+{
+    if (argc != 2) {
+        chprintf(chp, "Usage: servo N PULSE_MS\r\n");
+        return;
+    }
+    unsigned int n = atoi(argv[0]);
+    float pw = atof(argv[1]);
+
+    pca9685_pwm_set_pulse_width(n, pw/1000);
+}
+
 const ShellCommand commands[] = {
     {"crashme", cmd_crashme},
     {"config_tree", cmd_config_tree},
@@ -274,5 +288,6 @@ const ShellCommand commands[] = {
     {"threads", cmd_threads},
     {"time", cmd_time},
     {"vel", cmd_vel},
+    {"servo", cmd_servo},
     {NULL, NULL}
 };

--- a/drive-board-firmware/src/main.c
+++ b/drive-board-firmware/src/main.c
@@ -209,9 +209,9 @@ void init_base_motors(void)
     rover_base.left.back_wheel.servo = 0;
     rover_base.left.center_wheel.servo = 2;
     rover_base.left.front_wheel.servo = 4;
-    rover_base.left.back_wheel.steering_center = 0.0015f;
-    rover_base.left.center_wheel.steering_center = 0.0015f;
-    rover_base.left.front_wheel.steering_center = 0.0015f;
+    rover_base.left.back_wheel.steering_center = 0.001675f;
+    rover_base.left.center_wheel.steering_center = 0.00158f;
+    rover_base.left.front_wheel.steering_center = 0.00165f;
 
     rover_base.right.back_wheel.motor = motor_manager_create_driver(&motor_manager, "right-back-wheel");
     rover_base.right.center_wheel.motor = motor_manager_create_driver(&motor_manager, "right-center-wheel");
@@ -221,9 +221,9 @@ void init_base_motors(void)
     rover_base.right.back_wheel.servo = 6;
     rover_base.right.center_wheel.servo = 8;
     rover_base.right.front_wheel.servo = 10;
-    rover_base.right.back_wheel.steering_center = 0.0015f;
+    rover_base.right.back_wheel.steering_center = 0.00156f;
     rover_base.right.center_wheel.steering_center = 0.0015f;
-    rover_base.right.front_wheel.steering_center = 0.0015f;
+    rover_base.right.front_wheel.steering_center = 0.001535f;
 }
 
 void __stack_chk_fail(void)

--- a/drive-board-firmware/src/main.c
+++ b/drive-board-firmware/src/main.c
@@ -206,10 +206,24 @@ void init_base_motors(void)
     rover_base.left.front_wheel.motor = motor_manager_create_driver(&motor_manager, "left-front-wheel");
     rover_base.left.back_wheel.speed_factor = rover_base.left.center_wheel.speed_factor = rover_base.left.front_wheel.speed_factor = 1.f;
 
+    rover_base.left.back_wheel.servo = 0;
+    rover_base.left.center_wheel.servo = 2;
+    rover_base.left.front_wheel.servo = 4;
+    rover_base.left.back_wheel.steering_center = 0.0015f;
+    rover_base.left.center_wheel.steering_center = 0.0015f;
+    rover_base.left.front_wheel.steering_center = 0.0015f;
+
     rover_base.right.back_wheel.motor = motor_manager_create_driver(&motor_manager, "right-back-wheel");
     rover_base.right.center_wheel.motor = motor_manager_create_driver(&motor_manager, "right-center-wheel");
     rover_base.right.front_wheel.motor = motor_manager_create_driver(&motor_manager, "right-front-wheel");
     rover_base.right.back_wheel.speed_factor = rover_base.right.center_wheel.speed_factor = rover_base.right.front_wheel.speed_factor = -1.f;
+
+    rover_base.right.back_wheel.servo = 6;
+    rover_base.right.center_wheel.servo = 8;
+    rover_base.right.front_wheel.servo = 10;
+    rover_base.right.back_wheel.steering_center = 0.0015f;
+    rover_base.right.center_wheel.steering_center = 0.0015f;
+    rover_base.right.front_wheel.steering_center = 0.0015f;
 }
 
 void __stack_chk_fail(void)

--- a/drive-board-firmware/src/remote_control.c
+++ b/drive-board-firmware/src/remote_control.c
@@ -95,6 +95,7 @@ static THD_FUNCTION(rc_thread_main, arg)
 
             // NOTICE("%f,%f", linear_x, angular_z);
             base_set_speed(&rover_base, linear_x, angular_z);
+            chThdSleepMilliseconds(10);
         }
     }
 }


### PR DESCRIPTION
Rover can now move forward or rotate (choose one at a time). The servos are actuated to achieve that (and wired :tada:).

Note: I had to put the remote control thread to sleep or the servos started going crazy (not keeping their position and jittered motion).