### PR TITLE
Reduce goap ram footprint

### DIFF
--- a/lib/goap/goap.hpp
+++ b/lib/goap/goap.hpp
@@ -45,23 +45,14 @@ public:
 
 template<typename State, int N = 100>
 class Planner {
-    Action<State> **actions;
-    size_t action_count;
     VisitedState<State> nodes[N];
-
 public:
-
-    /** Constructor, takes an array of possible actions. */
-    Planner(Action<State> *actions[], size_t action_count)
-        : actions(actions), action_count(action_count)
-    {
-    }
-
     /** Finds a plan from state to goal and returns its length.
      *
      * If path is given, then the found path is stored there.
      */
     int plan(const State &state, Goal<State> &goal,
+             Action<State> *actions[], unsigned action_count,
              Action<State> **path = nullptr, int path_len = 10)
     {
         visited_states_array_to_list(nodes, N);

--- a/lib/goap/tests/goap_test.cpp
+++ b/lib/goap/tests/goap_test.cpp
@@ -109,12 +109,12 @@ TEST(SimpleScenario, CompletedGoalDoesNotRequireAnyAction)
 {
     int action_count = 1;
     goap::Action<TestState> *actions[] = {&cut_wood_action};
-    goap::Planner<TestState> planner(actions, action_count);
+    goap::Planner<TestState> planner;
 
     state.has_wood = true;
 
     /* Since the goal is reached, we should not need any plan. */
-    auto path_len = planner.plan(state, goal);
+    auto path_len = planner.plan(state, goal, actions, action_count);
 
     CHECK_EQUAL(0, path_len);
 }
@@ -123,12 +123,12 @@ TEST(SimpleScenario, DirectActionLeadsToSolution)
 {
     int action_count = 1;
     goap::Action<TestState> *actions[] = {&cut_wood_action};
-    goap::Planner<TestState> planner(actions, action_count);
+    goap::Planner<TestState> planner;
 
     state.has_axe = true;
 
     /* Since the goal is reached, we should not need any plan. */
-    auto path_len = planner.plan(state, goal);
+    auto path_len = planner.plan(state, goal, actions, action_count);
 
     CHECK_EQUAL(1, path_len);
 }
@@ -138,9 +138,9 @@ TEST(SimpleScenario, RespectActionConstrains)
     int action_count = 2;
     goap::Action<TestState> *actions[] = {&cut_wood_action, &grab_axe_action};
 
-    goap::Planner<TestState> planner(actions, action_count);
+    goap::Planner<TestState> planner;
 
-    auto path_len = planner.plan(state, goal);
+    auto path_len = planner.plan(state, goal, actions, action_count);
 
     CHECK_EQUAL(2, path_len);
 }
@@ -153,10 +153,10 @@ TEST(SimpleScenario, GetPath)
     const int max_path_len = 10;
     goap::Action<TestState> *path[max_path_len] = {nullptr};
 
-    goap::Planner<TestState> planner(actions, action_count);
+    goap::Planner<TestState> planner;
 
     /* Since the goal is reached, we should not need any plan. */
-    auto len = planner.plan(state, goal, path, max_path_len);
+    auto len = planner.plan(state, goal, actions, action_count, path, max_path_len);
     CHECK_EQUAL(2, len);
 
     /* Check that the path is OK. */
@@ -168,11 +168,11 @@ TEST(SimpleScenario, MinimizeCost)
 {
     int action_count = 2;
     goap::Action<TestState> *actions[] = {&grab_axe_action, &cut_wood_action};
-    goap::Planner<TestState> planner(actions, action_count);
+    goap::Planner<TestState> planner;
 
     /* We have two paths: one costing 2 and one costing 1 */
     state.has_axe = true;
-    auto cost = planner.plan(state, goal);
+    auto cost = planner.plan(state, goal, actions, action_count);
     CHECK_EQUAL(1, cost);
 }
 
@@ -181,12 +181,12 @@ TEST(SimpleScenario, WhatHappensIfThereIsNoPath)
     int action_count = 1;
     goap::Action<TestState> *actions[] = {&cut_wood_action};
 
-    goap::Planner<TestState> planner(actions, action_count);
+    goap::Planner<TestState> planner;
 
     const int max_path_len = 10;
     goap::Action<TestState> *path[max_path_len] = {nullptr};
 
-    auto cost = planner.plan(state, goal, path, max_path_len);
+    auto cost = planner.plan(state, goal, actions, action_count, path, max_path_len);
     CHECK_EQUAL(-1, cost);
 }
 
@@ -240,10 +240,10 @@ TEST(TooLongPathTestGroup, DoNotFindFarAwayPlan)
     goap::Action<FarAwayState> *actions[] = {&a};
 
     // And feed it to a planner than can do path of at most 10 actions
-    goap::Planner<FarAwayState> planner(actions, 1);
+    goap::Planner<FarAwayState> planner;
 
     // Of course it will fail
-    auto cost = planner.plan(state, goal);
+    auto cost = planner.plan(state, goal, actions, 1);
     CHECK_EQUAL(-2, cost);
 }
 

--- a/master-firmware/Makefile
+++ b/master-firmware/Makefile
@@ -267,8 +267,8 @@ libssp_nonshared.a:
 
 .PHONY: mem_info
 mem_info: $(BUILDDIR)/$(PROJECT).elf
-	arm-none-eabi-nm --size-sort --print-size $(BUILDDIR)/$(PROJECT).elf > $(BUILDDIR)/memory_size.txt
-	arm-none-eabi-nm --numeric-sort --print-size $(BUILDDIR)/$(PROJECT).elf > $(BUILDDIR)/memory_layout.txt
+	arm-none-eabi-nm -C --size-sort --print-size $(BUILDDIR)/$(PROJECT).elf > $(BUILDDIR)/memory_size.txt
+	arm-none-eabi-nm -C --numeric-sort --print-size $(BUILDDIR)/$(PROJECT).elf > $(BUILDDIR)/memory_layout.txt
 
 # Openocd config file
 ifeq ($(OPENOCD_CFG), )

--- a/master-firmware/src/strategy.cpp
+++ b/master-firmware/src/strategy.cpp
@@ -1122,7 +1122,8 @@ void strategy_order_play_game(enum strat_color_t color, RobotState& state)
         &fill_watertower,
     };
 
-    static goap::Planner<RobotState> planner(actions, sizeof(actions) / sizeof(actions[0]));
+    const auto action_count = sizeof(actions) / sizeof(actions[0]);
+    static goap::Planner<RobotState> planner;
 
     lever_retract(&right_lever);
     lever_retract(&left_lever);
@@ -1130,7 +1131,7 @@ void strategy_order_play_game(enum strat_color_t color, RobotState& state)
     wrist_set_horizontal(&main_wrist);
 
     NOTICE("Getting arms ready...");
-    int len = planner.plan(state, init_goal, path, max_path_len);
+    int len = planner.plan(state, init_goal, actions, action_count, path, max_path_len);
     for (int i = 0; i < len; i++) {
         path[i]->execute(state);
         messagebus_topic_publish(state_topic, &state, sizeof(state));
@@ -1159,7 +1160,7 @@ void strategy_order_play_game(enum strat_color_t color, RobotState& state)
     NOTICE("Starting game...");
     while (!trajectory_game_has_ended()) {
         for (auto goal : goals) {
-            int len = planner.plan(state, *goal, path, max_path_len);
+            int len = planner.plan(state, *goal, actions, action_count, path, max_path_len);
             for (int i = 0; i < len; i++) {
                 bool success = path[i]->execute(state);
                 messagebus_topic_publish(state_topic, &state, sizeof(state));
@@ -1260,7 +1261,8 @@ void strategy_chaos_play_game(enum strat_color_t color, RobotState& state)
         &turn_opponent_switch_off,
     };
 
-    static goap::Planner<RobotState> planner(actions, sizeof(actions) / sizeof(actions[0]));
+    const auto action_count = sizeof(actions) / sizeof(actions[0]);
+    static goap::Planner<RobotState> planner;
 
     lever_retract(&right_lever);
     lever_retract(&left_lever);
@@ -1268,7 +1270,7 @@ void strategy_chaos_play_game(enum strat_color_t color, RobotState& state)
     wrist_set_horizontal(&main_wrist);
 
     NOTICE("Getting arms ready...");
-    int len = planner.plan(state, init_goal, path, max_path_len);
+    int len = planner.plan(state, init_goal, actions, action_count, path, max_path_len);
     for (int i = 0; i < len; i++) {
         path[i]->execute(state);
         messagebus_topic_publish(state_topic, &state, sizeof(state));
@@ -1305,7 +1307,7 @@ void strategy_chaos_play_game(enum strat_color_t color, RobotState& state)
 
     while (!trajectory_game_has_ended()) {
         for (auto goal : goals) {
-            int len = planner.plan(state, *goal, path, max_path_len);
+            int len = planner.plan(state, *goal, actions, action_count, path, max_path_len);
             for (int i = 0; i < len; i++) {
                 bool success = path[i]->execute(state);
                 messagebus_topic_publish(state_topic, &state, sizeof(state));

--- a/master-firmware/src/strategy.cpp
+++ b/master-firmware/src/strategy.cpp
@@ -39,6 +39,8 @@
 #include "protobuf/strategy.pb.h"
 
 
+static goap::Planner<RobotState, GOAP_SPACE_SIZE> planner;
+
 static enum strat_color_t wait_for_color_selection(void);
 static void wait_for_autoposition_signal(void);
 static void wait_for_starter(void);
@@ -1123,7 +1125,6 @@ void strategy_order_play_game(enum strat_color_t color, RobotState& state)
     };
 
     const auto action_count = sizeof(actions) / sizeof(actions[0]);
-    static goap::Planner<RobotState> planner;
 
     lever_retract(&right_lever);
     lever_retract(&left_lever);
@@ -1262,7 +1263,6 @@ void strategy_chaos_play_game(enum strat_color_t color, RobotState& state)
     };
 
     const auto action_count = sizeof(actions) / sizeof(actions[0]);
-    static goap::Planner<RobotState> planner;
 
     lever_retract(&right_lever);
     lever_retract(&left_lever);

--- a/master-firmware/src/strategy/actions.h
+++ b/master-firmware/src/strategy/actions.h
@@ -4,6 +4,10 @@
 #include <goap/goap.hpp>
 #include "state.h"
 
+/** Number of states goap can visit before giving up. Increasing it means a
+ * solution is found on more complex problems at the expense of RAM use. */
+#define GOAP_SPACE_SIZE 30
+
 namespace actions {
 
 struct IndexArms : public goap::Action<RobotState> {

--- a/master-firmware/tests/test_strategy.cpp
+++ b/master-firmware/tests/test_strategy.cpp
@@ -124,10 +124,10 @@ TEST_GROUP(Strategy) {
     {
         const int max_path_len = 10;
         goap::Action<RobotState> *path[max_path_len] = {nullptr};
+        goap::Planner<RobotState> planner;
         auto actions = availableActions();
-        goap::Planner<RobotState> planner(actions.data(), actions.size());
 
-        int len = planner.plan(state, goal, path, max_path_len);
+        int len = planner.plan(state, goal, actions.data(), actions.size(), path, max_path_len);
         for (int i = 0; i < len; i++) {
             path[i]->execute(state);
         }

--- a/master-firmware/tests/test_strategy.cpp
+++ b/master-firmware/tests/test_strategy.cpp
@@ -124,7 +124,7 @@ TEST_GROUP(Strategy) {
     {
         const int max_path_len = 10;
         goap::Action<RobotState> *path[max_path_len] = {nullptr};
-        goap::Planner<RobotState> planner;
+        goap::Planner<RobotState, GOAP_SPACE_SIZE> planner;
         auto actions = availableActions();
 
         int len = planner.plan(state, goal, actions.data(), actions.size(), path, max_path_len);

--- a/uwb-beacon-firmware/tools/read_range.py
+++ b/uwb-beacon-firmware/tools/read_range.py
@@ -56,10 +56,10 @@ def main():
 
     # TODO This path is a bit too hardcoded
     dsdl_path = os.path.join(
-        os.path.dirname(__file__), '..', 'beacon_messages')
+        os.path.dirname(__file__), '..', '..', 'uavcan_data_types', 'cvra', 'uwb_beacon')
     uavcan.load_dsdl(dsdl_path)
 
-    node.add_handler(uavcan.thirdparty.beacon_messages.equipment.RadioRange,
+    node.add_handler(uavcan.thirdparty.uwb_beacon.RadioRange,
                      range_cb)
 
     node.spin()


### PR DESCRIPTION
This PR makes GOAP more usable on lower RAM. It was an issue before, but it was more in our use of the planner than in the algorithm itself.

Should be good now.