### PR TITLE
Update pid plotter

### DIFF
--- a/tools/studio/cvra_studio/commands/pid_plot.py
+++ b/tools/studio/cvra_studio/commands/pid_plot.py
@@ -39,7 +39,6 @@ class PidViewer(QtGui.QWidget):
         self.params_view = NestedDictView()
         self.save_button = QtGui.QPushButton('Save')
 
-        self.motor =  LineEdit(title="Motor CAN ID\t", callback=None, parent=parent)
         self.topic =  ComboBox(title="Topic       \t", callback=None, items=list(ControlTopic), parent=parent)
         self.value =  LineEdit(title="Value       \t", callback=None, parent=parent)
         self.period = LineEdit(title="Period [s]  \t", callback=None, parent=parent)
@@ -50,7 +49,6 @@ class PidViewer(QtGui.QWidget):
                 vstack([
                     self.params_view,
                     self.save_button,
-                    self.motor,
                     self.topic,
                     self.value,
                     self.period,
@@ -178,7 +176,6 @@ class PidPlotController:
         self.model.params_model.on_new_params(self.viewer.params_view.set)
         self.viewer.save_button.clicked.connect(self._save_params)
 
-        self.viewer.motor.callback = self.model.setpt_pub.update_motor
         self.viewer.topic.callback = self.model.setpt_pub.update_topic
         self.viewer.value.callback = self.model.setpt_pub.update_value
         self.viewer.period.callback = self.model.setpt_pub.update_period
@@ -200,6 +197,7 @@ class PidPlotController:
         self.model.clear()
         self.logger.info('Selected node {}'.format(self.model.tracked_node))
         self.model.params_model.fetch_params(self.selected_node_id())
+        self.model.setpt_pub.update_motor(self.selected_node_id())
 
     def _change_selected_pid_loop(self, i):
         self.model.tracked_pid_loop = self.model.PID_LOOPS[i]

--- a/tools/studio/cvra_studio/commands/pid_plot.py
+++ b/tools/studio/cvra_studio/commands/pid_plot.py
@@ -40,7 +40,8 @@ class PidViewer(QtGui.QWidget):
         self.save_button = QtGui.QPushButton('Save')
 
         self.topic =  ComboBox(title="Topic       \t", callback=None, items=list(ControlTopic), parent=parent)
-        self.value =  LineEdit(title="Value       \t", callback=None, parent=parent)
+        self.value_min =  LineEdit(title="Value min   \t", callback=None, parent=parent)
+        self.value_max =  LineEdit(title="Value max   \t", callback=None, parent=parent)
         self.period = LineEdit(title="Period [s]  \t", callback=None, parent=parent)
 
         self.setLayout(vstack([
@@ -50,7 +51,8 @@ class PidViewer(QtGui.QWidget):
                     self.params_view,
                     self.save_button,
                     self.topic,
-                    self.value,
+                    self.value_min,
+                    self.value_max,
                     self.period,
                 ]),
                 vstack([
@@ -63,8 +65,8 @@ class PidViewer(QtGui.QWidget):
         self.show()
 
 class SetpointPublisherModel:
-    def __init__(self, node, topic, motor, value, period):
-        self.publisher = SetpointPublisher(node, ControlTopic(topic), motor, value, period)
+    def __init__(self, node, topic, motor, value_min, value_max, period):
+        self.publisher = SetpointPublisher(node, ControlTopic(topic), motor, value_min, value_max, period)
 
     def update_motor(self, value):
         self.publisher.motor = int(value)
@@ -74,8 +76,12 @@ class SetpointPublisherModel:
         self.publisher.topic = ControlTopic(value)
         self.publisher.update()
 
-    def update_value(self, value):
-        self.publisher.value = float(value)
+    def update_value_min(self, value_min):
+        self.publisher.value_min = float(value_min)
+        self.publisher.update()
+
+    def update_value_max(self, value_max):
+        self.publisher.value_max = float(value_max)
         self.publisher.update()
 
     def update_period(self, value):
@@ -102,7 +108,7 @@ class PidFeedbackRecorder():
         self.monitor = NodeStatusMonitor(node)
         self.monitor.on_new_node(self._update_nodes)
 
-        self.setpt_pub = SetpointPublisherModel(node, topic='voltage', motor=1, value=0, period=1)
+        self.setpt_pub = SetpointPublisherModel(node, topic='voltage', motor=1, value_min=0, value_max=0, period=1)
 
         self.clear()
         self.node.add_handler(uavcan.thirdparty.cvra.motor.feedback.CurrentPID, self._current_pid_callback)
@@ -177,7 +183,8 @@ class PidPlotController:
         self.viewer.save_button.clicked.connect(self._save_params)
 
         self.viewer.topic.callback = self.model.setpt_pub.update_topic
-        self.viewer.value.callback = self.model.setpt_pub.update_value
+        self.viewer.value_min.callback = self.model.setpt_pub.update_value_min
+        self.viewer.value_max.callback = self.model.setpt_pub.update_value_max
         self.viewer.period.callback = self.model.setpt_pub.update_period
 
         threading.Thread(target=self.run).start()

--- a/tools/studio/cvra_studio/network/SetpointPublisher.py
+++ b/tools/studio/cvra_studio/network/SetpointPublisher.py
@@ -23,11 +23,12 @@ class ControlTopic(enum.Enum):
         }[self.value]
 
 class SetpointPublisher():
-    def __init__(self, node, topic, motor, value, period):
+    def __init__(self, node, topic, motor, value_min, value_max, period):
         self.node = node
         self.topic = topic
-        self.motor = motor
-        self.value = value
+        self.motor = motor 
+        self.value_min = value_min
+        self.value_max = value_max
         self.period = period
         self.lock = threading.RLock()
         self.handle = node.node.periodic(0.01, self._publish)
@@ -41,9 +42,12 @@ class SetpointPublisher():
 
     def _update(self):
         while True:
+            with self.lock:
+                self.value = self.value_min
             time.sleep(self.period)
             with self.lock:
-                self.value *= -1
+                self.value = self.value_max
+            time.sleep(self.period)
 
     def update(self):
         self.handle.remove()


### PR DESCRIPTION
On the PID tuner, this PR:
* implement to choose a min&max for the set point
* remove the choice "motor" which was useless. (It, now, select automatically the node we are on)
