### PR TITLE
WIP: Reenable on-board SDCard for logging

### DIFF
--- a/master-firmware/src/board/board.h
+++ b/master-firmware/src/board/board.h
@@ -462,10 +462,10 @@
                                      PIN_PUPDR_FLOATING(GPIOC_ETH_RMII_RXD1) | \
                                      PIN_PUPDR_PULLUP(GPIOC_ENCODER_RIGHT_CHA) | \
                                      PIN_PUPDR_PULLUP(GPIOC_ENCODER_RIGHT_CHB) | \
-                                     PIN_PUPDR_FLOATING(GPIOC_SD_D0) | \
-                                     PIN_PUPDR_FLOATING(GPIOC_SD_D1) | \
-                                     PIN_PUPDR_FLOATING(GPIOC_SD_D2) | \
-                                     PIN_PUPDR_FLOATING(GPIOC_SD_D3) | \
+                                     PIN_PUPDR_PULLUP(GPIOC_SD_D0) | \
+                                     PIN_PUPDR_PULLUP(GPIOC_SD_D1) | \
+                                     PIN_PUPDR_PULLUP(GPIOC_SD_D2) | \
+                                     PIN_PUPDR_PULLUP(GPIOC_SD_D3) | \
                                      PIN_PUPDR_FLOATING(GPIOC_SD_CLK) | \
                                      PIN_PUPDR_FLOATING(GPIOC_USER_BUTTON) | \
                                      PIN_PUPDR_FLOATING(GPIOC_OSC32_IN) | \
@@ -556,7 +556,7 @@
                                      PIN_OSPEED_100M(GPIOD_PIN15))
 #define VAL_GPIOD_PUPDR             (PIN_PUPDR_FLOATING(GPIOD_CAN1_RX) | \
                                      PIN_PUPDR_FLOATING(GPIOD_CAN1_TX) | \
-                                     PIN_PUPDR_FLOATING(GPIOD_SD_CMD) | \
+                                     PIN_PUPDR_PULLUP(GPIOD_SD_CMD) | \
                                      PIN_PUPDR_FLOATING(GPIOD_PIN3) | \
                                      PIN_PUPDR_FLOATING(GPIOD_PIN4) | \
                                      PIN_PUPDR_FLOATING(GPIOD_UART2_TX) | \

--- a/master-firmware/src/debug/log.c
+++ b/master-firmware/src/debug/log.c
@@ -126,6 +126,14 @@ static void vlogfile_log_message(struct error* e, va_list args)
         return;
     }
 
+    if (!palReadPad(GPIOA, GPIOA_SD_DETECT)) {
+        /* Indicate SD activity */
+        palTogglePad(GPIOB, GPIOB_LED_SD);
+    } else {
+        /* Card was removed */
+        return;
+    }
+
     static char buffer[256];
     UINT dummy;
     const char* thread_name = NULL;

--- a/master-firmware/src/filesystem.c
+++ b/master-firmware/src/filesystem.c
@@ -9,6 +9,13 @@ static FATFS SDC_FS;
 void filesystem_start(void)
 {
     FRESULT err;
+
+    /* Enable SD power if card present */
+    if (!palReadPad(GPIOA, GPIOA_SD_DETECT)) {
+        palClearPad(GPIOA, GPIOA_SD_PWR);
+        chThdSleepMilliseconds(100);
+    }
+
     sdcStart(&SDCD1, NULL);
     sdcConnect(&SDCD1);
 


### PR DESCRIPTION
We disabled SD card logging because it didn't work during initial tests.
Probably this was due to missing pull-ups on the SD D0-4 and CMD lines.
I tested it on one board and it works reliably, yay 👻 

However, it only works if `gui_start()` is commented out. Otherwise it panics with a UsageFault 🔥   
The stack backtrace looks weird, it claims the error is at address 0x00000000 😱

My guess is that the fatfs routines in `log_message()` use too much stack and things start to break.
Need to investigate more...