### PR TITLE
Read IP parameters from tree

### DIFF
--- a/config_chaos.yaml
+++ b/config_chaos.yaml
@@ -4,6 +4,13 @@ logging:
     level: "notice"
   sdcard:
     level: "notice" # changing this to debug slows down things too much and causes panic
+ip:
+  ethernet:
+    address: "192.168.3.20"
+    netmask: "255.255.255.0"
+  uwb:
+    address: "10.0.0.10"
+    netmask: "255.255.255.0"
 master:
     is_main_robot: false
     control_panel_active_high: true

--- a/config_order.yaml
+++ b/config_order.yaml
@@ -4,6 +4,13 @@ logging:
     level: "notice"
   sdcard:
     level: "notice" # changing this to debug slows down things too much and causes panic
+ip:
+  ethernet:
+    address: "192.168.3.20"
+    netmask: "255.255.255.0"
+  uwb:
+    address: "10.0.0.20"
+    netmask: "255.255.255.0"
 master:
     is_main_robot: true
     control_panel_active_high: false

--- a/master-firmware/package.yml
+++ b/master-firmware/package.yml
@@ -63,6 +63,7 @@ target.arm:
     - src/udp_topic_broadcaster.c
     - src/manipulator/hw.cpp
     - src/manipulator/manipulator_thread.cpp
+    - src/uid.c
 
 source:
     - src/unix_timestamp.c

--- a/master-firmware/src/can/can_uwb_ip_netif.cpp
+++ b/master-firmware/src/can/can_uwb_ip_netif.cpp
@@ -31,7 +31,6 @@ static DataPacket tx_packet, rx_packet;
 static MUTEX_DECL(lock_rx_packet);
 static BSEMAPHORE_DECL(sem_rx_available, true);
 static EVENTSOURCE_DECL(event_rx);
-static pbuf* rx_pbuf;
 
 uavcan::LazyConstructor<uavcan::Publisher<DataPacket>> data_pub;
 
@@ -76,6 +75,7 @@ int can_uwb_ip_netif_init(uavcan::INode& node)
 
 static err_t low_level_output(struct netif* netif, struct pbuf* p)
 {
+    (void) netif;
     /* First, copy all the data */
     tx_packet = DataPacket();
     for (auto q = p; q != NULL; q = q->next) {
@@ -96,6 +96,7 @@ static err_t low_level_output(struct netif* netif, struct pbuf* p)
 
 bool lwip_uwb_ip_read(struct netif* netif, struct pbuf** pbuf)
 {
+    (void) netif;
     if (chBSemWaitTimeout(&sem_rx_available, TIME_IMMEDIATE) != MSG_OK) {
         return false;
     }
@@ -122,6 +123,7 @@ bool lwip_uwb_ip_read(struct netif* netif, struct pbuf** pbuf)
 
 int can_uwb_ip_netif_spin(uavcan::INode& node)
 {
+    (void) node;
     /* Check if data is available for transmit */
     if (chBSemWaitTimeout(&sem_tx_ready, TIME_IMMEDIATE) == MSG_OK) {
         data_pub->broadcast(tx_packet);

--- a/master-firmware/src/lwipopts.h
+++ b/master-firmware/src/lwipopts.h
@@ -19,8 +19,6 @@
 #define TCPIP_THREAD_STACKSIZE 4096
 #define TCPIP_MBOX_SIZE MEMP_NUM_PBUF
 
-#define LWIP_DHCP 1
-
 #define LWIP_SOCKET 0
 
 #define DEFAULT_THREAD_STACK_SIZE 4096
@@ -29,14 +27,13 @@
 #define DEFAULT_TCP_RECVMBOX_SIZE 4
 #define DEFAULT_ACCEPTMBOX_SIZE 4
 
+/* Deprecated, use parameter instead */
+/* Set the default IP of each interface */
 #define LWIP_ETHERNET_IPADDR(p) IP4_ADDR(p, 192, 168, 3, 20)
 #define LWIP_ETHERNET_NETMASK(p) IP4_ADDR(p, 255, 255, 255, 0)
 #define LWIP_CAN_IPADDR(p) IP4_ADDR(p, 192, 168, 4, 20)
 #define LWIP_CAN_NETMASK(p) IP4_ADDR(p, 255, 255, 255, 0)
 #define LWIP_GATEWAY(p) IP4_ADDR(p, 192, 168, 3, 1)
-
-#define LWIP_IFNAME0 'e'
-#define LWIP_IFNAME1 'n'
 
 /** Use newlib malloc() instead of memory pools. */
 #include <stdlib.h>
@@ -47,27 +44,5 @@
 #define STREAM_PORT 20042
 #define BUTTON_PRESS_PUBLISHER_PORT 20042
 
-/* Robot settings. */
-#ifdef ON_ROBOT
-
-#define STREAM_HOST(server) ((server)->addr = (IP_ADDR_BROADCAST)->addr)
-
-#define ODOMETRY_PUBLISHER_HOST(server) ((server)->addr = (IP_ADDR_BROADCAST)->addr)
-
-#define BUTTON_PRESS_PUBLISHER(server) ((server)->addr = (IP_ADDR_BROADCAST)->addr)
-
-#else
-/* Laptop debug settings. We cannot use a broadcast address to debug over wifi
- * because routers don't forward broadcast packets. */
-
-#error "currently untested"
-
-#define LAPTOP_IP(p) IP4_ADDR(p, 192, 168, 2, 101)
-
-#define ODOMETRY_PUBLISHER_HOST(server) LAPTOP_IP(server)
-
-#define STREAM_HOST(server) LAPTOP_IP(server)
-
-#endif
 
 #endif /* __LWIPOPT_H__ */

--- a/master-firmware/src/main.c
+++ b/master-firmware/src/main.c
@@ -220,12 +220,6 @@ int main(void)
     init_base_motors();
     init_arm_motors();
 
-    /* Load stored robot config */
-    config_load_from_flash();
-
-    control_panel_init(config_get_boolean("master/control_panel_active_high"));
-    gui_start();
-
     /* Initiaze UAVCAN communication */
     uavcan_node_start(10);
 
@@ -233,6 +227,11 @@ int main(void)
     chThdSleepMilliseconds(100);
     ip_thread_init();
 
+    /* Load stored robot config */
+    config_load_from_flash();
+
+    control_panel_init(config_get_boolean("master/control_panel_active_high"));
+    gui_start();
 
     // http_server_start();
     udp_topic_broadcast_start();

--- a/master-firmware/src/uid.c
+++ b/master-firmware/src/uid.c
@@ -1,0 +1,9 @@
+#include <string.h>
+#include "uid.h"
+
+#define UID_REGISTER ((const uint8_t*)(0x1FFF7A10))
+
+void uid_read(uint8_t out[UID_LENGTH])
+{
+    memcpy(out, UID_REGISTER, UID_LENGTH);
+}

--- a/master-firmware/src/uid.h
+++ b/master-firmware/src/uid.h
@@ -1,0 +1,11 @@
+#ifndef UID_H
+#define UID_H
+
+#include <stdint.h>
+
+#define UID_LENGTH 12
+
+/** Returns the microcontroller's unique ID */
+void uid_read(uint8_t out[UID_LENGTH]);
+
+#endif


### PR DESCRIPTION
This PR implements two different things, both needed to have IP comms between robots:

* The MAC address is derived from hardware serial numbers and used a locally administered MAC.
* The IP is read from the config tree.

This means each robot will have a different IP address.

Tested that the IP address changes in lwip.