### PR TITLE
Proximity beacon speed control

### DIFF
--- a/motor-control-firmware/board/board.h
+++ b/motor-control-firmware/board/board.h
@@ -286,8 +286,8 @@
                                      PIN_PUPDR_PULLDOWN(GPIOB_NC_3) |       \
                                      PIN_PUPDR_FLOATING(GPIOB_GPIO_A) |     \
                                      PIN_PUPDR_FLOATING(GPIOB_GPIO_B) |     \
-                                     PIN_PUPDR_FLOATING(GPIOB_QUAD_ENC_A) | \
-                                     PIN_PUPDR_FLOATING(GPIOB_QUAD_ENC_B) | \
+                                     PIN_PUPDR_PULLUP(GPIOB_QUAD_ENC_A) | \
+                                     PIN_PUPDR_PULLUP(GPIOB_QUAD_ENC_B) | \
                                      PIN_PUPDR_FLOATING(GPIOB_CAN_RX) |     \
                                      PIN_PUPDR_FLOATING(GPIOB_CAN_TX) |     \
                                      PIN_PUPDR_FLOATING(GPIOB_USART3_TX) |  \

--- a/motor-control-firmware/src/encoder.c
+++ b/motor-control-firmware/src/encoder.c
@@ -22,6 +22,9 @@ void encoder_init_primary(void)
     STM32_TIM4->SMCR = STM32_TIM_SMCR_SMS(3); // count on both edges
     STM32_TIM4->CCMR1 = STM32_TIM_CCMR1_CC1S(1); // CC1 channel is input, IC1 is mapped on TI1
     STM32_TIM4->CCMR1 |= STM32_TIM_CCMR1_CC2S(1); // CC2 channel is input, IC2 is mapped on TI2
+    /* enable filtering, clock prescaler 32, 8 samples */
+    STM32_TIM4->CCMR1 |= STM32_TIM_CCMR1_IC1F(0xf);
+    STM32_TIM4->CCMR1 |= STM32_TIM_CCMR1_IC2F(0xf);
     STM32_TIM4->CCER = 0;
     STM32_TIM4->ARR = 0xFFFF;
     STM32_TIM4->CR1 = 1; // start
@@ -41,6 +44,11 @@ void encoder_init_secondary(void)
     STM32_TIM3->SMCR = STM32_TIM_SMCR_SMS(3); // count on both edges
     STM32_TIM3->CCMR1 = STM32_TIM_CCMR1_CC1S(1); // CC1 channel is input, IC1 is mapped on TI1
     STM32_TIM3->CCMR1 |= STM32_TIM_CCMR1_CC2S(1); // CC2 channel is input, IC2 is mapped on TI2
+
+    /* enable filtering, clock prescaler 32, 8 samples */
+    STM32_TIM3->CCMR1 |= STM32_TIM_CCMR1_IC1F(0xf);
+    STM32_TIM3->CCMR1 |= STM32_TIM_CCMR1_IC2F(0xf);
+
     STM32_TIM3->CCER = 0;
     STM32_TIM3->ARR = 0xFFFF;
     STM32_TIM3->CR1 = 1; // start

--- a/proximity-beacon-firmware/package.yml
+++ b/proximity-beacon-firmware/package.yml
@@ -25,6 +25,9 @@ target.arm:
     - ../motor-control-firmware/src/rpm.c
     - ../motor-control-firmware/src/bootloader_config.c
     - ../motor-control-firmware/src/reboot.c
+    - ../motor-control-firmware/src/uavcan/Velocity_handler.cpp
+    - ../motor-control-firmware/src/uavcan/Position_handler.cpp
+    - ../motor-control-firmware/src/uavcan/Torque_handler.cpp
     - ../motor-control-firmware/src/uavcan/Reboot_handler.cpp
     - ../motor-control-firmware/src/uavcan/EmergencyStop_handler.cpp
     - ../motor-control-firmware/src/uavcan/parameter_server.cpp

--- a/proximity-beacon-firmware/src/beacon_main.c
+++ b/proximity-beacon-firmware/src/beacon_main.c
@@ -3,6 +3,7 @@
 #include <chprintf.h>
 
 #include <parameter/parameter.h>
+#include <parameter_flash_storage/parameter_flash_storage.h>
 #include <timestamp/timestamp_stm32.h>
 
 #include "blocking_uart_driver.h"
@@ -14,6 +15,7 @@
 #include "bootloader_config.h"
 #include "uavcan/uavcan_node.h"
 #include "index.h"
+#include "main.h"
 
 BaseSequentialStream* ch_stdout;
 parameter_namespace_t parameter_root_ns;
@@ -133,8 +135,10 @@ int main(void)
     /* Wait for all services to boot, then try to load config. */
     chThdSleepMilliseconds(300);
 
-    uavcan_init_complete();
-    control_start();
+    if (parameter_flash_storage_load(&parameter_root_ns, &_config_start)) {
+        uavcan_init_complete();
+        control_start();
+    }
 
     while (1) {
         chThdSleepMilliseconds(1000);

--- a/proximity-beacon-firmware/src/node.cpp
+++ b/proximity-beacon-firmware/src/node.cpp
@@ -15,6 +15,9 @@
 
 #include "Reboot_handler.hpp"
 #include "EmergencyStop_handler.hpp"
+#include "Velocity_handler.hpp"
+#include "Position_handler.hpp"
+#include "Torque_handler.hpp"
 
 #include "proximity_beacon_publisher.hpp"
 
@@ -50,6 +53,9 @@ static void uavcan_services_start(Node& node)
         {proximity_beacon_start, "proximity beacon"},
         {parameter_server_start, "UAVCAN parameter server"},
         {uavcan_streams_start, "UAVCAN state streamer"},
+        {Velocity_handler_start, "cvra::motor::control::Velocity subscriber"},
+        {Position_handler_start, "cvra::motor::control::Position subscriber"},
+        {Torque_handler_start, "cvra::motor::control::Torque subscriber"},
         {NULL, NULL} /* Must be last */
     };
 

--- a/proximity-beacon-firmware/src/proximity_beacon_publisher.cpp
+++ b/proximity-beacon-firmware/src/proximity_beacon_publisher.cpp
@@ -19,8 +19,9 @@ static void timer_cb(const uavcan::TimerEvent& event)
         proximity_beacon_signal_delete(pbs);
     }
 
-    /* periodic setpoint update to keep the motor running */
-    control_update_voltage_setpoint(-4.0);
+    /* Rotate at 10 Hz */
+    const auto setpoint = -10 * 2 * 3.14f;
+    control_update_velocity_setpoint(setpoint);
 }
 
 int proximity_beacon_start(Node& node)


### PR DESCRIPTION
This PR implements proximity beacon speed control using the encoder built into the motor. It also adds filters to the quadrature encoder inputs, which prevents issues with the (i assume) noisy signal coming from the motors.

We should now test it on the robot, but no rush and please review it carefully, as I dont want it to cause encoder damage or loss of precision.