### PR TITLE
Register shell commands using linker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: false
+dist: trusty
 addons:
     apt:
         sources:

--- a/master-firmware/linker/STM32F429xI.ld
+++ b/master-firmware/linker/STM32F429xI.ld
@@ -90,3 +90,5 @@ REGION_ALIAS("CCM_RAM", ram4);
 
 /* Generic rules inclusion.*/
 INCLUDE rules.ld
+
+INCLUDE shell_commands.ld

--- a/master-firmware/linker/shell_commands.ld
+++ b/master-firmware/linker/shell_commands.ld
@@ -1,10 +1,11 @@
 SECTIONS
 {
-    .shell_commands :
+    .shell_commands : ALIGN(4)
     {
         . = ALIGN(4);
-        _shell_commands = .;
-        KEEP(*(SORT(.shell_commands.*)))
+        __shell_commands_start = .;
+        KEEP(*(SORT(.shell_commands*)))
+        __shell_commands_end = .;
         . = ALIGN(4);
-    } > RODATA_FLASH
+    } > RODATA_FLASH AT > RODATA_FLASH_LMA
 }

--- a/master-firmware/linker/shell_commands.ld
+++ b/master-firmware/linker/shell_commands.ld
@@ -5,7 +5,6 @@ SECTIONS
         . = ALIGN(4);
         _shell_commands = .;
         KEEP(*(SORT(.shell_commands.*)))
-        KEEP(*(.shell_commands_end))
         . = ALIGN(4);
     } > RODATA_FLASH
 }

--- a/master-firmware/linker/shell_commands.ld
+++ b/master-firmware/linker/shell_commands.ld
@@ -1,0 +1,11 @@
+SECTIONS
+{
+    .shell_commands :
+    {
+        . = ALIGN(4);
+        _shell_commands = .;
+        KEEP(*(SORT(.shell_commands.*)))
+        KEEP(*(.shell_commands_end))
+        . = ALIGN(4);
+    } > RODATA_FLASH
+}

--- a/master-firmware/src/commands.cpp
+++ b/master-firmware/src/commands.cpp
@@ -59,7 +59,7 @@ static char sc_histbuf[SHELL_MAX_HIST_BUFF];
 
 static ShellConfig shell_cfg = {
     NULL,
-    _shell_commands,
+    __shell_commands_start,
 #if SHELL_USE_HISTORY == TRUE
     sc_histbuf,
     sizeof(sc_histbuf),

--- a/master-firmware/src/commands.cpp
+++ b/master-firmware/src/commands.cpp
@@ -49,8 +49,9 @@ extern "C" {
 #include "protobuf/sensors.pb.h"
 #include "protobuf/encoders.pb.h"
 #include "usbconf.h"
+#include "shell_commands.h"
 
-extern ShellCommand commands[];
+SHELL_COMMAND_END();
 
 #if SHELL_USE_HISTORY == TRUE
 static char sc_histbuf[SHELL_MAX_HIST_BUFF];
@@ -58,7 +59,7 @@ static char sc_histbuf[SHELL_MAX_HIST_BUFF];
 
 static ShellConfig shell_cfg = {
     NULL,
-    commands,
+    _shell_commands,
 #if SHELL_USE_HISTORY == TRUE
     sc_histbuf,
     sizeof(sc_histbuf),
@@ -81,7 +82,7 @@ void shell_spawn(BaseSequentialStream* stream)
     }
 }
 
-static void cmd_threads(BaseSequentialStream* chp, int argc, char* argv[])
+SHELL_COMMAND(threads, chp, argc, argv)
 {
     static const char* states[] = {CH_STATE_NAMES};
     thread_t* tp;
@@ -108,7 +109,7 @@ static void cmd_threads(BaseSequentialStream* chp, int argc, char* argv[])
     } while (tp != NULL);
 }
 
-static void cmd_stack(BaseSequentialStream* chp, int argc, char* argv[])
+SHELL_COMMAND(stack, chp, argc, argv)
 {
 #if (CH_DBG_FILL_THREADS != TRUE) || (CH_CFG_USE_REGISTRY != TRUE) || (CH_DBG_ENABLE_STACK_CHECK != TRUE)
 #error "Requires: CH_DBG_FILL_THREADS CH_CFG_USE_REGISTRY CH_DBG_ENABLE_STACK_CHECK"
@@ -144,7 +145,7 @@ static void cmd_stack(BaseSequentialStream* chp, int argc, char* argv[])
     }
 }
 
-static void cmd_ip(BaseSequentialStream* chp, int argc, char** argv)
+SHELL_COMMAND(ip, chp, argc, argv)
 {
     (void)argv;
     (void)argc;
@@ -162,7 +163,7 @@ static void cmd_ip(BaseSequentialStream* chp, int argc, char** argv)
     }
 }
 
-static void cmd_crashme(BaseSequentialStream* chp, int argc, char** argv)
+SHELL_COMMAND(crashme, chp, argc, argv)
 {
     (void)argv;
     (void)argc;
@@ -171,7 +172,7 @@ static void cmd_crashme(BaseSequentialStream* chp, int argc, char** argv)
     // ERROR("You asked for it!, uptime=%d ms", TIME_I2MS(chVTGetSystemTime()));
 }
 
-static void cmd_reboot(BaseSequentialStream* chp, int argc, char** argv)
+SHELL_COMMAND(reboot, chp, argc, argv)
 {
     (void)argv;
     (void)argc;
@@ -179,7 +180,7 @@ static void cmd_reboot(BaseSequentialStream* chp, int argc, char** argv)
     NVIC_SystemReset();
 }
 
-static void cmd_time(BaseSequentialStream* chp, int argc, char** argv)
+SHELL_COMMAND(time, chp, argc, argv)
 {
     (void)argv;
     (void)argc;
@@ -263,7 +264,7 @@ static void show_config_tree(BaseSequentialStream* out, parameter_namespace_t* n
     }
 }
 
-static void cmd_config_tree(BaseSequentialStream* chp, int argc, char** argv)
+SHELL_COMMAND(config_tree, chp, argc, argv)
 {
     parameter_namespace_t* ns;
     if (argc != 1) {
@@ -286,7 +287,7 @@ static void cmd_config_tree(BaseSequentialStream* chp, int argc, char** argv)
     show_config_tree(chp, ns, 0);
 }
 
-static void cmd_config_set(BaseSequentialStream* chp, int argc, char** argv)
+SHELL_COMMAND(config_set, chp, argc, argv)
 {
     parameter_t* param;
     int value_i;
@@ -345,7 +346,7 @@ static void cmd_config_set(BaseSequentialStream* chp, int argc, char** argv)
     }
 }
 
-static void cmd_node(BaseSequentialStream* chp, int argc, char** argv)
+SHELL_COMMAND(node, chp, argc, argv)
 {
     if (argc != 1) {
         chprintf(chp, "usage: node node_name.\r\n");
@@ -366,7 +367,7 @@ static void cmd_node(BaseSequentialStream* chp, int argc, char** argv)
     }
 }
 
-static void cmd_topics(BaseSequentialStream* chp, int argc, char* argv[])
+SHELL_COMMAND(topics, chp, argc, argv)
 {
     (void)argc;
     (void)argv;
@@ -378,7 +379,7 @@ static void cmd_topics(BaseSequentialStream* chp, int argc, char* argv[])
     }
 }
 
-static void cmd_encoders(BaseSequentialStream* chp, int argc, char* argv[])
+SHELL_COMMAND(encoders, chp, argc, argv)
 {
     (void)argc;
     (void)argv;
@@ -392,7 +393,8 @@ static void cmd_encoders(BaseSequentialStream* chp, int argc, char* argv[])
     chprintf(chp, "left: %ld\r\nright: %ld\r\n", values.left, values.right);
 }
 
-static void cmd_position(BaseSequentialStream* chp, int argc, char* argv[])
+/* position */
+SHELL_COMMAND(pos, chp, argc, argv)
 {
     (void)argc;
     (void)argv;
@@ -406,7 +408,8 @@ static void cmd_position(BaseSequentialStream* chp, int argc, char* argv[])
     chprintf(chp, "x: %f [mm]\r\ny: %f [mm]\r\na: %f [rad]\r\n", x, y, a);
 }
 
-static void cmd_position_reset(BaseSequentialStream* chp, int argc, char* argv[])
+/* position_reset */
+SHELL_COMMAND(pos_reset, chp, argc, argv)
 {
     if (argc == 3) {
         float x = atof(argv[0]);
@@ -421,7 +424,8 @@ static void cmd_position_reset(BaseSequentialStream* chp, int argc, char* argv[]
     }
 }
 
-static void cmd_ally_position(BaseSequentialStream* chp, int argc, char* argv[])
+/* ally_position */
+SHELL_COMMAND(ally_pos, chp, argc, argv)
 {
     (void)argc;
     (void)argv;
@@ -443,7 +447,8 @@ static void cmd_ally_position(BaseSequentialStream* chp, int argc, char* argv[])
     }
 }
 
-static void cmd_traj_forward(BaseSequentialStream* chp, int argc, char* argv[])
+/* traj_forward */
+SHELL_COMMAND(forward, chp, argc, argv)
 {
     if (argc == 1) {
         robot.mode = BOARD_MODE_ANGLE_DISTANCE;
@@ -462,7 +467,7 @@ static void cmd_traj_forward(BaseSequentialStream* chp, int argc, char* argv[])
     }
 }
 
-static void cmd_traj_rotate(BaseSequentialStream* chp, int argc, char* argv[])
+SHELL_COMMAND(rotate, chp, argc, argv)
 {
     if (argc == 1) {
         robot.mode = BOARD_MODE_ANGLE_DISTANCE;
@@ -477,7 +482,8 @@ static void cmd_traj_rotate(BaseSequentialStream* chp, int argc, char* argv[])
     }
 }
 
-static void cmd_traj_goto(BaseSequentialStream* chp, int argc, char* argv[])
+/* traj_goto */
+SHELL_COMMAND(goto, chp, argc, argv)
 {
     if (argc == 3) {
         int32_t x, y, a;
@@ -492,7 +498,7 @@ static void cmd_traj_goto(BaseSequentialStream* chp, int argc, char* argv[])
     }
 }
 
-static void cmd_goto_avoid(BaseSequentialStream* chp, int argc, char* argv[])
+SHELL_COMMAND(goto_avoid, chp, argc, argv)
 {
     if (argc == 3) {
         int32_t x = atoi(argv[0]);
@@ -505,7 +511,7 @@ static void cmd_goto_avoid(BaseSequentialStream* chp, int argc, char* argv[])
     }
 }
 
-static void cmd_pid(BaseSequentialStream* chp, int argc, char* argv[])
+SHELL_COMMAND(pid, chp, argc, argv)
 {
     if (argc == 2) {
         float kp, ki, kd, ilim;
@@ -534,7 +540,7 @@ static void cmd_pid(BaseSequentialStream* chp, int argc, char* argv[])
     }
 }
 
-static void cmd_pid_tune(BaseSequentialStream* chp, int argc, char* argv[])
+SHELL_COMMAND(pid_tune, chp, argc, argv)
 {
     (void)argc;
     (void)argv;
@@ -634,7 +640,8 @@ static void cmd_pid_tune(BaseSequentialStream* chp, int argc, char* argv[])
     }
 }
 
-static void cmd_blocking_detection_config(BaseSequentialStream* chp, int argc, char* argv[])
+/* blocking_detection_config */
+SHELL_COMMAND(bdconf, chp, argc, argv)
 {
     if (argc == 3) {
         uint32_t err_th = atoi(argv[1]);
@@ -649,7 +656,8 @@ static void cmd_blocking_detection_config(BaseSequentialStream* chp, int argc, c
     }
 }
 
-static void cmd_wheel_calibration(BaseSequentialStream* chp, int argc, char* argv[])
+/* wheel_calibration */
+SHELL_COMMAND(wheel_calib, chp, argc, argv)
 {
     int count;
     if (argc < 1) {
@@ -719,7 +727,8 @@ static void cmd_wheel_calibration(BaseSequentialStream* chp, int argc, char* arg
     chprintf(chp, "New wheel correction factors set\r\n");
 }
 
-static void cmd_track_calibration(BaseSequentialStream* chp, int argc, char* argv[])
+/* track_calibration */
+SHELL_COMMAND(track_calib, chp, argc, argv)
 {
     int count;
     if (argc < 1) {
@@ -774,7 +783,7 @@ static void cmd_track_calibration(BaseSequentialStream* chp, int argc, char* arg
     chprintf(chp, "New track set\r\n");
 }
 
-static void cmd_autopos(BaseSequentialStream* chp, int argc, char* argv[])
+SHELL_COMMAND(autopos, chp, argc, argv)
 {
     if (argc < 4) {
         chprintf(chp, "Usage: autopos {yellow|violet} x y a\r\n");
@@ -800,7 +809,7 @@ static void cmd_autopos(BaseSequentialStream* chp, int argc, char* argv[])
     strategy_auto_position(x, y, a, color);
 }
 
-static void cmd_motors(BaseSequentialStream* chp, int argc, char* argv[])
+SHELL_COMMAND(motors, chp, argc, argv)
 {
     (void)argc;
     (void)argv;
@@ -813,7 +822,7 @@ static void cmd_motors(BaseSequentialStream* chp, int argc, char* argv[])
     }
 }
 
-static void cmd_motor_pos(BaseSequentialStream* chp, int argc, char* argv[])
+SHELL_COMMAND(motor_pos, chp, argc, argv)
 {
     if (argc < 2) {
         chprintf(chp, "Usage: motor_pos motor_name position\r\n");
@@ -824,7 +833,7 @@ static void cmd_motor_pos(BaseSequentialStream* chp, int argc, char* argv[])
     motor_manager_set_position(&motor_manager, argv[0], position);
 }
 
-static void cmd_motor_voltage(BaseSequentialStream* chp, int argc, char* argv[])
+SHELL_COMMAND(motor_voltage, chp, argc, argv)
 {
     if (argc < 2) {
         chprintf(chp, "Usage: motor_voltage motor_name voltage\r\n");
@@ -835,7 +844,7 @@ static void cmd_motor_voltage(BaseSequentialStream* chp, int argc, char* argv[])
     motor_manager_set_voltage(&motor_manager, argv[0], voltage);
 }
 
-static void cmd_motor_index_sym(BaseSequentialStream* chp, int argc, char* argv[])
+SHELL_COMMAND(motor_index_sym, chp, argc, argv)
 {
     if (argc < 3) {
         chprintf(chp, "Usage: motor_index_sym motor_name direction speed\r\n");
@@ -856,7 +865,7 @@ static void cmd_motor_index_sym(BaseSequentialStream* chp, int argc, char* argv[
     chprintf(chp, "Average index is %.4f\r\n", index);
 }
 
-static void cmd_motor_index(BaseSequentialStream* chp, int argc, char* argv[])
+SHELL_COMMAND(motor_index, chp, argc, argv)
 {
     if (argc < 3) {
         chprintf(chp, "Usage: motor_index motor_name direction speed\r\n");
@@ -871,7 +880,8 @@ static void cmd_motor_index(BaseSequentialStream* chp, int argc, char* argv[])
     chprintf(chp, "Index at %.4f\r\n", index);
 }
 
-static void cmd_arm_index(BaseSequentialStream* chp, int argc, char* argv[])
+/* arm_index */
+SHELL_COMMAND(index, chp, argc, argv)
 {
     if (argc < 4) {
         chprintf(chp, "Usage: index left|right t1 t2 t3\r\n");
@@ -897,7 +907,8 @@ static void cmd_arm_index(BaseSequentialStream* chp, int argc, char* argv[])
     }
 }
 
-static void cmd_arm_index_manual(BaseSequentialStream* chp, int argc, char* argv[])
+/* arm_index_manual */
+SHELL_COMMAND(index_manual, chp, argc, argv)
 {
     if (argc < 1) {
         chprintf(chp, "Usage: index_manual left|right\r\n");
@@ -945,7 +956,7 @@ static void cmd_arm_index_manual(BaseSequentialStream* chp, int argc, char* argv
     }
 }
 
-static void cmd_base_mode(BaseSequentialStream* chp, int argc, char* argv[])
+SHELL_COMMAND(base_mode, chp, argc, argv)
 {
     if (argc != 1) {
         chprintf(chp, "Usage: base_mode {all,angle,distance,free}\r\n");
@@ -963,7 +974,7 @@ static void cmd_base_mode(BaseSequentialStream* chp, int argc, char* argv[])
     }
 }
 
-static void cmd_state(BaseSequentialStream* chp, int argc, char* argv[])
+SHELL_COMMAND(state, chp, argc, argv)
 {
     (void)argc;
     (void)argv;
@@ -983,7 +994,7 @@ static void print_fn(void* arg, const char* fmt, ...)
     va_end(ap);
 }
 
-static void cmd_trace(BaseSequentialStream* chp, int argc, char* argv[])
+SHELL_COMMAND(trace, chp, argc, argv)
 {
     if (argc != 1) {
         chprintf(chp, "Usage: trace dump|clear\r\n");
@@ -996,7 +1007,7 @@ static void cmd_trace(BaseSequentialStream* chp, int argc, char* argv[])
     }
 }
 
-static void cmd_servo(BaseSequentialStream* chp, int argc, char* argv[])
+SHELL_COMMAND(servo, chp, argc, argv)
 {
     if (argc != 2) {
         chprintf(chp, "Usage: servo N PULSE_MS\r\n");
@@ -1010,7 +1021,7 @@ static void cmd_servo(BaseSequentialStream* chp, int argc, char* argv[])
 
 #include "can/can_io_driver.h"
 
-static void cmd_canio(BaseSequentialStream* chp, int argc, char* argv[])
+SHELL_COMMAND(canio, chp, argc, argv)
 {
     if (argc != 3) {
         chprintf(chp, "Usage: canio name channel pwm\r\n");
@@ -1023,7 +1034,7 @@ static void cmd_canio(BaseSequentialStream* chp, int argc, char* argv[])
     chprintf(chp, "Set CAN-IO %s Channel %d PWM %f\r\n", argv[0], channel, pwm);
 }
 
-static void cmd_motor_sin(BaseSequentialStream* chp, int argc, char* argv[])
+SHELL_COMMAND(motor_sin, chp, argc, argv)
 {
     if (argc != 4) {
         chprintf(chp, "Usage: motor_sin motor amplitude period times\r\n");
@@ -1045,7 +1056,7 @@ static void cmd_motor_sin(BaseSequentialStream* chp, int argc, char* argv[])
     }
 }
 
-static void cmd_speed(BaseSequentialStream* chp, int argc, char* argv[])
+SHELL_COMMAND(speed, chp, argc, argv)
 {
     if (argc != 1) {
         chprintf(chp, "Usage: speed init|slow|fast\r\n");
@@ -1063,7 +1074,8 @@ static void cmd_speed(BaseSequentialStream* chp, int argc, char* argv[])
     }
 }
 
-static void cmd_panel_status(BaseSequentialStream* chp, int argc, char* argv[])
+/* panel_status */
+SHELL_COMMAND(panel, chp, argc, argv)
 {
     (void)argc;
     (void)argv;
@@ -1086,7 +1098,8 @@ static void cmd_panel_status(BaseSequentialStream* chp, int argc, char* argv[])
     }
 }
 
-static void cmd_proximity_beacon(BaseSequentialStream* chp, int argc, char* argv[])
+/* proximity_beacon */
+SHELL_COMMAND(beacon, chp, argc, argv)
 {
     (void)argc;
     (void)argv;
@@ -1100,7 +1113,7 @@ static void cmd_proximity_beacon(BaseSequentialStream* chp, int argc, char* argv
              beacon_signal.range.angle * (180.f / 3.1415f));
 }
 
-static void cmd_beacon_calib(BaseSequentialStream* chp, int argc, char* argv[])
+SHELL_COMMAND(beacon_calib, chp, argc, argv)
 {
     (void)argc;
     (void)argv;
@@ -1147,7 +1160,7 @@ static void cmd_beacon_calib(BaseSequentialStream* chp, int argc, char* argv[])
     }
 }
 
-static void cmd_arm(BaseSequentialStream* chp, int argc, char* argv[])
+SHELL_COMMAND(arm, chp, argc, argv)
 {
     float angles[3];
 
@@ -1237,7 +1250,8 @@ static void cmd_arm(BaseSequentialStream* chp, int argc, char* argv[])
     }
 }
 
-static void cmd_arm_offset_calib(BaseSequentialStream* chp, int argc, char* argv[])
+/* arm_offset_calib */
+SHELL_COMMAND(arm_calib, chp, argc, argv)
 {
     if (argc != 4) {
         chprintf(chp, "Usage: arm_calib l|r d1[mm] d2[mm] d3[mm]\r\n");
@@ -1308,7 +1322,7 @@ static void cmd_arm_offset_calib(BaseSequentialStream* chp, int argc, char* argv
     chprintf(chp, "After correction, the bot thinks the angles are %.3f %.3f %.3f\r\n", angles[0], angles[1], angles[2]);
 }
 
-static void cmd_grip(BaseSequentialStream* chp, int argc, char* argv[])
+SHELL_COMMAND(grip, chp, argc, argv)
 {
     if (argc != 2) {
         chprintf(chp, "Usage: grip l|r -1|0|1\r\n");
@@ -1349,7 +1363,7 @@ static void cmd_grip(BaseSequentialStream* chp, int argc, char* argv[])
     }
 }
 
-static void cmd_electron(BaseSequentialStream* chp, int argc, char* argv[])
+SHELL_COMMAND(electron, chp, argc, argv)
 {
     (void)chp;
     (void)argc;
@@ -1362,7 +1376,7 @@ static void simulation_logger(const char* msg)
     chprintf((BaseSequentialStream*)&SDU1, "%s\r\n", msg);
 }
 
-static void cmd_goal(BaseSequentialStream* chp, int argc, char* argv[])
+SHELL_COMMAND(goal, chp, argc, argv)
 {
     static char line[20];
     RobotState state = initial_state();
@@ -1443,52 +1457,3 @@ static void cmd_goal(BaseSequentialStream* chp, int argc, char* argv[])
         }
     }
 }
-
-ShellCommand commands[] = {
-    {"crashme", cmd_crashme},
-    {"config_tree", cmd_config_tree},
-    {"config_set", cmd_config_set},
-    {"encoders", cmd_encoders},
-    {"forward", cmd_traj_forward},
-    {"ip", cmd_ip},
-    {"node", cmd_node},
-    {"pos", cmd_position},
-    {"pos_reset", cmd_position_reset},
-    {"ally_pos", cmd_ally_position},
-    {"reboot", cmd_reboot},
-    {"rotate", cmd_traj_rotate},
-    {"threads", cmd_threads},
-    {"stack", cmd_stack},
-    {"time", cmd_time},
-    {"topics", cmd_topics},
-    {"pid", cmd_pid},
-    {"pid_tune", cmd_pid_tune},
-    {"goto", cmd_traj_goto},
-    {"goto_avoid", cmd_goto_avoid},
-    {"bdconf", cmd_blocking_detection_config},
-    {"wheel_calib", cmd_wheel_calibration},
-    {"track_calib", cmd_track_calibration},
-    {"autopos", cmd_autopos},
-    {"motor_pos", cmd_motor_pos},
-    {"motor_voltage", cmd_motor_voltage},
-    {"motor_index", cmd_motor_index},
-    {"motor_index_sym", cmd_motor_index_sym},
-    {"index", cmd_arm_index},
-    {"index_manual", cmd_arm_index_manual},
-    {"motors", cmd_motors},
-    {"base_mode", cmd_base_mode},
-    {"state", cmd_state},
-    {"trace", cmd_trace},
-    {"servo", cmd_servo},
-    {"canio", cmd_canio},
-    {"motor_sin", cmd_motor_sin},
-    {"speed", cmd_speed},
-    {"panel", cmd_panel_status},
-    {"beacon", cmd_proximity_beacon},
-    {"beacon_calib", cmd_beacon_calib},
-    {"arm", cmd_arm},
-    {"arm_calib", cmd_arm_offset_calib},
-    {"grip", cmd_grip},
-    {"electron", cmd_electron},
-    {"goal", cmd_goal},
-    {NULL, NULL}};

--- a/master-firmware/src/shell_commands.h
+++ b/master-firmware/src/shell_commands.h
@@ -5,13 +5,13 @@
 
 /* Must define shell_commands final element */
 #define SHELL_COMMAND_END() \
-__attribute__((section(".shell_commands_end"))) \
+__attribute__((section(".shell_commands.1"))) \
 const ShellCommand __cmd_final = {NULL, NULL}
 
 #define SHELL_COMMAND(NAME, CHP, ARGC, ARGV) \
 static void __cmd_##NAME (BaseSequentialStream *, int, char *[]); \
 /* shell command list entry */ \
-__attribute__((section(".shell_commands.entry."#NAME))) \
+__attribute__((section(".shell_commands.0."#NAME))) \
 const ShellCommand __cmd_##NAME##_entry = {#NAME, __cmd_##NAME}; \
 /* shell command function */ \
 static void __cmd_##NAME (BaseSequentialStream *CHP, int ARGC, char *ARGV[])

--- a/master-firmware/src/shell_commands.h
+++ b/master-firmware/src/shell_commands.h
@@ -6,13 +6,13 @@
 /* Must define shell_commands final element */
 #define SHELL_COMMAND_END() \
 __attribute__((section(".shell_commands.1"))) \
-const ShellCommand __cmd_final = {NULL, NULL}
+ShellCommand __cmd_final = {NULL, NULL}
 
 #define SHELL_COMMAND(NAME, CHP, ARGC, ARGV) \
 static void __cmd_##NAME (BaseSequentialStream *, int, char *[]); \
 /* shell command list entry */ \
 __attribute__((section(".shell_commands.0."#NAME))) \
-const ShellCommand __cmd_##NAME##_entry = {#NAME, __cmd_##NAME}; \
+ShellCommand __cmd_##NAME##_entry = {#NAME, __cmd_##NAME}; \
 /* shell command function */ \
 static void __cmd_##NAME (BaseSequentialStream *CHP, int ARGC, char *ARGV[])
 
@@ -20,7 +20,7 @@ static void __cmd_##NAME (BaseSequentialStream *CHP, int ARGC, char *ARGV[])
 extern "C" {
 #endif
 
-extern ShellCommand _shell_commands[];
+extern ShellCommand __shell_commands_start[];
 
 #ifdef __cplusplus
 }

--- a/master-firmware/src/shell_commands.h
+++ b/master-firmware/src/shell_commands.h
@@ -1,0 +1,29 @@
+#ifndef SHELL_COMMANDS_H
+#define SHELL_COMMANDS_H
+
+#include <shell.h>
+
+/* Must define shell_commands final element */
+#define SHELL_COMMAND_END() \
+__attribute__((section(".shell_commands_end"))) \
+const ShellCommand __cmd_final = {NULL, NULL}
+
+#define SHELL_COMMAND(NAME, CHP, ARGC, ARGV) \
+static void __cmd_##NAME (BaseSequentialStream *, int, char *[]); \
+/* shell command list entry */ \
+__attribute__((section(".shell_commands.entry."#NAME))) \
+const ShellCommand __cmd_##NAME##_entry = {#NAME, __cmd_##NAME}; \
+/* shell command function */ \
+static void __cmd_##NAME (BaseSequentialStream *CHP, int ARGC, char *ARGV[])
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern ShellCommand _shell_commands[];
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SHELL_COMMANDS_H */


### PR DESCRIPTION
This PR changes the way shell commands are registered in the commands list.
Instead of manually keeping a list of available commands, one can simply define a shell command using the macro `SHELL_COMMAND(name, chp, argc, argv)`.
In addition to defining the function, the macro also defines a list entry struct placed in `.shell_commands` section located in flash.

This also allows to define a shell command anywhere in the code which helps decoupling the modules.