### PR TITLE
ci: Do not distinguish between order & chaos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,7 @@ matrix:
         - compiler: gcc
           env: BUILD_TYPE="tests"
         - compiler: gcc
-          env: BUILD_TYPE="build" PLATFORM="master-firmware" ROBOT="order"
-        - compiler: gcc
-          env: BUILD_TYPE="build" PLATFORM="master-firmware" ROBOT="chaos"
+          env: BUILD_TYPE="build" PLATFORM="master-firmware"
         - compiler: gcc
           env: BUILD_TYPE="build" PLATFORM="motor-control-firmware"
         - compiler: gcc

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -19,13 +19,6 @@ export CFLAGS="$CFLAGS -I $HOME/cpputest/include/"
 export CXXFLAGS="$CXXFLAGS -I $HOME/cpputest/include/"
 export LDFLAGS="$CXXFLAGS -L $HOME/cpputest/lib/"
 
-ROBOT_FLAG=""
-if [ -n "$ROBOT" ]
-then
-    ROBOT_FLAG="ROBOT=$ROBOT"
-fi
-
-
 case $BUILD_TYPE in
     tests)
         pushd master-firmware
@@ -59,14 +52,14 @@ case $BUILD_TYPE in
         echo "build $PLATFORM"
         pushd $PLATFORM
         packager
-        make $ROBOT_FLAG dsdlc
+        make dsdlc
 
         if [ "$PLATFORM" == "master-firmware" ]
         then
             make protoc
         fi
 
-        make $ROBOT_FLAG
+        make
         popd
         ;;
     *)


### PR DESCRIPTION
Nowadays, both robots have the same firmware and only the loaded
configuration is changed at runtime depending on the presence of a
jumper.

Fixes #234 (Travis build still distinguishes between Order and Chaos)