### PR TITLE
Add more debug info to UWB firmware (temperature and tracing)

### DIFF
--- a/uwb-beacon-firmware/package.yml
+++ b/uwb-beacon-firmware/package.yml
@@ -14,6 +14,7 @@ depends:
   - parameter_flash_storage
   - chibios-syscalls
   - trace
+  - error
 
 target.arm:
   - src/board.c
@@ -37,6 +38,7 @@ target.arm:
   - src/parameter_port.c
   - src/state_estimation_thread.cpp
   - src/anchor_position_cache.c
+  - src/log.c
 
 target.stm32f4: []
 

--- a/uwb-beacon-firmware/src/cmd.c
+++ b/uwb-beacon-firmware/src/cmd.c
@@ -126,17 +126,30 @@ static void cmd_temp(BaseSequentialStream* chp, int argc, char** argv)
     temperature_topic = messagebus_find_topic(&bus, "/imu/temperature");
 
     if (temperature_topic == NULL) {
-        chprintf(chp, "Could not find temperature topic.\r\n");
-        return;
+        chprintf(chp, "Could not find IMU temperature topic.\r\n");
+    } else {
+        if (messagebus_topic_read(temperature_topic, &msg, sizeof(msg))) {
+            chprintf(chp, "timestamp: %.3f s\r\n", msg.timestamp * 1e-6);
+            chprintf(chp, "IMU temperature: %d\r\n", (int)msg.temperature);
+        } else {
+            chprintf(chp, "No IMU temperature data available.\r\n");
+        }
     }
 
-    if (!messagebus_topic_read(temperature_topic, &msg, sizeof(msg))) {
-        chprintf(chp, "No temperature data available.\r\n");
-        return;
+    dw1000_temp_msg_t dw1000_msg;
+    temperature_topic = messagebus_find_topic(&bus, "/dw1000/temperature");
+
+    if (temperature_topic == NULL) {
+        chprintf(chp, "Could not find DW1000 temperature topic.\r\n");
+    } else {
+        if (messagebus_topic_read(temperature_topic, &dw1000_msg, sizeof(dw1000_msg))) {
+            chprintf(chp, "timestamp: %.3f s\r\n", dw1000_msg.timestamp * 1e-6);
+            chprintf(chp, "DW1000 temperature: %d\r\n", (int)dw1000_msg.temperature);
+        } else {
+            chprintf(chp, "No DW1000 temperature data available.\r\n");
+        }
     }
 
-    chprintf(chp, "timestamp: %.3f s\r\n", msg.timestamp * 1e-6);
-    chprintf(chp, "IMU temperature: %d\r\n", (int)msg.temperature);
 }
 
 static void cmd_ahrs(BaseSequentialStream* chp, int argc, char** argv)

--- a/uwb-beacon-firmware/src/cmd.c
+++ b/uwb-beacon-firmware/src/cmd.c
@@ -414,7 +414,7 @@ static void cmd_config_load(BaseSequentialStream* chp, int argc, char** argv)
     }
 }
 
-static void print_fn_foo(void* arg, const char* fmt, ...)
+static void print_fn_base_seq_stream(void* arg, const char* fmt, ...)
 {
     BaseSequentialStream* chp = (BaseSequentialStream*)arg;
     va_list ap;
@@ -428,7 +428,7 @@ static void cmd_trace(BaseSequentialStream* chp, int argc, char* argv[])
     (void)argc;
     (void)argv;
 
-    trace_print(print_fn_foo, chp);
+    trace_print(print_fn_base_seq_stream, chp);
     trace_clear();
 }
 
@@ -472,8 +472,8 @@ static void cmd_data_tx(BaseSequentialStream* chp, int argc, char* argv[])
 
 static void cmd_data_rx(BaseSequentialStream* chp, int argc, char* argv[])
 {
-    (void) argc;
-    (void) argv;
+    (void)argc;
+    (void)argv;
 
     messagebus_topic_t* topic = messagebus_find_topic(&bus, "/uwb_data");
 

--- a/uwb-beacon-firmware/src/log.c
+++ b/uwb-beacon-firmware/src/log.c
@@ -1,0 +1,87 @@
+#include <ch.h>
+#include <hal.h>
+#include <chprintf.h>
+#include <stdio.h>
+#include <string.h>
+#include <error/error.h>
+#include <parameter/parameter.h>
+#include "main.h"
+
+#include "log.h"
+#include "usbconf.h"
+
+#define OUTPUT_STREAM ((BaseSequentialStream*)&SDU1)
+
+MUTEX_DECL(log_lock);
+
+static void vuart_log_message(struct error* e, va_list args);
+static void vpanic_message(struct error* e, va_list args);
+
+static void log_message(struct error* e, ...)
+{
+    va_list va;
+
+    if (e->severity == ERROR_SEVERITY_ERROR) {
+        va_start(va, e);
+        vpanic_message(e, va);
+        va_end(va);
+    }
+
+    chMtxLock(&log_lock);
+
+    va_start(va, e);
+    vuart_log_message(e, va);
+    va_end(va);
+
+    chMtxUnlock(&log_lock);
+}
+
+static const char* get_thread_name(void)
+{
+    const char* thread_name;
+
+    thread_name = chRegGetThreadNameX(chThdGetSelfX());
+    if (thread_name == NULL) {
+        thread_name = "unknown";
+    }
+
+    return thread_name;
+}
+
+static void vuart_log_message(struct error* e, va_list args)
+{
+    /* Print time */
+    uint32_t ms = (chVTGetSystemTime() * 1000) / CH_CFG_ST_FREQUENCY;
+    chprintf(OUTPUT_STREAM, "[%06d]\t", ms);
+
+    /* Print location. */
+    chprintf(OUTPUT_STREAM, "%s:%d\t", strrchr(e->file, '/') + 1, e->line);
+
+    /* Print current thread */
+    chprintf(OUTPUT_STREAM, "%s\t", get_thread_name());
+
+    /* Print severity message */
+    chprintf(OUTPUT_STREAM, "%s\t", error_severity_get_name(e->severity));
+
+    /* Print message */
+    chvprintf(OUTPUT_STREAM, e->text, args);
+
+    chprintf(OUTPUT_STREAM, "\n");
+}
+
+static void vpanic_message(struct error* e, va_list args)
+{
+    static char buffer[256];
+    vsnprintf(buffer, sizeof(buffer), e->text, args);
+    chSysHalt(buffer);
+}
+
+void log_init(void)
+{
+    error_register_error(log_message);
+    error_register_warning(log_message);
+    error_register_notice(log_message);
+#if 0
+    error_register_debug(log_message);
+#endif
+}

--- a/uwb-beacon-firmware/src/log.h
+++ b/uwb-beacon-firmware/src/log.h
@@ -1,0 +1,14 @@
+#ifndef LOG_H
+#define LOG_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void log_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LOG_H */

--- a/uwb-beacon-firmware/src/ranging_thread.c
+++ b/uwb-beacon-firmware/src/ranging_thread.c
@@ -139,6 +139,7 @@ static void ranging_thread(void* p)
 
         if (flags & EVENT_ADVERTISE_TIMER) {
             if (!handler.is_anchor && nb_anchor_macs > 0) {
+                trace(TRACE_POINT_UWB_SEND_ADVERTISEMENT);
                 /* First disable transceiver */
                 dwt_forcetrxoff();
 

--- a/uwb-beacon-firmware/src/ranging_thread.h
+++ b/uwb-beacon-firmware/src/ranging_thread.h
@@ -37,6 +37,13 @@ typedef struct {
     uint8_t data[1024];
 } data_packet_msg_t;
 
+/** Struct used on the DWM1000 stats topics */
+typedef struct {
+    uint32_t timestamp; /**< Timestamp in us since boot. */
+    float temperature; /**< DW1000 Chip temperature in deg C */
+    float voltage; /**< Chip voltage in V */
+} dw1000_temp_msg_t;
+
 void ranging_start(void);
 
 /** Asks the ranging thread to send this data packet when possible.

--- a/uwb-beacon-firmware/src/trace_points.h
+++ b/uwb-beacon-firmware/src/trace_points.h
@@ -6,7 +6,8 @@
     C(TRACE_POINT_UWB_IRQ)                \
     C(TRACE_POINT_UWB_SEND_ADVERTISEMENT) \
     C(TRACE_POINT_UWB_TX_DONE)            \
-    C(TRACE_POINT_UWB_RX)
+    C(TRACE_POINT_UWB_RX)                 \
+    C(TRACE_POINT_UWB_PROCESS_FRAME)
 
 /* List of all trace points in numerical format. */
 #undef C

--- a/uwb-beacon-firmware/src/uwb_protocol.c
+++ b/uwb-beacon-firmware/src/uwb_protocol.c
@@ -1,5 +1,7 @@
 #include <string.h>
 #include "uwb_protocol.h"
+#include <trace/trace.h>
+#include "trace_points.h"
 
 #define MAC_802_15_4_FC_DATA_FRAME (0x1 << 0)
 #define MAC_802_15_4_FC_PAN_ID_COMPRESS (0x1 << 6)
@@ -254,6 +256,8 @@ void uwb_process_incoming_frame(uwb_protocol_handler_t* handler,
     if (dst_addr != handler->address && dst_addr != MAC_802_15_4_BROADCAST_ADDR) {
         return;
     }
+
+    trace_integer(TRACE_POINT_UWB_PROCESS_FRAME, seq_num);
 
     /* Measurement advertisement */
     if (seq_num == UWB_SEQ_NUM_ADVERTISEMENT) {

--- a/uwb-beacon-firmware/src/uwb_protocol.c
+++ b/uwb-beacon-firmware/src/uwb_protocol.c
@@ -19,7 +19,7 @@
 #define UWB_SEQ_NUM_INITIATE_MEASUREMENT 5
 #define UWB_SEQ_NUM_USER_DATA 100
 
-#define UWB_DELAY (1000 * 65536)
+#define UWB_DELAY (800 * 65536)
 #define MASK_40BIT 0xfffffffe00
 
 static void write_40bit_int(uint64_t val, uint8_t* bytes);

--- a/uwb-beacon-firmware/tests/uwb_protocol.cpp
+++ b/uwb-beacon-firmware/tests/uwb_protocol.cpp
@@ -3,7 +3,7 @@
 #include <cstring>
 #include "uwb_protocol.h"
 
-#define UWB_TX_DELAY 1000
+#define UWB_TX_DELAY 800
 
 TEST_GROUP (MACLayerTestCase) {
 };
@@ -172,7 +172,7 @@ TEST(RangingProtocol, SendAdvertisementFrame)
     size_t frame_size;
 
     // The message should be sent when the lower 9 bits are zero
-    uint64_t tx_ts = ts + (1000 * 65536ULL);
+    uint64_t tx_ts = ts + (UWB_TX_DELAY * 65536ULL);
     tx_ts &= ~(0x1FFULL);
 
     frame_size =


### PR DESCRIPTION
This pull request adds more tracing and temperature monitoring to the UWB beacon firmware. Using the tracing for tuning and putting the advertisement period at 6 ms, I was able to get 160 Hz distance measurement. Now I need to do a proper setup and test if the positioning works.

Both are tested on hardware.