### PR TITLE
Setup motor board emulator UAVCAN + Cmake

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -19,3 +19,6 @@
 [submodule "lib/nanopb/nanopb"]
 	path = lib/nanopb/nanopb
 	url = https://github.com/nanopb/nanopb
+[submodule "lib/abseil"]
+	path = lib/abseil
+	url = https://github.com/abseil/abseil-cpp.git

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This repo contains all the software used on our robots:
 - `eurobot` contains documentation and cofiguration files specific to the Eurobot competition
 - `sensor-firmware` contains code running on the [sensor board](https://www.cvra.ch/robot-software/sensor.html)
 - `uwb-beacon-firmware` contains code and documentation that runs on the [UWB beacon board](https://www.cvra.ch/robot-software/beacon.html)
+- `hitl` contains code to support Hardware In The Loop testing of the master board firmware.
 
 Other important software components can be found in this repo:
 - `lib` contains all the libraries and building blocks we use on multiple boards, which includes:

--- a/hitl/.gitignore
+++ b/hitl/.gitignore
@@ -1,0 +1,1 @@
+!CMakeLists.txt

--- a/hitl/CMakeLists.txt
+++ b/hitl/CMakeLists.txt
@@ -6,5 +6,7 @@ add_executable(motor_board_emulator
 target_link_libraries(motor_board_emulator
     uavcan
     uavcan_linux
+    absl::flags
+    absl::flags_parse
 )
 

--- a/hitl/CMakeLists.txt
+++ b/hitl/CMakeLists.txt
@@ -21,3 +21,16 @@ target_link_libraries(hitl_logging
     error
 )
 
+add_executable(voltage_injector
+    voltage_injector.cpp
+)
+
+target_link_libraries(voltage_injector
+    absl::flags
+    absl::flags_parse
+    hitl_logging
+    error
+    uavcan
+    uavcan_linux
+)
+

--- a/hitl/CMakeLists.txt
+++ b/hitl/CMakeLists.txt
@@ -1,0 +1,9 @@
+
+add_executable(motor_board_emulator
+    motor_board_emulator.cpp
+)
+
+target_link_libraries(motor_board_emulator
+    uavcan
+)
+

--- a/hitl/CMakeLists.txt
+++ b/hitl/CMakeLists.txt
@@ -5,5 +5,6 @@ add_executable(motor_board_emulator
 
 target_link_libraries(motor_board_emulator
     uavcan
+    uavcan_linux
 )
 

--- a/hitl/CMakeLists.txt
+++ b/hitl/CMakeLists.txt
@@ -1,12 +1,23 @@
-
 add_executable(motor_board_emulator
     motor_board_emulator.cpp
 )
 
 target_link_libraries(motor_board_emulator
-    uavcan
-    uavcan_linux
     absl::flags
     absl::flags_parse
+    hitl_logging
+    error
+    uavcan
+    uavcan_linux
+)
+
+add_library(hitl_logging
+    logging.cpp
+    logging.h
+)
+
+target_link_libraries(hitl_logging
+    absl::flags
+    error
 )
 

--- a/hitl/README.md
+++ b/hitl/README.md
@@ -1,0 +1,12 @@
+# Hardware in the loop
+
+## Building
+
+From the root of the project (robot-software), **NOT** from this directory, run the following:
+
+```
+mkdir build
+cd build
+cmake ..
+make
+```

--- a/hitl/README.md
+++ b/hitl/README.md
@@ -1,5 +1,14 @@
 # Hardware in the loop
 
+# Requirements
+
+* SocketCAN for the parts that emulate a board.
+    That means those binaries can only be used on Linux.
+* gRPC for inter process communication.
+    This was testing with version 1.24.1.
+    See [the quick start guide](https://grpc.io/docs/quickstart/cpp/) for explanations.
+* Protoc version 3 or more.
+
 ## Building
 
 From the root of the project (robot-software), **NOT** from this directory, run the following:
@@ -10,3 +19,16 @@ cd build
 cmake ..
 make
 ```
+
+## Adding a virtual SocketCAN interface
+
+```bash
+lib/uavcan/libuavcan_drivers/linux/scripts/uavcan_add_vcan vcan0
+
+# check its existence
+ip link show dev vcan0
+
+# to delete it
+ip link delete vcan0
+```
+

--- a/hitl/logging.cpp
+++ b/hitl/logging.cpp
@@ -2,16 +2,24 @@
 #include <cstdarg>
 #include "error/error.h"
 #include "absl/flags/flag.h"
+#include "absl/synchronization/mutex.h"
 
 ABSL_FLAG(bool, verbose, false, "Enable verbose logging.");
+static ABSL_CONST_INIT absl::Mutex logging_lock(absl::kConstInit);
 
 static void log_message(struct error* e, ...)
 {
+    absl::MutexLock l(&logging_lock);
     va_list va;
     va_start(va, e);
     printf("%s ", error_severity_get_name(e->severity));
     vprintf(e->text, va);
+    printf("\n");
     va_end(va);
+
+    if (e->severity == ERROR_SEVERITY_ERROR) {
+        exit(1);
+    }
 }
 
 void logging_init()

--- a/hitl/logging.cpp
+++ b/hitl/logging.cpp
@@ -1,0 +1,26 @@
+#include <cstdio>
+#include <cstdarg>
+#include "error/error.h"
+#include "absl/flags/flag.h"
+
+ABSL_FLAG(bool, verbose, false, "Enable verbose logging.");
+
+static void log_message(struct error* e, ...)
+{
+    va_list va;
+    va_start(va, e);
+    printf("%s ", error_severity_get_name(e->severity));
+    vprintf(e->text, va);
+    va_end(va);
+}
+
+void logging_init()
+{
+    error_register_error(log_message);
+    error_register_warning(log_message);
+    error_register_notice(log_message);
+
+    if (absl::GetFlag(FLAGS_verbose)) {
+        error_register_debug(log_message);
+    }
+}

--- a/hitl/logging.h
+++ b/hitl/logging.h
@@ -1,0 +1,3 @@
+#pragma once
+
+void logging_init();

--- a/hitl/motor_board_emulator.cpp
+++ b/hitl/motor_board_emulator.cpp
@@ -1,7 +1,49 @@
 #include <cvra/motor/EmergencyStop.hpp>
+#include <uavcan_linux/uavcan_linux.hpp>
 
-int main(void)
+constexpr unsigned NodeMemoryPoolSize = 16384;
+
+typedef uavcan::Node<NodeMemoryPoolSize> Node;
+
+uavcan::ISystemClock& getSystemClock();
+uavcan::ICanDriver& getCanDriver();
+
+int main(int argc, char** argv)
 {
-    cvra::motor::EmergencyStop foo;
+    Node node(getCanDriver(), getSystemClock());
+    node.setNodeID(42);
+    node.setName("ch.cvra.motor-board-emulator");
+
+    node.start();
+
+    while (true) {
+        /*
+         * If there's nothing to do, the thread blocks inside the driver's
+         * method select() until the timeout expires or an error occurs (e.g. driver failure).
+         * All error codes are listed in the header uavcan/error.hpp.
+         */
+        const int res = node.spin(uavcan::MonotonicDuration::fromMSec(1000));
+        if (res < 0) {
+            std::cerr << "Transient failure: " << res << std::endl;
+        }
+    }
+
     return 0;
+}
+
+uavcan::ISystemClock& getSystemClock()
+{
+    static uavcan_linux::SystemClock clock;
+    return clock;
+}
+
+uavcan::ICanDriver& getCanDriver()
+{
+    static uavcan_linux::SocketCanDriver driver(dynamic_cast<const uavcan_linux::SystemClock&>(getSystemClock()));
+    if (driver.getNumIfaces() == 0) {
+        if (driver.addIface("vcan0") < 0) {
+            throw std::runtime_error("Failed to add iface");
+        }
+    }
+    return driver;
 }

--- a/hitl/motor_board_emulator.cpp
+++ b/hitl/motor_board_emulator.cpp
@@ -3,6 +3,7 @@
 #include "absl/flags/flag.h"
 #include "absl/flags/parse.h"
 #include "absl/flags/usage.h"
+#include "logging.h"
 
 constexpr unsigned NodeMemoryPoolSize = 16384;
 
@@ -19,6 +20,7 @@ int main(int argc, char** argv)
     absl::SetProgramUsageMessage("Emulates one of CVRA "
                                  "motor control board over UAVCAN");
     absl::ParseCommandLine(argc, argv);
+    logging_init();
 
     Node node(getCanDriver(), getSystemClock());
 

--- a/hitl/motor_board_emulator.cpp
+++ b/hitl/motor_board_emulator.cpp
@@ -1,0 +1,7 @@
+#include <cvra/motor/EmergencyStop.hpp>
+
+int main(void)
+{
+    cvra::motor::EmergencyStop foo;
+    return 0;
+}

--- a/hitl/motor_board_emulator.cpp
+++ b/hitl/motor_board_emulator.cpp
@@ -1,19 +1,49 @@
 #include <cvra/motor/EmergencyStop.hpp>
 #include <uavcan_linux/uavcan_linux.hpp>
+#include <thread>
+#include <vector>
 #include "absl/flags/flag.h"
 #include "absl/flags/parse.h"
 #include "absl/flags/usage.h"
+#include "error/error.h"
 #include "logging.h"
 
 constexpr unsigned NodeMemoryPoolSize = 16384;
 
 typedef uavcan::Node<NodeMemoryPoolSize> Node;
 
-ABSL_FLAG(int, uavcan_id, 42, "UAVCAN ID of this instance");
-ABSL_FLAG(std::string, uavcan_name, "example-board", "UAVCAN board name of this instance");
+ABSL_FLAG(int, first_uavcan_id, 42, "UAVCAN ID of the first board."
+                                    " Subsequent ones will be incremented by 1 each.");
+ABSL_FLAG(std::vector<std::string>, uavcan_names, {"example-board"}, "Comma separated list of motor boards to emulate.");
+ABSL_FLAG(std::string, can_iface, "vcan0", "SocketCAN interface to connect the emulation to");
 
 uavcan::ISystemClock& getSystemClock();
 uavcan::ICanDriver& getCanDriver();
+
+void node_thread(int id, std::string board_name)
+{
+    NOTICE("Starting CAN thread for '%s'", board_name.c_str());
+    uavcan_linux::SystemClock clock;
+    uavcan_linux::SocketCanDriver driver(clock);
+
+    auto iface = absl::GetFlag(FLAGS_can_iface).c_str();
+    if (driver.addIface(iface) < 0) {
+        ERROR("Failed to add iface %s", iface);
+    }
+
+    Node node(driver, clock);
+    node.setNodeID(id);
+    node.setName(board_name.c_str());
+
+    node.start();
+
+    while (true) {
+        const int res = node.spin(uavcan::MonotonicDuration::fromMSec(1000));
+        if (res < 0) {
+            WARNING("UAVCAN failure (%s): %d", board_name.c_str(), res);
+        }
+    }
+}
 
 int main(int argc, char** argv)
 {
@@ -22,36 +52,19 @@ int main(int argc, char** argv)
     absl::ParseCommandLine(argc, argv);
     logging_init();
 
-    Node node(getCanDriver(), getSystemClock());
+    int n = absl::GetFlag(FLAGS_first_uavcan_id);
 
-    node.setNodeID(absl::GetFlag(FLAGS_uavcan_id));
-    node.setName(absl::GetFlag(FLAGS_uavcan_name).c_str());
+    std::vector<std::thread> threads;
 
-    node.start();
+    for (auto& name : absl::GetFlag(FLAGS_uavcan_names)) {
+        std::thread t(node_thread, n, name);
+        threads.push_back(std::move(t));
+        n++;
+    }
 
-    while (true) {
-        const int res = node.spin(uavcan::MonotonicDuration::fromMSec(1000));
-        if (res < 0) {
-            std::cerr << "Transient failure: " << res << std::endl;
-        }
+    for (auto& thread : threads) {
+        thread.join();
     }
 
     return 0;
-}
-
-uavcan::ISystemClock& getSystemClock()
-{
-    static uavcan_linux::SystemClock clock;
-    return clock;
-}
-
-uavcan::ICanDriver& getCanDriver()
-{
-    static uavcan_linux::SocketCanDriver driver(dynamic_cast<const uavcan_linux::SystemClock&>(getSystemClock()));
-    if (driver.getNumIfaces() == 0) {
-        if (driver.addIface("vcan0") < 0) {
-            throw std::runtime_error("Failed to add iface");
-        }
-    }
-    return driver;
 }

--- a/hitl/voltage_injector.cpp
+++ b/hitl/voltage_injector.cpp
@@ -1,0 +1,48 @@
+#include <cvra/motor/control/Voltage.hpp>
+#include <uavcan_linux/uavcan_linux.hpp>
+#include "absl/flags/flag.h"
+#include "absl/flags/parse.h"
+#include "absl/flags/usage.h"
+#include "error/error.h"
+#include "logging.h"
+
+typedef uavcan::Node<16384> Node;
+
+ABSL_FLAG(int, uavcan_id, 10, "UAVCAN ID to use");
+ABSL_FLAG(int, dst_id, 42, "ID of the board to which send messages");
+ABSL_FLAG(std::string, can_iface, "vcan0", "SocketCAN interface to connect the emulation to");
+
+int main(int argc, char** argv)
+{
+    absl::SetProgramUsageMessage("Sends a voltage setpoint");
+    absl::ParseCommandLine(argc, argv);
+    logging_init();
+
+    uavcan_linux::SystemClock clock;
+    uavcan_linux::SocketCanDriver driver(clock);
+
+    driver.addIface(absl::GetFlag(FLAGS_can_iface).c_str());
+
+    Node node(driver, clock);
+
+    node.setNodeID(absl::GetFlag(FLAGS_uavcan_id));
+    node.setName("ch.cvra.hitl.voltage_injector");
+    node.setHealthOk();
+    node.setModeOperational();
+
+    node.start();
+
+    uavcan::Publisher<cvra::motor::control::Voltage> pub(node);
+    auto res = pub.init();
+    if (res < 0) {
+        ERROR("Could not init publisher (error %d)", res);
+    }
+
+    while (true) {
+        cvra::motor::control::Voltage voltage;
+        voltage.voltage = 12.;
+        voltage.node_id = absl::GetFlag(FLAGS_dst_id);
+        pub.broadcast(voltage);
+        node.spin(uavcan::MonotonicDuration::fromMSec(1000));
+    }
+}

--- a/lib/.gitignore
+++ b/lib/.gitignore
@@ -1,0 +1,1 @@
+!CMakeLists.txt

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,0 +1,75 @@
+set(DSDLC_INPUTS uavcan/dsdl/uavcan ../uavcan_data_types/cvra)
+set(DSDLC_OUTPUT ${CMAKE_BINARY_DIR}/dsdlc_generated)
+
+# Build list of UAVCAN inputs and outputs
+execute_process(
+    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/list_uavcan_dsdl.py ${DSDLC_INPUTS}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    OUTPUT_VARIABLE UAVCAN_FILES
+    RESULT_VARIABLE RETURN_VALUE
+)
+if (NOT RETURN_VALUE EQUAL 0)
+    message(FATAL_ERROR "Failed to get the dependencies (error ${RETURN_VALUE})")
+endif()
+
+execute_process(
+    COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/list_uavcan_dsdl.py ${DSDLC_INPUTS} --output-dir ${DSDLC_OUTPUT}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    OUTPUT_VARIABLE UAVCAN_HEADERS
+    RESULT_VARIABLE RETURN_VALUE
+)
+if (NOT RETURN_VALUE EQUAL 0)
+    message(FATAL_ERROR "Failed to get the dependencies (error ${RETURN_VALUE})")
+endif()
+
+message(STATUS "Found the following UAVCAN files...")
+foreach(F ${UAVCAN_FILES})
+    message(STATUS ${F})
+endforeach()
+
+message(STATUS "Which generate the following headers...")
+foreach(F ${UAVCAN_HEADERS})
+    message(STATUS ${F})
+endforeach()
+
+
+add_custom_command(COMMAND ${PYTHON} uavcan/libuavcan/dsdl_compiler/libuavcan_dsdlc ${DSDLC_INPUTS} -O${DSDLC_OUTPUT}
+    OUTPUT ${UAVCAN_HEADERS}
+    DEPENDS ${UAVCAN_FILES}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    COMMENT "Running dsdl compiler")
+
+add_library(uavcan
+    uavcan/libuavcan/src/driver/uc_can.cpp
+    uavcan/libuavcan/src/marshal/uc_bit_array_copy.cpp
+    uavcan/libuavcan/src/marshal/uc_bit_stream.cpp
+    uavcan/libuavcan/src/marshal/uc_float_spec.cpp
+    uavcan/libuavcan/src/marshal/uc_scalar_codec.cpp
+    uavcan/libuavcan/src/node/uc_generic_publisher.cpp
+    uavcan/libuavcan/src/node/uc_generic_subscriber.cpp
+    uavcan/libuavcan/src/node/uc_global_data_type_registry.cpp
+    uavcan/libuavcan/src/node/uc_scheduler.cpp
+    uavcan/libuavcan/src/node/uc_service_client.cpp
+    uavcan/libuavcan/src/node/uc_timer.cpp
+    uavcan/libuavcan/src/protocol/uc_dynamic_node_id_client.cpp
+    uavcan/libuavcan/src/protocol/uc_node_status_provider.cpp
+    uavcan/libuavcan/src/transport/uc_can_acceptance_filter_configurator.cpp
+    uavcan/libuavcan/src/transport/uc_can_io.cpp
+    uavcan/libuavcan/src/transport/uc_crc.cpp
+    uavcan/libuavcan/src/transport/uc_dispatcher.cpp
+    uavcan/libuavcan/src/transport/uc_frame.cpp
+    uavcan/libuavcan/src/transport/uc_outgoing_transfer_registry.cpp
+    uavcan/libuavcan/src/transport/uc_transfer.cpp
+    uavcan/libuavcan/src/transport/uc_transfer_buffer.cpp
+    uavcan/libuavcan/src/transport/uc_transfer_listener.cpp
+    uavcan/libuavcan/src/transport/uc_transfer_receiver.cpp
+    uavcan/libuavcan/src/transport/uc_transfer_sender.cpp
+    uavcan/libuavcan/src/uc_data_type.cpp
+    uavcan/libuavcan/src/uc_dynamic_memory.cpp
+    uavcan/libuavcan/src/uc_error.cpp
+    ${UAVCAN_HEADERS}
+)
+
+target_include_directories(uavcan PUBLIC uavcan/libuavcan/include)
+target_compile_definitions(uavcan PUBLIC "UAVCAN_CPP_VERSION=UAVCAN_CPP11;UAVCAN_TOSTRING=0;UAVCAN_DEBUG=0")
+target_include_directories(uavcan PUBLIC ${DSDLC_OUTPUT})

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,3 +1,7 @@
+add_subdirectory(abseil)
+
+# UAVCAN stuff
+
 set(DSDLC_INPUTS uavcan/dsdl/uavcan ../uavcan_data_types/cvra)
 set(DSDLC_OUTPUT ${CMAKE_BINARY_DIR}/dsdlc_generated)
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -1,5 +1,12 @@
 add_subdirectory(abseil)
 
+add_library(error
+    error/error.c
+    error/error.h
+)
+
+target_include_directories(error PUBLIC .)
+
 # UAVCAN stuff
 
 set(DSDLC_INPUTS uavcan/dsdl/uavcan ../uavcan_data_types/cvra)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -73,3 +73,6 @@ add_library(uavcan
 target_include_directories(uavcan PUBLIC uavcan/libuavcan/include)
 target_compile_definitions(uavcan PUBLIC "UAVCAN_CPP_VERSION=UAVCAN_CPP11;UAVCAN_TOSTRING=0;UAVCAN_DEBUG=0")
 target_include_directories(uavcan PUBLIC ${DSDLC_OUTPUT})
+
+add_library(uavcan_linux INTERFACE)
+target_include_directories(uavcan_linux INTERFACE uavcan/libuavcan_drivers/linux/include/)

--- a/lib/list_uavcan_dsdl.py
+++ b/lib/list_uavcan_dsdl.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""
+Lists all the UAVCAN files in a format compatible with CMake (column separated
+data).
+
+It is intended to be handled as part of the build, not be used interactively.
+"""
+
+import argparse
+import glob
+import os.path
+import re
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-dir", help="Generate list of outputs")
+    parser.add_argument("dsdl_dirs", help="Files containing dsdl definitions", nargs="+")
+
+    return parser.parse_args()
+
+def output_file(input_path: str, input_dir: str, output_path: str) -> str:
+    """
+    Converts an input path to an output DSDLC path
+
+    >>> output_file('foo/uavcan_data_types/cvra/20001.Reboot.uavcan', 'foo/uavcan_data_types/cvra', 'dsdlc_generated')
+    'dsdlc_generated/cvra/Reboot.hpp'
+    """
+    input_dir = os.path.join(*input_dir.split('/')[:-1])
+
+    path = input_path.replace(input_dir, '')
+    path = path.split('/', maxsplit=1)
+
+    # Change the extension
+    path[-1] = path[-1].replace('.uavcan', '.hpp')
+    path[-1] = re.sub(r'[0-9]+\.', '', path[-1])
+
+    return os.path.join(output_path, *path)
+
+
+def main():
+    args = parse_args()
+
+    input_files = []
+    output_files = []
+
+    for d in args.dsdl_dirs:
+        files = glob.glob(os.path.join(d, '**/**.uavcan'), recursive=True)
+
+        input_files += files
+
+        if args.output_dir:
+            output_files += [output_file(i, d, args.output_dir) for i in files]
+
+    if args.output_dir:
+        print(output_files[0], end='')
+    else:
+        print(";".join(os.path.abspath(p) for p in input_files), end='')
+
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This pull request set ups the base project for our simulation idea. It spins up a single node, giving it a CAN id and a CAN name based on the commandline flags.

It adds a dependency on Abseil, which I like as a stdlib extension after using it at work, but maybe we should discuss whether or not we are ok with this dependency.

We will most likely review this during the next software call.

Fixes issue #240 

Tested manually by running it on a virtual SocketCAN adapter and querying the bus with UAVCAN's monitoring tools.