### PR TITLE
Actuator board: Basic readout functionality

### DIFF
--- a/actuator-firmware/Makefile
+++ b/actuator-firmware/Makefile
@@ -78,7 +78,7 @@ include $(CHIBIOS)/os/common/ports/ARMCMx/compilers/GCC/mk/port_v7m.mk
 # Define linker script file here
 
 ifeq ($(USE_BOOTLOADER), )
-	USE_BOOTLOADER = no
+	USE_BOOTLOADER = yes
 endif
 
 ifeq ($(USE_BOOTLOADER), yes)

--- a/actuator-firmware/package.yml
+++ b/actuator-firmware/package.yml
@@ -17,6 +17,7 @@ target.arm:
   - src/debug.c
   - src/board.c
   - src/uavcan/node.cpp
+  - src/uavcan/feedback_publisher.cpp
   - src/bootloader_config.c
   - src/pwm.c
   - src/servo.c

--- a/actuator-firmware/package.yml
+++ b/actuator-firmware/package.yml
@@ -21,6 +21,7 @@ target.arm:
   - src/pwm.c
   - src/servo.c
   - src/pressure_sensor_interface.c
+  - src/analog_input.c
   - ../lib/can-bootloader/config.c
 
 tests:

--- a/actuator-firmware/src/analog_input.c
+++ b/actuator-firmware/src/analog_input.c
@@ -1,0 +1,34 @@
+#include <ch.h>
+#include <hal.h>
+
+#include "hal_adc.h"
+#include "hal_adc_lld.h"
+
+/* We have an external attenuation of 0.5 before reaching the analog input */
+static const float ADC_GAIN = 2 * 3.3 / 4096;
+
+static const ADCConversionGroup group = {
+    .circular = true,
+    .num_channels = 2,
+    .end_cb = NULL,
+    .error_cb = NULL,
+    .cfgr = 0,
+    /* Sample every channel for 600 ADC clock cycles (SMP=5) .*/
+    .smpr = {ADC_SMPR1_SMP_AN0(5) | ADC_SMPR1_SMP_AN1(5), 0},
+    /* We want to sample 2 channels: Channel 0 and 1 */
+    .sqr = {ADC_SQR1_NUM_CH(2) | ADC_SQR1_SQ1_N(0) | ADC_SQR1_SQ2_N(1),
+            0, 0, 0},
+};
+
+void analog_input_read(float voltages[2])
+{
+    adcsample_t samples[2];
+    adcAcquireBus(&ADCD1);
+    /* Blocking conversion */
+    adcConvert(&ADCD1, &group, samples, 2);
+    adcReleaseBus(&ADCD1);
+
+    for (int i = 0; i < 2; i++) {
+        voltages[i] = samples[i] * ADC_GAIN;
+    }
+}

--- a/actuator-firmware/src/analog_input.h
+++ b/actuator-firmware/src/analog_input.h
@@ -1,0 +1,15 @@
+#ifndef ANALOG_INPUT_H
+#define ANALOG_INPUT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Reads the analog inputs, and fills the provided array with the voltage from
+ * 0 to 6.6 [V]. */
+void analog_input_read(float voltages[2]);
+
+#ifdef __cplusplus
+}
+#endif
+#endif

--- a/actuator-firmware/src/board.c
+++ b/actuator-firmware/src/board.c
@@ -14,8 +14,10 @@
     limitations under the License.
  */
 
+#include "board.h"
 #include "hal.h"
 
+#include "hal_pal.h"
 /**
  * @brief   Type of STM32 GPIO port setup.
  */
@@ -111,4 +113,9 @@ void board_reset_pressure_sensors(void)
     palClearPad(GPIOA, GPIOA_PRESSURE_RST);
     chThdSleepMilliseconds(1);
     palSetPad(GPIOA, GPIOA_PRESSURE_RST);
+}
+
+int board_digital_input_read(void)
+{
+    return palReadPad(GPIOB, GPIOB_DEBUG_RX);
 }

--- a/actuator-firmware/src/board.h
+++ b/actuator-firmware/src/board.h
@@ -336,6 +336,10 @@ extern "C" {
 void boardInit(void);
 void board_set_led(int state);
 void board_reset_pressure_sensors(void);
+
+/* Read the digital-only input for external sensors. */
+int board_digital_input_read(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/actuator-firmware/src/halconf.h
+++ b/actuator-firmware/src/halconf.h
@@ -41,7 +41,7 @@
  * @brief   Enables the ADC subsystem.
  */
 #if !defined(HAL_USE_ADC) || defined(__DOXYGEN__)
-#define HAL_USE_ADC FALSE
+#define HAL_USE_ADC TRUE
 #endif
 
 /**

--- a/actuator-firmware/src/main.c
+++ b/actuator-firmware/src/main.c
@@ -33,7 +33,6 @@ void _unhandled_exception(void)
     }
 }
 
-
 bootloader_config_t config;
 
 int main(void)

--- a/actuator-firmware/src/uavcan/feedback_publisher.cpp
+++ b/actuator-firmware/src/uavcan/feedback_publisher.cpp
@@ -1,0 +1,23 @@
+#include <ch.h>
+#include <hal.h>
+#include "board.h"
+#include "feedback_publisher.h"
+#include <cvra/actuator/Feedback.hpp>
+#include "analog_input.h"
+
+void feedback_publish(uavcan::INode& node)
+{
+    static uavcan::Publisher<cvra::actuator::Feedback> pub(node);
+    float analog[2];
+
+    analog_input_read(analog);
+
+    cvra::actuator::Feedback msg;
+
+    msg.analog_input[0] = analog[0];
+    msg.analog_input[1] = analog[1];
+
+    msg.digital_input = board_digital_input_read();
+
+    pub.broadcast(msg);
+}

--- a/actuator-firmware/src/uavcan/feedback_publisher.h
+++ b/actuator-firmware/src/uavcan/feedback_publisher.h
@@ -1,0 +1,8 @@
+#ifndef FEEDBACK_PUBLISHER_H
+#define FEEDBACK_PUBLISHER_H
+
+#include <uavcan/uavcan.hpp>
+
+void feedback_publish(uavcan::INode& node);
+
+#endif

--- a/actuator-firmware/src/uavcan/node.cpp
+++ b/actuator-firmware/src/uavcan/node.cpp
@@ -9,6 +9,7 @@
 
 #include "pressure_sensor.h"
 #include "pressure_sensor_interface.h"
+#include "feedback_publisher.h"
 
 #define UAVCAN_SPIN_FREQ 10 // [Hz]
 
@@ -92,6 +93,7 @@ void main(unsigned int id, const char* name)
         }
         node.spin(uavcan::MonotonicDuration::fromMSec(1000 / UAVCAN_SPIN_FREQ));
         pressure_sensor_spin(node);
+        feedback_publish(node);
     }
 }
 } // namespace uavcan_node

--- a/uavcan_data_types/cvra/actuator/20150.Feedback.uavcan
+++ b/uavcan_data_types/cvra/actuator/20150.Feedback.uavcan
@@ -1,0 +1,7 @@
+#
+# Feedback coming from actuator-firmware nodes
+#
+
+float16[2] pressure       # [Pascal]
+float16[2] analog_input   # [V]
+bool       digital_input

--- a/uavcan_data_types/cvra/actuator/20151.Command.uavcan
+++ b/uavcan_data_types/cvra/actuator/20151.Command.uavcan
@@ -1,0 +1,9 @@
+#
+# Command for an actuator board
+#
+
+# UAVCAN node ID for unicast addressing
+uint7 node_id
+
+float16[2] pump     # PWM in range 0-1
+bool[2]    solenoid # Power output for solenoids


### PR DESCRIPTION
This pull requests implements some basic readout of the board's analog input (for testing), as well as the status of the pressure sensors.

It currently reports if the pressure sensor has any faults through the NodeStatus message. I guess next step would be to actually publish a pressure, but for that I would need a physical board.

not tested, as hardware has not arrived yet.