### PR TITLE
Implement an API to log a message every N call

### DIFF
--- a/lib/error/error.h
+++ b/lib/error/error.h
@@ -99,6 +99,19 @@ const char* error_severity_get_name(uint8_t severity);
         }                                                           \
     } while (0)
 
+/** Call this macro to only log one out of N occurence. This is useful in tight call loops. */
+#define WARNING_EVERY_N(n, text, ...)                               \
+    do {                                                            \
+        static int _cnt = 0;                                        \
+        if ((_cnt++ % n) == 0 && g_error_fct.warning) {             \
+            struct error e = error_generate(ERROR_SEVERITY_WARNING, \
+                                            (text),                 \
+                                            (__FILE__),             \
+                                            __LINE__);              \
+            g_error_fct.warning(&e, ##__VA_ARGS__);                 \
+        }                                                           \
+    } while (0)
+
 /** Call this macro to log NOTICE events */
 #define NOTICE(text, ...)                                          \
     do {                                                           \
@@ -111,10 +124,36 @@ const char* error_severity_get_name(uint8_t severity);
         }                                                          \
     } while (0)
 
+/** Call this macro to only log one out of N occurence. This is useful in tight call loops. */
+#define NOTICE_EVERY_N(n, text, ...)                               \
+    do {                                                           \
+        static int _cnt = 0;                                       \
+        if ((_cnt++ % n) == 0 && g_error_fct.notice) {             \
+            struct error e = error_generate(ERROR_SEVERITY_NOTICE, \
+                                            (text),                \
+                                            (__FILE__),            \
+                                            __LINE__);             \
+            g_error_fct.notice(&e, ##__VA_ARGS__);                 \
+        }                                                          \
+    } while (0)
+
 /** Call this macro to log DEBUG events */
 #define DEBUG(text, ...)                                          \
     do {                                                          \
         if (g_error_fct.debug) {                                  \
+            struct error e = error_generate(ERROR_SEVERITY_DEBUG, \
+                                            (text),               \
+                                            (__FILE__),           \
+                                            __LINE__);            \
+            g_error_fct.debug(&e, ##__VA_ARGS__);                 \
+        }                                                         \
+    } while (0)
+
+/** Call this macro to only log one out of N occurence. This is useful in tight call loops. */
+#define DEBUG_EVERY_N(n, text, ...)                               \
+    do {                                                          \
+        static int _cnt = 0;                                      \
+        if ((_cnt++ % n) == 0 && g_error_fct.debug) {             \
             struct error e = error_generate(ERROR_SEVERITY_DEBUG, \
                                             (text),               \
                                             (__FILE__),           \

--- a/lib/error/tests/error.cpp
+++ b/lib/error/tests/error.cpp
@@ -69,6 +69,57 @@ TEST(ErrorLogging, GeneratesDebug)
     DEBUG("foo");
 }
 
+TEST(ErrorLogging, GeneratesWarningEvery10)
+{
+    error_register_warning(error_mock);
+
+    // We only expect two calls to occur
+    mock().expectOneCall("error").withStringParameter("text", "foo").ignoreOtherParameters();
+    mock().expectOneCall("error").withStringParameter("text", "bar").ignoreOtherParameters();
+    mock().expectOneCall("error").withStringParameter("text", "foo").ignoreOtherParameters();
+    mock().expectOneCall("error").withStringParameter("text", "bar").ignoreOtherParameters();
+
+    for (int i = 0; i < 20; i++) {
+        // Log every 10 loop iteration
+        WARNING_EVERY_N(10, "foo");
+        WARNING_EVERY_N(10, "bar");
+    }
+}
+
+TEST(ErrorLogging, GeneratesNoticeEvery10)
+{
+    error_register_notice(error_mock);
+
+    // We only expect two calls to occur
+    mock().expectOneCall("error").withStringParameter("text", "foo").ignoreOtherParameters();
+    mock().expectOneCall("error").withStringParameter("text", "bar").ignoreOtherParameters();
+    mock().expectOneCall("error").withStringParameter("text", "foo").ignoreOtherParameters();
+    mock().expectOneCall("error").withStringParameter("text", "bar").ignoreOtherParameters();
+
+    for (int i = 0; i < 20; i++) {
+        // Log every 10 loop iteration
+        NOTICE_EVERY_N(10, "foo");
+        NOTICE_EVERY_N(10, "bar");
+    }
+}
+
+TEST(ErrorLogging, GeneratesDebugEvery10)
+{
+    error_register_debug(error_mock);
+
+    // We only expect two calls to occur
+    mock().expectOneCall("error").withStringParameter("text", "foo").ignoreOtherParameters();
+    mock().expectOneCall("error").withStringParameter("text", "bar").ignoreOtherParameters();
+    mock().expectOneCall("error").withStringParameter("text", "foo").ignoreOtherParameters();
+    mock().expectOneCall("error").withStringParameter("text", "bar").ignoreOtherParameters();
+
+    for (int i = 0; i < 20; i++) {
+        // Log every 10 loop iteration
+        DEBUG_EVERY_N(10, "foo");
+        DEBUG_EVERY_N(10, "bar");
+    }
+}
+
 TEST(ErrorLogging, ErrorName)
 {
     auto name = error_severity_get_name(ERROR_SEVERITY_ERROR);
@@ -92,6 +143,7 @@ TEST(ErrorLogging, DebugName)
     auto name = error_severity_get_name(ERROR_SEVERITY_DEBUG);
     STRCMP_EQUAL("DEBUG", name);
 }
+
 TEST(ErrorLogging, UnknownName)
 {
     auto invalid_severity = 42;


### PR DESCRIPTION
This new API allows easier debugging of very frequent loops (such as
control loops) without spamming the terminal.

Note that there is no ERROR_N message, as I don't think we should ever
silently drop errors.