### PR TITLE
Implement reading front panel GPIOs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ addons:
     apt:
         packages:
             - freeglut3-dev
+            - libgpiod-dev
             - libsdl2-dev
             - protobuf-compiler
             - python

--- a/eurobot/arm-simulator/setup.py
+++ b/eurobot/arm-simulator/setup.py
@@ -18,5 +18,7 @@ setup(
     url="http://cvra.ch",
     license="BSD",
     packages=find_packages(exclude=["contrib", "docs", "tests*"]),
-    install_requires=["autograd",],
+    install_requires=[
+        "autograd",
+    ],
 )

--- a/master-firmware/CMakeLists.txt
+++ b/master-firmware/CMakeLists.txt
@@ -161,6 +161,12 @@ add_library(config_data
 )
 target_include_directories(config_data PUBLIC ${CMAKE_BINARY_DIR}/config)
 
+add_library(gpioinput
+    src/gpio_input.cpp
+)
+
+target_link_libraries(gpioinput PUBLIC gpiod error absl::base)
+
 add_executable(master-firmware
     src/main.cpp
     src/debug/log.c
@@ -198,6 +204,7 @@ target_link_libraries(master-firmware PUBLIC
     ugfx
     config_data
     master_config_structure
+    gpioinput
 )
 
 target_include_directories(master-firmware PUBLIC src

--- a/master-firmware/src/control_panel.cpp
+++ b/master-firmware/src/control_panel.cpp
@@ -136,8 +136,6 @@ bool control_panel_read(enum control_panel_input in)
 {
     auto input = gpio_inputs.find(in);
 
-    WARNING("reading %d", in);
-
     if (input == gpio_inputs.end()) {
         DEBUG_EVERY_N(10, "could not read input %d", in);
         return false;

--- a/master-firmware/src/control_panel.cpp
+++ b/master-firmware/src/control_panel.cpp
@@ -1,10 +1,12 @@
 #include <absl/flags/flag.h>
+#include <absl/types/optional.h>
 #include <error/error.h>
 #include "control_panel.h"
 #include <unordered_map>
 #include <string>
 #include <cstdio>
 #include <cerrno>
+#include "gpio_input.h"
 
 ABSL_FLAG(std::string, led_ready_path, "/sys/class/leds/ready", "Path in sysfs used to control LED_READY.");
 ABSL_FLAG(std::string, led_debug_path, "/sys/class/leds/debug", "Path in sysfs used to control LED_DEBUG.");
@@ -12,6 +14,13 @@ ABSL_FLAG(std::string, led_error_path, "/sys/class/leds/error", "Path in sysfs u
 ABSL_FLAG(std::string, led_power_path, "/sys/class/leds/power", "Path in sysfs used to control LED_POWER.");
 ABSL_FLAG(std::string, led_pc_path, "/sys/class/leds/pc", "Path in sysfs used to control LED_PC.");
 ABSL_FLAG(std::string, led_bus_path, "/sys/class/leds/bus", "Path in sysfs used to control LED_BUS.");
+ABSL_FLAG(std::string, gpiochip_starter, "", "Path used to control the gpio chip for the start hall sensor (e.g. 'gpiochip0').");
+ABSL_FLAG(std::string, gpiochip_team_a, "", "Path used to control the gpio chip for the team A button (e.g. 'gpiochip0').");
+ABSL_FLAG(std::string, gpiochip_team_b, "", "Path used to control the gpio chip for the team B button (e.g. 'gpiochip0').");
+ABSL_FLAG(int, gpioline_starter, -1, "Line number for the start hall sensor GPIO.");
+ABSL_FLAG(int, gpioline_team_a, -1, "Line number for the team A button GPIO.");
+ABSL_FLAG(int, gpioline_team_b, -1, "Line number for the team A button GPIO.");
+
 // TODO: Support for RGB led
 
 struct LedInfo {
@@ -21,6 +30,7 @@ struct LedInfo {
 };
 
 std::unordered_map<enum control_panel_output, LedInfo> led_infos;
+std::unordered_map<enum control_panel_input, GpioInput> gpio_inputs;
 
 const char* control_panel_input[] = {
     "BUTTON_YELLOW",
@@ -43,7 +53,7 @@ static void set_output(enum control_panel_output out, bool value)
 {
     auto led_info = led_infos.find(out);
 
-    DEBUG("seting %s to %d", control_panel_output[out], value);
+    DEBUG("setting %s to %d", control_panel_output[out], value);
 
     if (led_info == led_infos.end()) {
         WARNING("can not set output %s", control_panel_output[out]);
@@ -93,21 +103,47 @@ static void open_led(enum control_panel_output led_num, std::string path)
     DEBUG("opened %s succesfully", control_panel_output[led_num]);
 }
 
-void control_panel_init(bool is_active_high)
+static void open_input(enum control_panel_input input_num, std::string gpiochip, int line)
 {
-    (void)is_active_high;
+    if (gpiochip.empty()) {
+        // exit early in case we were not provided with a flag
+        return;
+    }
+    DEBUG("input %s is at %s:%d", control_panel_input[input_num], gpiochip.c_str(), line);
+
+    auto res = GpioInput::open(gpiochip, line);
+    if (res) {
+        gpio_inputs[input_num] = {}; //std::move(res.value());
+    } else {
+        WARNING("Could not open input %s", control_panel_input[input_num]);
+    }
+}
+
+void control_panel_init(void)
+{
     open_led(LED_READY, absl::GetFlag(FLAGS_led_ready_path));
     open_led(LED_DEBUG, absl::GetFlag(FLAGS_led_debug_path));
     open_led(LED_ERROR, absl::GetFlag(FLAGS_led_error_path));
     open_led(LED_POWER, absl::GetFlag(FLAGS_led_power_path));
     open_led(LED_PC, absl::GetFlag(FLAGS_led_pc_path));
     open_led(LED_BUS, absl::GetFlag(FLAGS_led_bus_path));
+    open_input(STARTER, absl::GetFlag(FLAGS_gpiochip_starter), absl::GetFlag(FLAGS_gpioline_starter));
+    open_input(BUTTON_YELLOW, absl::GetFlag(FLAGS_gpiochip_team_a), absl::GetFlag(FLAGS_gpioline_team_a));
+    open_input(BUTTON_GREEN, absl::GetFlag(FLAGS_gpiochip_team_b), absl::GetFlag(FLAGS_gpioline_team_b));
 }
 
 bool control_panel_read(enum control_panel_input in)
 {
-    WARNING_EVERY_N(100, "%s(%s) not implemented yet.", __FUNCTION__, control_panel_input[in]);
-    return false;
+    auto input = gpio_inputs.find(in);
+
+    WARNING("reading %d", in);
+
+    if (input == gpio_inputs.end()) {
+        DEBUG_EVERY_N(10, "could not read input %d", in);
+        return false;
+    }
+
+    return input->second.read();
 }
 
 bool control_panel_button_is_pressed(enum control_panel_input in)

--- a/master-firmware/src/control_panel.h
+++ b/master-firmware/src/control_panel.h
@@ -24,7 +24,7 @@ enum control_panel_output {
 extern "C" {
 #endif
 
-void control_panel_init(bool is_active_high);
+void control_panel_init(void);
 bool control_panel_read(enum control_panel_input in);
 void control_panel_set(enum control_panel_output out);
 void control_panel_clear(enum control_panel_output out);

--- a/master-firmware/src/gpio_input.cpp
+++ b/master-firmware/src/gpio_input.cpp
@@ -45,5 +45,5 @@ absl::optional<GpioInput> GpioInput::open(std::string chipname, int line_num)
         return {};
     }
 
-    return result;
+    return {std::move(result)};
 }

--- a/master-firmware/src/gpio_input.cpp
+++ b/master-firmware/src/gpio_input.cpp
@@ -1,0 +1,49 @@
+#include "gpio_input.h"
+#include <error/error.h>
+
+GpioInput::~GpioInput()
+{
+    if (line) {
+        DEBUG("releasing line");
+        gpiod_line_release(line);
+    }
+
+    if (chip) {
+        DEBUG("closing chip");
+        gpiod_chip_close(chip);
+    }
+}
+
+bool GpioInput::read()
+{
+    if (!line) {
+        return false;
+    }
+    return gpiod_line_get_value(line) == 1;
+}
+
+absl::optional<GpioInput> GpioInput::open(std::string chipname, int line_num)
+{
+    GpioInput result;
+    result.chip = gpiod_chip_open_by_name(chipname.c_str());
+    if (!result.chip) {
+        WARNING("Could not open gpio chip %s", chipname.c_str());
+        return {};
+    }
+
+    result.line = gpiod_chip_get_line(result.chip, line_num);
+
+    if (!result.line) {
+        WARNING("Could not open gpio line");
+        return {};
+    }
+
+    int ret = gpiod_line_request_input(result.line, "master-firmware");
+
+    if (ret < 0) {
+        WARNING("Request line as input failed");
+        return {};
+    }
+
+    return result;
+}

--- a/master-firmware/src/gpio_input.h
+++ b/master-firmware/src/gpio_input.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <gpiod.h>
+#include <absl/types/optional.h>
+
+/** Wrapper around libgpiod, used to read a single GPIO at a time. */
+class GpioInput {
+private:
+    struct gpiod_chip* chip;
+    struct gpiod_line* line;
+
+public:
+    // Returns the state of the GPIO
+    bool read();
+
+    // Function used to open the GPIO for reading. Returns an empty object in
+    // case it could not be opened.
+    static absl::optional<GpioInput> open(std::string chipname, int line_num);
+
+    GpioInput()
+        : chip(nullptr)
+        , line(nullptr)
+    {
+    }
+
+    // The copy constructor and operator must be deleted, as handles to GPIOs
+    // cannot be copied (they need to be re-opened separately).
+    GpioInput(GpioInput&) = delete; // cannot be copied
+    GpioInput& operator=(GpioInput& other) = delete;
+
+    GpioInput(GpioInput&& other)
+        : chip(other.chip)
+        , line(other.line)
+    {
+        chip = other.chip;
+        line = other.line;
+    }
+
+    GpioInput& operator=(GpioInput&& other)
+    {
+        std::swap(other.chip, chip);
+        std::swap(other.line, line);
+        return *this;
+    }
+
+    ~GpioInput();
+};

--- a/master-firmware/src/gpio_input.h
+++ b/master-firmware/src/gpio_input.h
@@ -25,8 +25,8 @@ public:
 
     // The copy constructor and operator must be deleted, as handles to GPIOs
     // cannot be copied (they need to be re-opened separately).
-    GpioInput(GpioInput&) = delete; // cannot be copied
-    GpioInput& operator=(GpioInput& other) = delete;
+    GpioInput(const GpioInput&) = delete; // cannot be copied
+    GpioInput& operator=(const GpioInput& other) = delete;
 
     GpioInput(GpioInput&& other)
         : chip(other.chip)

--- a/master-firmware/src/gpio_input.h
+++ b/master-firmware/src/gpio_input.h
@@ -25,7 +25,7 @@ public:
 
     // The copy constructor and operator must be deleted, as handles to GPIOs
     // cannot be copied (they need to be re-opened separately).
-    GpioInput(const GpioInput&) = delete; // cannot be copied
+    GpioInput(const GpioInput&) = delete;
     GpioInput& operator=(const GpioInput& other) = delete;
 
     GpioInput(GpioInput&& other)

--- a/master-firmware/src/main.cpp
+++ b/master-firmware/src/main.cpp
@@ -148,7 +148,7 @@ int main(int argc, char** argv)
     /* Load stored robot config */
     config_load_from_flash();
 
-    control_panel_init(false);
+    control_panel_init();
     if (absl::GetFlag(FLAGS_enable_gui)) {
         gui_start();
     }

--- a/tools/config/tests/test_config_to_init.py
+++ b/tools/config/tests/test_config_to_init.py
@@ -32,7 +32,12 @@ class TestCodeGenerator(unittest.TestCase):
         self.assertEqual(tree, expected_code)
 
     def test_has_one_namespace_with_entries(self):
-        config = {"controller": {"kp": 10, "ki": 0.1,}}
+        config = {
+            "controller": {
+                "kp": 10,
+                "ki": 0.1,
+            }
+        }
         expected_code = [
             "void config_init(void)",
             "{",
@@ -48,7 +53,14 @@ class TestCodeGenerator(unittest.TestCase):
         self.assertEqual(tree, expected_code)
 
     def test_has_depth_three(self):
-        config = {"robot": {"controller": {"kp": 10, "ki": 0.1,}}}
+        config = {
+            "robot": {
+                "controller": {
+                    "kp": 10,
+                    "ki": 0.1,
+                }
+            }
+        }
         expected_code = [
             "void config_init(void)",
             "{",
@@ -65,7 +77,15 @@ class TestCodeGenerator(unittest.TestCase):
         self.assertEqual(tree, expected_code)
 
     def test_has_depth_max_three(self):
-        config = {"robot": {"controller": {"kp": 10, "ki": 0.1,}, "so": 1337,}}
+        config = {
+            "robot": {
+                "controller": {
+                    "kp": 10,
+                    "ki": 0.1,
+                },
+                "so": 1337,
+            }
+        }
         expected_code = [
             "void config_init(void)",
             "{",

--- a/tools/config/tests/test_config_to_struct.py
+++ b/tools/config/tests/test_config_to_struct.py
@@ -30,7 +30,12 @@ class TestCodeGenerator(unittest.TestCase):
         self.assertEqual(tree, expected_code)
 
     def test_has_one_namespace_with_entries(self):
-        config = {"controller": {"kp": 10, "ki": 0.1,}}
+        config = {
+            "controller": {
+                "kp": 10,
+                "ki": 0.1,
+            }
+        }
         expected_code = [
             "struct {",
             "    parameter_namespace_t ns;",
@@ -47,7 +52,14 @@ class TestCodeGenerator(unittest.TestCase):
         self.assertEqual(tree, expected_code)
 
     def test_has_depth_three(self):
-        config = {"robot": {"controller": {"kp": 10, "ki": 0.1,}}}
+        config = {
+            "robot": {
+                "controller": {
+                    "kp": 10,
+                    "ki": 0.1,
+                }
+            }
+        }
         expected_code = [
             "struct {",
             "    parameter_namespace_t ns;",
@@ -67,7 +79,15 @@ class TestCodeGenerator(unittest.TestCase):
         self.assertEqual(tree, expected_code)
 
     def test_has_depth_max_three(self):
-        config = {"robot": {"controller": {"kp": 10, "ki": 0.1,}, "so": 1337,}}
+        config = {
+            "robot": {
+                "controller": {
+                    "kp": 10,
+                    "ki": 0.1,
+                },
+                "so": 1337,
+            }
+        }
         expected_code = [
             "struct {",
             "    parameter_namespace_t ns;",

--- a/tools/studio/cvra_studio/commands/actuator.py
+++ b/tools/studio/cvra_studio/commands/actuator.py
@@ -55,7 +55,15 @@ class ServoInputWidget(QtGui.QWidget):
             callback=change_callback,
         )
 
-        self.setLayout(vstack([self.pos, self.vel, self.acc,]))
+        self.setLayout(
+            vstack(
+                [
+                    self.pos,
+                    self.vel,
+                    self.acc,
+                ]
+            )
+        )
         self.show()
 
 
@@ -87,16 +95,22 @@ class StatusOutputWidget(QtGui.QWidget):
     def __init__(self, parent=None):
         super(StatusOutputWidget, self).__init__(parent)
         self._uptime_widget = LineEdit(
-            title="Uptime [s]", parent=parent, initial_value="0",
+            title="Uptime [s]",
+            parent=parent,
+            initial_value="0",
         )
         self._uptime_widget.line.setReadOnly(True)
         self._health_widget = LineEdit(
-            title="Node health", parent=parent, initial_value="0",
+            title="Node health",
+            parent=parent,
+            initial_value="0",
         )
         self._health_widget.line.setReadOnly(True)
 
         self._vendor_status_widget = LineEdit(
-            title="Vendor status code", parent=parent, initial_value="0",
+            title="Vendor status code",
+            parent=parent,
+            initial_value="0",
         )
         self._vendor_status_widget.line.setReadOnly(True)
 
@@ -133,7 +147,9 @@ class ActuatorFeedbackWidget(QtGui.QWidget):
 
         self._analog_input_widgets = [
             LineEdit(
-                title="Analog {} [V]".format(i + 1), parent=parent, initial_value="0.0",
+                title="Analog {} [V]".format(i + 1),
+                parent=parent,
+                initial_value="0.0",
             )
             for i in range(2)
         ]

--- a/tools/studio/cvra_studio/commands/param_tree.py
+++ b/tools/studio/cvra_studio/commands/param_tree.py
@@ -147,7 +147,15 @@ class ParameterWidget(QWidget):
         self.save_button = QPushButton("Save")
         self.save_button.clicked.connect(self._save_params)
 
-        self.setLayout(vstack([self.node_selector, self.tree_view, self.save_button,]))
+        self.setLayout(
+            vstack(
+                [
+                    self.node_selector,
+                    self.tree_view,
+                    self.save_button,
+                ]
+            )
+        )
 
         self.model = ParameterTreeModel(node)
         self.model.on_new_node(self._update_nodes)

--- a/tools/studio/cvra_studio/commands/pid_plot.py
+++ b/tools/studio/cvra_studio/commands/pid_plot.py
@@ -66,7 +66,12 @@ class PidViewer(QtGui.QWidget):
                                     self.period,
                                 ]
                             ),
-                            vstack([self.pid_loop_selector, self.plot.widget,]),
+                            vstack(
+                                [
+                                    self.pid_loop_selector,
+                                    self.plot.widget,
+                                ]
+                            ),
                         ]
                     ),
                 ]

--- a/tools/studio/cvra_studio/commands/publish.py
+++ b/tools/studio/cvra_studio/commands/publish.py
@@ -71,7 +71,16 @@ class SetpointPublisherWidget(QWidget):
             title="Period [s]  \t", callback=self.model.update_period, parent=parent
         )
 
-        self.setLayout(vstack([self.motor, self.topic, self.value, self.period,]))
+        self.setLayout(
+            vstack(
+                [
+                    self.motor,
+                    self.topic,
+                    self.value,
+                    self.period,
+                ]
+            )
+        )
 
 
 def main(args):

--- a/tools/studio/cvra_studio/viewers/wrappers.py
+++ b/tools/studio/cvra_studio/viewers/wrappers.py
@@ -10,7 +10,14 @@ class LineEdit(QWidget):
         self.line = QLineEdit(str(initial_value), parent=parent)
         self.line.returnPressed.connect(self._on_value_change)
         self.callback = callback
-        self.setLayout(hstack([self.label, self.line,]))
+        self.setLayout(
+            hstack(
+                [
+                    self.label,
+                    self.line,
+                ]
+            )
+        )
 
     def _on_value_change(self):
         if self.callback:
@@ -29,7 +36,14 @@ class ComboBox(QWidget):
             self.combo.addItem(str(item))
         self.combo.currentTextChanged.connect(self._on_value_change)
         self.callback = callback
-        self.setLayout(hstack([self.label, self.combo,]))
+        self.setLayout(
+            hstack(
+                [
+                    self.label,
+                    self.combo,
+                ]
+            )
+        )
 
     def _on_value_change(self):
         if self.callback:

--- a/tools/studio/setup.py
+++ b/tools/studio/setup.py
@@ -11,6 +11,17 @@ setup(
     url="http://cvra.ch",
     license="BSD",
     packages=find_packages(exclude=["contrib", "docs", "tests*"]),
-    install_requires=["docopt", "PyQt5", "pyserial", "pyqtgraph", "numpy", "uavcan",],
-    entry_points={"console_scripts": ["cvra=cvra_studio.cli:main",],},
+    install_requires=[
+        "docopt",
+        "PyQt5",
+        "pyserial",
+        "pyqtgraph",
+        "numpy",
+        "uavcan",
+    ],
+    entry_points={
+        "console_scripts": [
+            "cvra=cvra_studio.cli:main",
+        ],
+    },
 )


### PR DESCRIPTION
This implementation uses libgpiod, which is the new recommended API for
dealing with GPIO from userland (sysfs is considered deprecated).

It does so by creating a thin wrapper in C++ that makes it easy to open a GPIO for reading and to read its state. It also exposes new flags for setting up to which GPIO the buttons are connected.

This still needs to be tested on hardware.