### PR TITLE
Light up a LED if emergency button is pressed

### DIFF
--- a/tools/build_opkg_package.py
+++ b/tools/build_opkg_package.py
@@ -16,6 +16,7 @@ import logging
 
 logger = logging.getLogger(os.path.basename(__file__))
 
+
 @contextlib.contextmanager
 def cd(path):
     cwd = os.getcwd()


### PR DESCRIPTION
If the emergency shutdown button is depressed, then the battery voltage
will be cut to the motor control boards, but they will still be powered
by the CAN bus.

This patch reports the battery powerdown from the motor control board as
a custom status code. On the master firmware we simply store the status
of the boards and report them through a LED.

Needs to be tested on hardware.