### PR TITLE
Prevent page out for master-firmware memory.

### DIFF
--- a/master-firmware/packaging/cvra-master.service
+++ b/master-firmware/packaging/cvra-master.service
@@ -6,6 +6,7 @@ Type=simple
 User=root
 # TODO(antoinealb): What do we want to do with the onboard LED?
 ExecStart=/bin/xinit /bin/cvra-master --enable_gui --can_iface="can0" \
+    --lock_memory \
     --led_comm_path=/sys/class/leds/onboard \
     --led_ready_path=/sys/class/leds/ready \
     --led_debug_path=/sys/class/leds/debug \
@@ -14,6 +15,7 @@ ExecStart=/bin/xinit /bin/cvra-master --enable_gui --can_iface="can0" \
     --led_power_path=/sys/class/leds/power \
     --strat_autoposition --strat_wait_for_starter
 Restart=on-failure
+LimitMEMLOCK=infinity
 
 
 [Install]


### PR DESCRIPTION
Paging out means storing part of the software's memory to disk and
occurs when we use more memory than what is available on the system.
This can cause high latency in some memory access, which is not possible
in realtime operations. This can be prevented by "locking" some memory,
which instructs the kernel to never page out memory.

This patch adds memory locking to the master firmware. As locking out
memory requires special capabilities or root, the call to memory locking
is put behind a flag that is disabled by default, and enabled on the
robot. On the robot we must also increase the maximum mlock size, as by
default it will only be a few kilobytes.

Ressources:

* https://lwn.net/Articles/876288/
* https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux_for_real_time/7/html/reference_guide/using_mlock_to_avoid_page_io